### PR TITLE
Add pre-plan beta notification to stages

### DIFF
--- a/website/docs/cloud-docs/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/website/docs/cloud-docs/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -22,7 +22,7 @@ Terraform Cloud uses run task stages and run task results to track [run task](/c
 
 When Terraform Cloud creates a [run][], it reads the run tasks associated to the workspace. Each run task in the workspace is configured to begin during a specific [run stage](/cloud-docs/run/states). Terraform Cloud creates a run task stage object for each run stage that will trigger run tasks. You can configure run tasks during the [Pre-Plan Stage](/cloud-docs/run/states#3-the-pre-plan-stage) and [Post-Plan Stage](/cloud-docs/run/states#5-the-post-plan-stage).
 
--> **Note:** Pre-plan run tasks are in beta. 
+-> **Note:** Pre-plan run tasks are in beta.
 
 Run task stages then create a run task result for each run task. For example, a workspace has two run tasks called `alpha` and `beta`. For each run, Terraform Cloud creates one run task stage called `post-plan`. That run task stage has two run task results: one for the `alpha` run task and one for the `beta` run task.
 

--- a/website/docs/cloud-docs/run/states.mdx
+++ b/website/docs/cloud-docs/run/states.mdx
@@ -39,6 +39,8 @@ _Leaving this stage:_
 
 The pre-plan phase only occurs if there are enabled [run tasks](/cloud-docs/workspaces/settings/run-tasks) in the workspace that are configured to begin before Terraform creates the plan. Terraform Cloud sends information about the run to the configured external system and waits for a `passed` or `failed` response to determine whether the run can continue. The information sent to the external system includes the configuration version of the run.
 
+-> **Note:** Pre-plan run tasks are in beta.
+
 All runs can enter this phase, including [speculative plans](/cloud-docs/run/#speculative-plans).
 
 _States in this stage:_

--- a/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
@@ -48,6 +48,8 @@ To create a new run task:
 
 1. Choose when Terraform Cloud should start the run task:
 
+-> **Note:** Pre-plan run tasks are in beta.
+
    - **Pre-plan**: Before Terraform creates the plan.
    - **Post-plan**: After Terraform creates the plan.
 


### PR DESCRIPTION
### What

Previously the documentation added pre-plan run tasks as beta but missed the
beta notification in the stages.  This commit adds a note to the stages
and run task configuration to indicate that pre-plan run tasks are beta.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x]  New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
