### PR TITLE
Modified the symlink to Client Library

### DIFF
--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -353,7 +353,7 @@ HashiCorp maintains [go-tfe](https://github.com/hashicorp/go-tfe), a Go client f
 
 Additionally, the community of Terraform Cloud users and vendors have built client libraries in other languages. These client libraries and tools are not tested nor officially maintained by HashiCorp, but are listed below in order to help users find them easily.
 
-If you have built a client library and would like to add it to this community list, please [contribute](https://github.com/hashicorp/terraform-website#contributions-welcome) to [this page](https://github.com/hashicorp/terraform-website/blob/master/content/cloud-docs/api-docs/index.mdx#client-libraries-and-tools).
+If you have built a client library and would like to add it to this community list, please [contribute](https://github.com/hashicorp/terraform-website#contributions-welcome) to [this page](https://github.com/hashicorp/terraform-docs-common/blob/main/website/docs/cloud-docs/api-docs/index.mdx#client-libraries-and-tools).
 
 - [tfh](https://github.com/hashicorp-community/tf-helper): UNIX shell console app
 - [tf_api_gateway](https://github.com/PlethoraOfHate/tf_api_gateway): Python API library and console app


### PR DESCRIPTION
The Client Library symlink is broken and it was forwarding to a non-existing location (https://github.com/hashicorp/terraform-website/blob/master/content/cloud-docs/api-docs/index.mdx#client-libraries-and-tools) I've added the new location - https://github.com/hashicorp/terraform-docs-common/blob/main/website/docs/cloud-docs/api-docs/index.mdx#client-libraries-and-tools

### What
<!-- Explain what you changed and provide a list of changed page names. -->

I've changed the symlink from https://github.com/hashicorp/terraform-website/blob/master/content/cloud-docs/api-docs/index.mdx#client-libraries-and-tools to https://github.com/hashicorp/terraform-docs-common/blob/main/website/docs/cloud-docs/api-docs/index.mdx#client-libraries-and-tools, as it was forwarding to non-existing location and returning error 404.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

Fixing the symlink will enable users to add new client libraries for the API.


### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
