### PR TITLE
Update Azure AD documentation for passing SAML groups claim

### DIFF
--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -82,7 +82,7 @@ To configure team management in your Microsoft Azure AD application:
 1. Edit step 2, "User Attributes & Claims."  
 2. Add a new group claim.
 3. In the "Group Claims" side window, select the "Security Groups" radio button.  
-   For "Source Attribute", select "sAMAccountName" to have group names passed in the SAML or select "Group ID" to pass thru the UUIDs for the group.  See **Note** below.
+   For "Source Attribute", select `sAMAccountName` to have group names passed in the SAML or select "Group ID" to pass thru the UUIDs for the group.  See **Note** below for more information on UUID's.  
    Check the box for "Customize the name of hte group claim" and in the "Name (required)" field put "MemberOf" and leave namespace blank.
 
 -> **Note:** When Azure AD is configured to use Group Claims, it provides Group UUIDs instead of human readable names in its SAML assertions. We recommend [configuring SSO Team IDs](/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) for your Terraform Cloud teams to match these Azure Group UUIDs.

--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -83,7 +83,7 @@ To configure team management in your Microsoft Azure AD application:
 2. Add a new group claim.
 3. In the "Group Claims" side window, select the "Security Groups" radio button.  
    For "Source Attribute", select `sAMAccountName` to have group names passed in the SAML or select "Group ID" to pass thru the UUIDs for the group.  See **Note** below for more information on UUID's.  
-   Check the box for "Customize the name of hte group claim" and in the "Name (required)" field put "MemberOf" and leave namespace blank.
+   Check the box for "Customize the name of the group claim" and in the "Name (required)" field put "MemberOf" and leave namespace blank.
 
 -> **Note:** When Azure AD is configured to use Group Claims, it provides Group UUIDs instead of human readable names in its SAML assertions. We recommend [configuring SSO Team IDs](/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) for your Terraform Cloud teams to match these Azure Group UUIDs.
 
@@ -94,3 +94,7 @@ If you plan to make use of SAML to set usernames in your Microsoft Azure AD appl
    We recommend naming the claim "Username", leaving the namespace blank, and sourcing something like `user.displayname` or `user.mailnickname`.
 
 If you namespaced any of your claims, note that the attribute name passed by Microsoft Azure AD will follow the form `<claim_namespace/claim_name>`. Consider this when setting Team and Username attribute names.
+
+## Troubleshooting the SAML assertion
+Use this guide to verify and validate the claims being sent in the SAML response. 
+https://support.hashicorp.com/hc/en-us/articles/1500005371682-Capturing-a-SAML-Assertion

--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -79,15 +79,18 @@ To edit your Azure SSO configuration settings:
 To configure team management in your Microsoft Azure AD application:
 
 1. Navigate to the single sign-on page.
-1. Edit step 2, "User Attributes & Claims."
-   We recommend naming it "MemberOf", leaving the namespace blank, and potentially sourcing `user.assignedroles` as an easy starting point.
+1. Edit step 2, "User Attributes & Claims."  
+2. Add a new group claim.
+3. In the "Group Claims" side window, select the "Security Groups" radio button.  
+   For "Source Attribute", select "sAMAccountName" to have group names passed in the SAML or select "Group ID" to pass thru the UUIDs for the group.  See **Note** below.
+   Check the box for "Customize the name of hte group claim" and in the "Name (required)" field put "MemberOf" and leave namespace blank.
 
 -> **Note:** When Azure AD is configured to use Group Claims, it provides Group UUIDs instead of human readable names in its SAML assertions. We recommend [configuring SSO Team IDs](/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) for your Terraform Cloud teams to match these Azure Group UUIDs.
 
 If you plan to make use of SAML to set usernames in your Microsoft Azure AD application:
 
 1. Navigate to the single sign-on page.
-1. Edit step 2, "User Attributes & Claims."
+1. Edit step 2, "User Attributes & Claims."  
    We recommend naming the claim "Username", leaving the namespace blank, and sourcing something like `user.displayname` or `user.mailnickname`.
 
 If you namespaced any of your claims, note that the attribute name passed by Microsoft Azure AD will follow the form `<claim_namespace/claim_name>`. Consider this when setting Team and Username attribute names.


### PR DESCRIPTION
### What
I updated the documentation for Azure AD configuration for setting up the Enterprise Application and the claims to pass groups thru the SAML response to allow Terraform Cloud to use the groups to determine workspace access via teams.

### Why
The documentation was outdated / not accurate due to changes on the MSFT AD side. 



----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [n/a] Description links to related pull requests or issues, if any.

#### Content
- [n/a] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [n/a ] API documentation and the API Changelog have been updated. 
- [n/a ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [X ] Pages with related content are updated and link to this content when appropriate.
- [ n/a] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ n/a] New pages have metadata (page name and description) at the top.
- [ n/a] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ x] UI elements (button names, page names, etc.) are bolded.
- [ x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
