### PR TITLE
Update config/v2 docs

### DIFF
--- a/website/docs/cloud-docs/sentinel/import/tfconfig-v2.mdx
+++ b/website/docs/cloud-docs/sentinel/import/tfconfig-v2.mdx
@@ -52,6 +52,7 @@ tfconfig/v2
 │   └── (indexed by [module_address:]provider[.alias])
 │       ├── provider_config_key (string)
 │       ├── name (string)
+│       ├── full_name (string)
 │       ├── alias (string)
 │       ├── module_address (string)
 │       ├── config (block expression representation)
@@ -294,6 +295,7 @@ The fields in this collection are as follows:
 
 * `provider_config_key` - The opaque configuration key, used as the index key.
 * `name` - The name of the provider, ie: `aws`.
+* `full_name` - The fully-qualified name of the provider, ie: `registry.terraform.io/hashicorp/aws`.
 * `alias` - The alias of the provider, ie: `east`. Empty for a default provider.
 * `module_address` - The address of the module this provider appears in.
 * `config` - A [block expression

--- a/website/docs/cloud-docs/sentinel/import/tfconfig-v2.mdx
+++ b/website/docs/cloud-docs/sentinel/import/tfconfig-v2.mdx
@@ -295,7 +295,7 @@ The fields in this collection are as follows:
 
 * `provider_config_key` - The opaque configuration key, used as the index key.
 * `name` - The name of the provider, ie: `aws`.
-* `full_name` - The fully-qualified name of the provider, ie: `registry.terraform.io/hashicorp/aws`.
+* `full_name` - The fully-qualified name of the provider, e.g. `registry.terraform.io/hashicorp/aws`.
 * `alias` - The alias of the provider, ie: `east`. Empty for a default provider.
 * `module_address` - The address of the module this provider appears in.
 * `config` - A [block expression


### PR DESCRIPTION
The Sentinel tfconfig import now supports changes that were introduced in [#30138](https://github.com/hashicorp/terraform/pull/30138)
ie, the provider config block in the import contains the full_name key-value pair
This has been reflected in the docs.

More details: https://app.asana.com/0/1201654039499505/1202112971006425/f