### PR TITLE
Mention 'retry run' button in the viewing and managing runs page

### DIFF
--- a/website/docs/cloud-docs/run/manage.mdx
+++ b/website/docs/cloud-docs/run/manage.mdx
@@ -50,6 +50,7 @@ In workspaces where you have permission to apply runs, run pages include control
 | Discard Run         | A plan needs confirmation or a soft-mandatory policy failed.                                                                                                                                                                       |
 | Cancel Run          | A plan or apply is currently running.                                                                                                                                                                                              |
 | Force Cancel Run    | A plan or apply was canceled, but something went wrong and Terraform Cloud couldn't end the run gracefully. Requires admin access to the workspace. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions)) |
+| Retry Run           | A plan-only run has finished. You can also change which Terraform version to use when retrying a plan-only run.                                                                                                                    |
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 


### PR DESCRIPTION
Realized we hadn't added this for some reason. This is probably the spot where it belongs! 