### PR TITLE
website/docs/plugin: Update the Which SDK page to include two new framework-only features

### DIFF
--- a/website/docs/plugin/which-sdk.mdx
+++ b/website/docs/plugin/which-sdk.mdx
@@ -41,7 +41,7 @@ should consider using the framework if you would benefit from the ability to:
 * Use nested attributes.
 * Use any type as the elements of a map.
 * Tell when an optional and computed field has been removed from a config.
-* Implement schema-based validation that is relative to the current attribute or applies to any list/map/set element.
+* Implement schema-based validation that is relative to the current attribute or applies to any list, map, or set element.
 * Return warning or error diagnostics during resource destruction.
 
 ## Do You Need Any Features That the Framework Doesn't Provide (Yet)?

--- a/website/docs/plugin/which-sdk.mdx
+++ b/website/docs/plugin/which-sdk.mdx
@@ -41,6 +41,8 @@ should consider using the framework if you would benefit from the ability to:
 * Use nested attributes.
 * Use any type as the elements of a map.
 * Tell when an optional and computed field has been removed from a config.
+* Implement schema-based validation that is relative to the current attribute or applies to any list/map/set element.
+* Return warning or error diagnostics during resource destruction.
 
 ## Do You Need Any Features That the Framework Doesn't Provide (Yet)?
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/pull/396
Reference: https://github.com/hashicorp/terraform-plugin-framework/pull/409

These will be included in the upcoming terraform-plugin-framework v0.10.0 release and are features not available in terraform-plugin-sdk/v2. Once the initial path expression support is finalized, we'll need to create a new page in the terraform-plugin-framework content, and it might be good to convert all these list items to links.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
