### PR TITLE
docs: update run tasks version requirement

### DIFF
--- a/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
@@ -14,7 +14,7 @@ You can manage run tasks through the UI as detailed below or through the [Run Ta
 
 ## Requirements
 
-**Terraform Version** - You can only assign run tasks to workspaces that use a Terraform version of 1.1.9 and later. Downgrading a workspace with existing run tasks to use a prior Terraform version will not result in an error, but Terraform Cloud will no longer trigger the run tasks during plan and apply operations.
+**Terraform Version** - You can only assign run tasks to workspaces that use a Terraform version of 1.1.9 and later. Downgrading a workspace with existing run tasks to use a prior Terraform version will not result in an error. Instead, Terraform Cloud will no longer trigger the run tasks during plan and apply operations.
 
 **Permissions** - To create a run task, you must have a user account with the [Manage Run Tasks permission](/cloud-docs/users-teams-organizations/permissions#manage-run-tasks). To associate run tasks with a workspace, you need the [Manage Workspace Run Tasks permission](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) on that particular workspace.
 

--- a/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
@@ -14,7 +14,7 @@ You can manage run tasks through the UI as detailed below or through the [Run Ta
 
 ## Requirements
 
-**Terraform Version** - You can only assign run tasks to workspaces that use a Terraform version of 1.1.9 and later. Downgrading a workspace with existing run tasks to use a prior Terraform version will not result in an error. Instead, Terraform Cloud will no longer trigger the run tasks during plan and apply operations.
+**Terraform Version** - You can only assign run tasks to workspaces that use a Terraform version of 1.1.9 and later. You can downgrade a workspace with existing runs to use a prior Terraform version without causing an error. However, Terraform Cloud no longer triggers the run tasks during plan and apply operations.
 
 **Permissions** - To create a run task, you must have a user account with the [Manage Run Tasks permission](/cloud-docs/users-teams-organizations/permissions#manage-run-tasks). To associate run tasks with a workspace, you need the [Manage Workspace Run Tasks permission](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) on that particular workspace.
 

--- a/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
@@ -14,7 +14,7 @@ You can manage run tasks through the UI as detailed below or through the [Run Ta
 
 ## Requirements
 
-**Terraform Version** - You can only assign run tasks to workspaces that use a Terraform version of 0.12 and later. Downgrading a workspace with existing run tasks to use a prior Terraform version will not result in an error, but Terraform Cloud will no longer trigger the run tasks during plan and apply operations.
+**Terraform Version** - You can only assign run tasks to workspaces that use a Terraform version of 1.1.9 and later. Downgrading a workspace with existing run tasks to use a prior Terraform version will not result in an error, but Terraform Cloud will no longer trigger the run tasks during plan and apply operations.
 
 **Permissions** - To create a run task, you must have a user account with the [Manage Run Tasks permission](/cloud-docs/users-teams-organizations/permissions#manage-run-tasks). To associate run tasks with a workspace, you need the [Manage Workspace Run Tasks permission](/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions) on that particular workspace.
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Update Terraform version requirement for Run Tasks from 0.12 to 1.1.9 in public documentation

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
According to the [release notes](https://github.com/hashicorp/terraform/blob/v1.1/CHANGELOG.md#119-april-20-2022), Run Tasks support in Terraform was introduced in 1.1.9

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] (N/A) The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
