### PR TITLE
Update aws.mdx

### DIFF
--- a/website/docs/cloud-docs/cost-estimation/aws.mdx
+++ b/website/docs/cloud-docs/cost-estimation/aws.mdx
@@ -15,7 +15,6 @@ Terraform Cloud can estimate monthly costs for many AWS Terraform resources.
 Below is a list of resources that cost estimation supports:
 
 * aws_alb
-* aws_autoscaling_group
 * aws_cloudhsm_v2_hsm
 * aws_cloudwatch_dashboard
 * aws_cloudwatch_metric_alarm


### PR DESCRIPTION
aws_autoscaling_group should be removed from supported list of resources for cost estimation since it is not a cost carrying resource on AWS

What
aws_autoscaling_group should be removed from supported list of resources for cost estimation

Why
aws_autoscaling_group is not a cost carrying resource, cost estimation will return null for this

Screenshot
![image](https://user-images.githubusercontent.com/32132864/172283241-80317655-cd88-497d-9f78-13fa8ad6218f.png)
