### PR TITLE
Update Migrating to TFC page title

### DIFF
--- a/website/docs/cloud-docs/migrate/index.mdx
+++ b/website/docs/cloud-docs/migrate/index.mdx
@@ -5,7 +5,7 @@ description: >-
   without de-provisioning.
 ---
 
-# Migrating to Terraform Cloud
+# Migrating to Terraform Cloud or Terraform Enterprise
 
 You can begin using Terraform Cloud to manage existing resources without de-provisioning them. This requires migrating the Terraform [state files](/language/state) for those resources to one or more Terraform Cloud workspaces. You can perform this migration with either the Terraform CLI or the Terraform Cloud API.
 

--- a/website/docs/cloud-docs/migrate/index.mdx
+++ b/website/docs/cloud-docs/migrate/index.mdx
@@ -1,8 +1,7 @@
 ---
-page_title: Migrating to Terraform Cloud - Terraform Cloud and Terraform Enterprise
+page_title: Migrating to Terraform Cloud or Terraform Enterprise - Terraform Cloud and Terraform Enterprise
 description: >-
-  Migrate state to Terraform Cloud to continue managing existing infrastructure
-  without de-provisioning.
+  Migrate state to Terraform Cloud or Terraform Enterprise to continue managing existing infrastructure without de-provisioning.
 ---
 
 # Migrating to Terraform Cloud or Terraform Enterprise


### PR DESCRIPTION
### What
This is a shared page. In most cases, it's okay to leave Terraform Cloud as is - especially in text. Users I think understand by now that we mean Terraform Enterprise, when we're in the Terraform Enterprise docs. But since this will be listed as "Migrating to Terraform Enterprise" in the TFE sidebar, I want to make sure that the title doesn't feel completely incongruent with the sidebar entry.

### Why
Hopefully users won't be confused by the name of the page when they click it :-) 

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
