### PR TITLE
plugin: Include terraform-plugin-framework in protocol version 5 implementations

### DIFF
--- a/website/docs/plugin/how-terraform-works.mdx
+++ b/website/docs/plugin/how-terraform-works.mdx
@@ -138,6 +138,7 @@ Protocol version 5 is compatible with Terraform CLI version 0.12 and later.
 
 Implementations include:
 
+* [terraform-plugin-framework](/plugin/framework): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
 * [terraform-plugin-sdk/v2](/plugin/sdkv2): A higher-level SDK that makes Terraform provider development easier by abstracting implementation details.
 * [terraform-plugin-go tf5server](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server): A lower-level SDK to develop Terraform providers for more advanced use cases.
 * [tf6to5server](/plugin/mux/translating-protocol-version-6-to-5): A package to translate protocol version 6 providers into protocol version 5.


### PR DESCRIPTION
### What

Updates to existing pages:

- /plugin/how-terraform-works

### Why

Reference: https://github.com/hashicorp/terraform-plugin-framework/pull/368

terraform-plugin-framework v0.9.0 will natively support Terraform Plugin Protocol version 5, which simplifies implementations which must support Terraform CLI 0.12 or later, or those migrating from terraform-plugin-sdk/v2 to the framework and using terraform-plugin-mux. Other plugin documentation is being separately updated.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
