### PR TITLE
updated api changelog to reflect api changes in April that were missed

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -27,8 +27,8 @@ Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 ### 2022-04-29
 
 * Updated [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration) to specify the allowed `status` attribute values.
-* Updated [Organization Memberships](/cloud-docs/api-docs/organization-memberships) to add new `filter[email]` option.
-* Updated [Teams](/cloud-docs/api-docs/teams) to add new `filter[names]` option.
+* Updated [Organization Memberships](/cloud-docs/api-docs/organization-memberships#query-parameters) to add new `filter[email]` query parameter.
+* Updated [Teams](/cloud-docs/api-docs/teams#query-parameters) to add new `filter[names]` query parameter.
 
 ### 2022-04-04
 

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -26,10 +26,10 @@ Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 ### 2022-04-29
 
-* Updated [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration.mdx) to specify the allowed `status` attribute values.
+* Updated [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration) to specify the allowed `status` attribute values.
 * These changes will be available in the folowing TFE Release: `v202205-1`
-  * Updated [Organization Memberships](/cloud-docs/api-docs/organization-memberships.mdx) to add new `filter[email]` option.
-  * Updated [Teams](/cloud-docs/api-docs/teams.mdx) to add new `filter[names]` option.
+  * Updated [Organization Memberships](/cloud-docs/api-docs/organization-memberships) to add new `filter[email]` option.
+  * Updated [Teams](/cloud-docs/api-docs/teams) to add new `filter[names]` option.
 
 ### 2022-04-04
 

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -27,9 +27,8 @@ Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 ### 2022-04-29
 
 * Updated [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration) to specify the allowed `status` attribute values.
-* These changes will be available in the folowing TFE Release: `v202205-1`
-  * Updated [Organization Memberships](/cloud-docs/api-docs/organization-memberships) to add new `filter[email]` option.
-  * Updated [Teams](/cloud-docs/api-docs/teams) to add new `filter[names]` option.
+* Updated [Organization Memberships](/cloud-docs/api-docs/organization-memberships) to add new `filter[email]` option.
+* Updated [Teams](/cloud-docs/api-docs/teams) to add new `filter[names]` option.
 
 ### 2022-04-04
 

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -26,7 +26,10 @@ Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 ### 2022-04-29
 
-Updated [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration.mdx) to specify the allowed `status` attribute values.
+* Updated [Run Tasks Integration](/cloud-docs/api-docs/run-tasks-integration.mdx) to specify the allowed `status` attribute values.
+* These changes will be available in the folowing TFE Release: `v202205-1`
+  * Updated [Organization Memberships](/cloud-docs/api-docs/organization-memberships.mdx) to add new `filter[email]` option.
+  * Updated [Teams](/cloud-docs/api-docs/teams.mdx) to add new `filter[names]` option.
 
 ### 2022-04-04
 

--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -47,6 +47,8 @@ See the navigation sidebar for the list of available endpoints.
 
 HashiCorp provides a [stability policy](/cloud-docs/api-docs/stability-policy) for the Terraform Cloud API, ensuring backwards compatibility for stable endpoints.
 
+See the [changelog](/cloud-docs/api-docs/changelog) for a list of api changes.
+
 ## Authentication
 
 All requests must be authenticated with a bearer token. Use the HTTP header `Authorization` with the value `Bearer <token>`. If the token is absent or invalid, Terraform Cloud responds with [HTTP status 401][401] and a [JSON API error object][]. The 401 status code is reserved for problems with the authentication token; forbidden requests with a valid token result in a 404.

--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -47,7 +47,7 @@ See the navigation sidebar for the list of available endpoints.
 
 HashiCorp provides a [stability policy](/cloud-docs/api-docs/stability-policy) for the Terraform Cloud API, ensuring backwards compatibility for stable endpoints.
 
-See the [changelog](/cloud-docs/api-docs/changelog) for a list of api changes.
+Refer to the [changelog](/cloud-docs/api-docs/changelog) for a list of api changes.
 
 ## Authentication
 


### PR DESCRIPTION
The api docs were updated as part of this [PR](https://github.com/hashicorp/terraform-website/pull/2265), but the api changelog was not updated to reflect the date of when the api change occurred.

Also added a link to the changelog from the api-docs overview page.