### PR TITLE
Update the value of the "MemberOf" attribute

### DIFF
--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -80,7 +80,7 @@ To configure team management in your Microsoft Azure AD application:
 
 1. Navigate to the single sign-on page.
 1. Edit step 2, "User Attributes & Claims."
-   We recommend naming it "MemberOf", leaving the namespace blank, and potentially sourcing `user.assignedroles` as an easy starting point.
+   We recommend naming it "MemberOf", leaving the namespace blank, and potentially sourcing `user.groups` as an easy starting point.
 
 -> **Note:** When Azure AD is configured to use Group Claims, it provides Group UUIDs instead of human readable names in its SAML assertions. We recommend [configuring SSO Team IDs](/cloud-docs/users-teams-organizations/single-sign-on#team-names-and-sso-team-ids) for your Terraform Cloud teams to match these Azure Group UUIDs.
 


### PR DESCRIPTION
This PR is based on feedback from Terraform Cloud customers having difficulties to setup SSO Team management and proposes a change in the value of "MemberOf" claim attribute to have a `user.groups` as a value instead of `user. assignedroles` that represent the general use case.
