### PR TITLE
Correct additional closing brace and format of list workspace response

### DIFF
--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -675,120 +675,120 @@ $ curl \
 
 ```json
 {
-  "data": {
-    "attributes": {
-      "actions": {
-        "is-destroyable": true
-      },
-      "allow-destroy-plan": true,
-      "apply-duration-average": null,
-      "auto-apply": false,
-      "auto-destroy-at": null,
-      "created-at": "2021-08-16T21:50:58.726Z",
-      "description": null,
-      "environment": "default",
-      "execution-mode": "remote",
-      "file-triggers-enabled": true,
-      "global-remote-state": false,
-      "latest-change-at": "2021-08-16T21:50:58.726Z",
-      "locked": false,
-      "name": "workspace-2",
-      "operations": true,
-      "permissions": {
-        "can-create-state-versions": true,
-        "can-destroy": true,
-        "can-force-unlock": true,
-        "can-lock": true,
-        "can-manage-run-tasks": true,
-        "can-manage-tags": true,
-        "can-queue-apply": true,
-        "can-queue-destroy": true,
-        "can-queue-run": true,
-        "can-read-settings": true,
-        "can-read-state-versions": true,
-        "can-read-variable": true,
-        "can-unlock": true,
-        "can-update": true,
-        "can-update-variable": true
-      },
-      "plan-duration-average": null,
-      "policy-check-failures": null,
-      "queue-all-runs": false,
-      "resource-count": 0,
-      "run-failures": null,
-      "source": "tfe-api",
-      "source-name": null,
-      "source-url": null,
-      "speculative-enabled": true,
-      "structured-run-output-enabled": true,
-      "terraform-version": "0.11.1",
-      "trigger-prefixes": [],
-      "updated-at": "2021-08-16T21:50:58.726Z",
-      "vcs-repo": {
-        "branch": "",
-        "display-identifier": "example/terraform-test-proj",
-        "identifier": "example/terraform-test-proj",
-        "ingress-submodules": false,
-        "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
-        "repository-http-url": "https://github.com/example/terraform-test-proj",
-        "service-provider": "github",
-        "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
-      },
-      "vcs-repo-identifier": "example/terraform-test-proj",
-      "working-directory": "",
-      "workspace-kpis-runs-count": null
-    },
-    "id": "ws-KTuq99JSzgmDSvYj",
-    "links": {
-      "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
-    },
-    "relationships": {
-      "agent-pool": {
-        "data": null
-      },
-      "current-configuration-version": {
-        "data": {
-          "id": "cv-9WgU5LYoTq3rrnG6",
-          "type": "configuration-versions"
+  "data": [
+    {
+      "attributes": {
+        "actions": {
+          "is-destroyable": true
         },
-        "links": {
-          "related": "/api/v2/configuration-versions/cv-9WgU5LYoTq3rrnG6"
+        "allow-destroy-plan": true,
+        "apply-duration-average": null,
+        "auto-apply": false,
+        "auto-destroy-at": null,
+        "created-at": "2021-08-16T21:50:58.726Z",
+        "description": null,
+        "environment": "default",
+        "execution-mode": "remote",
+        "file-triggers-enabled": true,
+        "global-remote-state": false,
+        "latest-change-at": "2021-08-16T21:50:58.726Z",
+        "locked": false,
+        "name": "workspace-2",
+        "operations": true,
+        "permissions": {
+          "can-create-state-versions": true,
+          "can-destroy": true,
+          "can-force-unlock": true,
+          "can-lock": true,
+          "can-manage-run-tasks": true,
+          "can-manage-tags": true,
+          "can-queue-apply": true,
+          "can-queue-destroy": true,
+          "can-queue-run": true,
+          "can-read-settings": true,
+          "can-read-state-versions": true,
+          "can-read-variable": true,
+          "can-unlock": true,
+          "can-update": true,
+          "can-update-variable": true
+        },
+        "plan-duration-average": null,
+        "policy-check-failures": null,
+        "queue-all-runs": false,
+        "resource-count": 0,
+        "run-failures": null,
+        "source": "tfe-api",
+        "source-name": null,
+        "source-url": null,
+        "speculative-enabled": true,
+        "structured-run-output-enabled": true,
+        "terraform-version": "0.11.1",
+        "trigger-prefixes": [],
+        "updated-at": "2021-08-16T21:50:58.726Z",
+        "vcs-repo": {
+          "branch": "",
+          "display-identifier": "example/terraform-test-proj",
+          "identifier": "example/terraform-test-proj",
+          "ingress-submodules": false,
+          "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
+          "repository-http-url": "https://github.com/example/terraform-test-proj",
+          "service-provider": "github",
+          "webhook-url": "https://app.terraform.io/webhooks/vcs/704ac743-df64-4b8e-b9a3-a4c5fe1bec87"
+        },
+        "vcs-repo-identifier": "example/terraform-test-proj",
+        "working-directory": "",
+        "workspace-kpis-runs-count": null
+      },
+      "id": "ws-KTuq99JSzgmDSvYj",
+      "links": {
+        "self": "/api/v2/organizations/my-organization/workspaces/workspace-2"
+      },
+      "relationships": {
+        "agent-pool": {
+          "data": null
+        },
+        "current-configuration-version": {
+          "data": {
+            "id": "cv-9WgU5LYoTq3rrnG6",
+            "type": "configuration-versions"
+          },
+          "links": {
+            "related": "/api/v2/configuration-versions/cv-9WgU5LYoTq3rrnG6"
+          }
+        },
+        "current-run": {
+          "data": null
+        },
+        "current-state-version": {
+          "data": null
+        },
+        "latest-run": {
+          "data": null
+        },
+        "organization": {
+          "data": {
+            "id": "my-organization",
+            "type": "organizations"
+          }
+        },
+        "outputs": {
+          "data": []
+        },
+        "readme": {
+          "data": {
+            "id": "227347",
+            "type": "workspace-readme"
+          }
+        },
+        "remote-state-consumers": {
+          "links": {
+            "related": "/api/v2/workspaces/ws-KTuq99JSzgmDSvYj/relationships/remote-state-consumers"
+          }
         }
       },
-      "current-run": {
-        "data": null
-      },
-      "current-state-version": {
-        "data": null
-      },
-      "latest-run": {
-        "data": null
-      },
-      "organization": {
-        "data": {
-          "id": "my-organization",
-          "type": "organizations"
-        }
-      },
-      "outputs": {
-        "data": []
-      },
-      "readme": {
-        "data": {
-          "id": "227347",
-          "type": "workspace-readme"
-        }
-      },
-      "remote-state-consumers": {
-        "links": {
-          "related": "/api/v2/workspaces/ws-KTuq99JSzgmDSvYj/relationships/remote-state-consumers"
-        }
-      }
+      "type": "workspaces"
     },
-    "type": "workspaces"
-  },
-  {
-    "data": {
+    {
       "attributes": {
         "actions": {
           "is-destroyable": true
@@ -885,6 +885,7 @@ $ curl \
       },
       "type": "workspaces"
     }
+  ]
 }
 ```
 


### PR DESCRIPTION
Fix relationships.agent-pool in sample response from workspace details API

### What
Fixed documentation for 'show workspace' example API response data.
The previous output closed too many objects within relationships.agent-pool and indentation was incorrect as a result.

### Why
The previous example did not appear to be valid

### Screenshots
I have not added any, but I can add some if necessary.

### Relevant docs:
https://www.terraform.io/cloud-docs/api-docs/workspaces#show-workspace

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc). (I do not have permissions to add labels)
- [x] Description links to related pull requests or issues, if any. (I have not created an issue, but can do if need be, otherwise N/A)

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file. (I don't think this applies - N/A)
- [x] API documentation and the API Changelog have been updated.  (The API documentation has been corrected)
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A)
- [x] New pages have metadata (page name and description) at the top. (N/A)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded. (N/A)
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
