### PR TITLE
Add note that Run Tasks is a paid feature

### DIFF
--- a/website/docs/cloud-docs/api-docs/run-tasks-integration.mdx
+++ b/website/docs/cloud-docs/api-docs/run-tasks-integration.mdx
@@ -10,6 +10,8 @@ page_title: Run Tasks Integration - API Docs - Terraform Cloud and Terraform Ent
 
 # Run Tasks Integration API
 
+-> **Note:** Run Tasks is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
+
 [Run tasks](/cloud-docs/workspaces/settings/run-tasks) allow Terraform Cloud to interact with external systems at specific points in the Terraform Cloud run lifecycle.
 This page lists the API endpoints used to trigger a run task and the expected response from the integration.
 

--- a/website/docs/cloud-docs/api-docs/run-tasks.mdx
+++ b/website/docs/cloud-docs/api-docs/run-tasks.mdx
@@ -36,6 +36,8 @@ page_title: Run Tasks - API Docs - Terraform Cloud and Terraform Enterprise
 
 # Run Tasks API
 
+-> **Note:** Run Tasks is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
+
 [Run tasks](/cloud-docs/workspaces/settings/run-tasks) allow Terraform Cloud to interact with external systems at specific points in the Terraform Cloud run lifecycle. Run tasks are reusable configurations that you can attach to any workspace in an organization. This page lists the API endpoints for run tasks in an organization and explains how to attach run tasks to workspaces.
 
 Refer to [run tasks Integration](/cloud-docs/api-docs/run-tasks-integration) for the API endpoints related triggering run tasks and the expected integration response.

--- a/website/docs/cloud-docs/integrations/run-tasks/index.mdx
+++ b/website/docs/cloud-docs/integrations/run-tasks/index.mdx
@@ -7,6 +7,8 @@ description: >-
 
 # Run Tasks Integration
 
+-> **Note:** Run Tasks is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
+
 In addition to using existing technology partners integrations, HashiCorp Terraform Cloud customers can build their own custom run task integrations. Custom integrations have access to plan details in between the plan and apply phase, and can display custom messages within the run pipeline as well as prevent a run from continuing to the apply phase.
 
 ## Prerequisites

--- a/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
@@ -4,6 +4,8 @@ page_title: Run Tasks - Workspaces - Terraform Cloud and Terraform Enterprise
 
 # Run Tasks
 
+-> **Note:** Run Tasks is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
+
 Run Tasks allow you to directly integrate third-party tools and services at certain stages in the Terraform Cloud run lifecycle. When triggered, a run task sends an API payload to the external service. This payload contains a collection of run-related information, including a callback URL that the service uses to respond back to Terraform Cloud with a passed or failed status. Terraform Cloud uses this status response to determine if a run should proceed, based on the run task's enforcement settings that have been configured for the workspace.
 
 You can manage run tasks through the UI as detailed below or through the [Run Tasks APIs](/cloud-docs/api-docs/run-tasks).


### PR DESCRIPTION
Seems it would be good to add a note that the "Run Tasks" feature is a paid one. 
Users are opening tickets that they do not have it available - which is because they are on Free or Team TFC tiers.