### PR TITLE
registry/providers/publishing: Call out branch name overlapping and JSON syntax issues

### DIFF
--- a/website/docs/registry/providers/publishing.mdx
+++ b/website/docs/registry/providers/publishing.mdx
@@ -97,7 +97,7 @@ GoReleaser is a tool for building Go projects for multiple platforms, creating a
 1. Copy the [.goreleaser.yml file](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.goreleaser.yml) from the [hashicorp/terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding) repository.
 1. Cache the password for your GPG private key with `gpg --armor --detach-sign` (see note below).
 1. Set your `GITHUB_TOKEN` to a [Personal Access Token](https://github.com/settings/tokens/new?scopes=public_repo) that has the **public_repo** scope.
-1. Ensure there is not a branch name with the expected version tag name (e.g. `v.1.2.3`).
+1. Ensure there is not a branch name with the expected version tag name (e.g. `v1.2.3`).
 1. Tag your version with `git tag v1.2.3` and push your tags to GitHub.
 1. Build, sign, and upload your release with `goreleaser release --rm-dist`.
 

--- a/website/docs/registry/providers/publishing.mdx
+++ b/website/docs/registry/providers/publishing.mdx
@@ -47,7 +47,7 @@ The Terraform Registry supports a JSON configuration file in each release that p
 }
 ```
 
-This file is conventionally named `terraform-registry-manifest.json` at the root of the provider repository and will be renamed in the release assets.
+This file is conventionally named `terraform-registry-manifest.json` at the root of the provider repository and will be renamed in the release assets. The file must contain valid JSON syntax, such as no trailing commas in lists or objects.
 
 It supports the following fields:
 
@@ -61,7 +61,7 @@ It supports the following fields:
 
 ### Creating a GitHub Release
 
-Publishing a provider requires at least one version be available on GitHub Releases. The tag must be a valid [Semantic Version](https://semver.org/) preceded with a `v` (for example, `v1.2.3`).
+Publishing a provider requires at least one version be available on GitHub Releases. The tag must be a valid [Semantic Version](https://semver.org/) preceded with a `v` (for example, `v1.2.3`). There must not be a branch name with the same name as the tag.
 
 Terraform CLI and the Terraform Registry follow the Semantic Versioning specification when detecting a valid version, sorting versions, solving version constraints, and choosing the latest version. Prerelease versions are supported (available if explicitly defined but not chosen automatically) with a hyphen (-) delimiter, such as `v1.2.3-pre`.
 
@@ -84,6 +84,7 @@ To use GitHub Actions to publish new provider releases to the Terraform Registry
 - `GPG_PRIVATE_KEY` - Your ASCII-armored GPG private key. You can export this with `gpg --armor --export-secret-keys [key ID or email]`.
 - `PASSPHRASE` - The passphrase for your GPG private key.
 
+1. Ensure there is not a branch name with the new valid version tag name (e.g. `v1.2.3`).
 1. Push a new valid version tag (e.g. `v1.2.3`) to test that the GitHub Actions releaser is working.
 
 Once a release is created, you can move on to [Publishing to the Registry](#publishing-to-the-registry).
@@ -96,6 +97,7 @@ GoReleaser is a tool for building Go projects for multiple platforms, creating a
 1. Copy the [.goreleaser.yml file](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.goreleaser.yml) from the [hashicorp/terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding) repository.
 1. Cache the password for your GPG private key with `gpg --armor --detach-sign` (see note below).
 1. Set your `GITHUB_TOKEN` to a [Personal Access Token](https://github.com/settings/tokens/new?scopes=public_repo) that has the **public_repo** scope.
+1. Ensure there is not a branch name with the expected version tag name (e.g. `v.1.2.3`).
 1. Tag your version with `git tag v1.2.3` and push your tags to GitHub.
 1. Build, sign, and upload your release with `goreleaser release --rm-dist`.
 


### PR DESCRIPTION
### What

Updates to existing pages:

- /registry/providers/publishing

### Why

Provider publishers have discovered issues in their repositories that have prevented successful publishing of their providers into the Terraform Registry. Notably:

- The manifest file must be valid JSON syntax.
- There cannot be an overlapping branch name that matches the tag being published.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
