### PR TITLE
Move speculative plan testing heading to correct location

### DIFF
--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -63,15 +63,6 @@ If you would rather automatically apply plans that don't have errors, you can [e
 
 To help you review proposed changes, Terraform Cloud can automatically run [speculative plans][speculative plan] for pull requests or merge requests.
 
-## Testing Terraform Upgrades with Speculative Plans
-
-Using the UI, you can start a new speculative plan with the workspace's current configuration version and any Terraform version available to the organization.
-
-1. Click **Start New Run** and see the **Start a new run** modal window.
-2. Select the **Plan only** option as the run type. This run mode reveals a new option to choose the specific Terraform version.
-3. Visit the workspace settings and change the [workspace terraform version](/cloud-docs/workspaces/settings#terraform-version) setting.
-4. Start a new run using the procedure above but this time select the type **Allow empty apply**. Creating a run in **Allow empty apply** mode allows Terraform to apply a plan containing no infrastructure changes. During an empty apply, Terraform upgrades the state file format to match the Terraform version, if required. This is particularly useful for upgrading between Terraform versions in your workspace. Once this run is applied, the state version upgrade will be complete.
-
 ### Viewing Pull Request Plans
 
 Speculative plans don't appear in a workspace's list of normal runs. Instead, Terraform Cloud adds a link to the run in the pull request itself, along with an indicator of the run's status.
@@ -107,6 +98,15 @@ Whenever a pull request is _created or updated,_ Terraform Cloud checks whether 
 ### Contents of Pull Request Plans
 
 Speculative plans for pull requests use the contents of the head branch (the branch that the PR proposes to merge into the destination branch), and they compare against the workspace's current state at the time of the plan. This means that if the destination branch changes significantly after the head branch is created, the speculative plan might not accurately show the results of accepting the PR. To get a more accurate view, you can rebase the head branch onto a more recent commit, or merge the destination branch into the head branch.
+
+## Testing Terraform Upgrades with Speculative Plans
+
+Using the UI, you can start a new speculative plan with the workspace's current configuration version and any Terraform version available to the organization.
+
+1. Click **Start New Run** and see the **Start a new run** modal window.
+2. Select the **Plan only** option as the run type. This run mode reveals a new option to choose the specific Terraform version.
+3. Visit the workspace settings and change the [workspace terraform version](/cloud-docs/workspaces/settings#terraform-version) setting.
+4. Start a new run using the procedure above but this time select the type **Allow empty apply**. Creating a run in **Allow empty apply** mode allows Terraform to apply a plan containing no infrastructure changes. During an empty apply, Terraform upgrades the state file format to match the Terraform version, if required. This is particularly useful for upgrading between Terraform versions in your workspace. Once this run is applied, the state version upgrade will be complete.
 
 ## Speculative Plans During Development
 


### PR DESCRIPTION
This PR moves newly added content about using speculative plans to test upgrades. The current format placed the new content in the middle of an existing section, making the subsequent h3s feel a bit out of place. This PR moves this content down to be below the original section, so that the original section continues to flow properly.