### PR TITLE
cloud-api(state-versions): adds json-state-outputs attribute

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -7,6 +7,11 @@ page_id: api-changelog
 
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
+### TBD
+
+* Update [State Versions](/cloud-docs/api-docs/state-versions#create) with `json-state-outputs` which describe the output values of the state.
+* Update [State Version Outputs](/cloud-docs/api-docs/state-version-outputs) with `detailed-type` which refines the output with the precise terraform type.
+
 ### 2022-07-26
 
 * Updated the [Run status list](/cloud-docs/api-docs/run#run-states) with `fetching`, `queuing`, `pre_plan_running` and `pre_plan_completed`

--- a/website/docs/cloud-docs/api-docs/state-version-outputs.mdx
+++ b/website/docs/cloud-docs/api-docs/state-version-outputs.mdx
@@ -13,8 +13,7 @@ page_title: State Version Outputs - API Docs - Terraform Cloud and Terraform Ent
 # State Version Outputs API
 
 State version outputs are the [output values](/language/values/outputs) from a Terraform state file. They include
-the name and value of the output, as well as a sensitive boolean if the value
-should be hidden by default in UIs.
+the name and value of the output, as well as a sensitive boolean if the value should be hidden by default in UIs.
 
 ## List State Version Outputs
 
@@ -66,6 +65,15 @@ curl \
           "strawberry",
           "blueberry",
           "rasberry"
+        ],
+        "detailed_type": [
+          "tuple",
+          [
+            "string",
+            "string",
+            "string",
+            "string"
+          ]
         ]
       },
       "links": {
@@ -84,6 +92,15 @@ curl \
           "potato",
           "tomato",
           "onions"
+        ],
+        "detailed_type": [
+          "tuple",
+          [
+            "string",
+            "string",
+            "string",
+            "string"
+          ]
         ]
       },
       "links": {
@@ -145,7 +162,8 @@ curl \
       "name": "flavor",
       "sensitive": false,
       "type": "string",
-      "value": "Peanut Butter"
+      "value": "Peanut Butter",
+      "detailed-type": "string"
     },
     "links": {
       "self": "/api/v2/state-version-outputs/wsout-J2zM24JPFbfc7bE5"
@@ -192,7 +210,8 @@ curl \
         "name": "flavor",
         "sensitive": false,
         "type": "string",
-        "value": "Peanut Butter"
+        "value": "Peanut Butter",
+        "detailed-type": "string"
       },
       "links": {
         "self": "/api/v2/state-version-outputs/wsout-J2zM24JPFbfc7bE5"
@@ -205,7 +224,8 @@ curl \
         "name": "recipe",
         "sensitive": true,
         "type": "string",
-        "value": null 
+        "value": "Don Douglas' Peanut Butter Frenzy",
+        "detailed-type": "string"
       },
       "links": {
         "self": "/api/v2/state-version-outputs/wsout-FLzM23Gcd5f37bE5"

--- a/website/docs/cloud-docs/api-docs/state-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/state-versions.mdx
@@ -43,7 +43,7 @@ page_title: State Versions - API Docs - Terraform Cloud and Terraform Enterprise
 `POST /workspaces/:workspace_id/state-versions`
 
 | Parameter       | Description                                                                                                                                                                                                       |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `:workspace_id` | The workspace ID to create the new state version in. Obtain this from the [workspace settings](/cloud-docs/workspaces/settings) or the [Show Workspace](/cloud-docs/api-docs/workspaces#show-workspace) endpoint. |
 
 Creates a state version and sets it as the current state version for the given workspace. The workspace must be locked by the user creating a state version. The workspace may be locked [with the API](/cloud-docs/api-docs/workspaces#lock-a-workspace) or [with the UI](/cloud-docs/workspaces/settings#locking). This is most useful for migrating existing state from open source Terraform into a new Terraform Cloud workspace.
@@ -59,7 +59,7 @@ Creating state versions requires permission to read and write state versions for
 -> **Note:** This endpoint cannot be accessed with [organization tokens](/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens). You must access it with a [user token](/cloud-docs/users-teams-organizations/users#api-tokens) or [team token](/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens).
 
 | Status  | Response                  | Reason                                                            |
-| ------- | ------------------------- | ----------------------------------------------------------------- |
+|---------|---------------------------|-------------------------------------------------------------------|
 | [201][] | [JSON API document][]     | Successfully created a state version.                             |
 | [404][] | [JSON API error object][] | Workspace not found, or user unauthorized to perform action.      |
 | [409][] | [JSON API error object][] | Conflict; check the error object for more information.            |
@@ -72,14 +72,15 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-| Key path                         | Type    | Default   | Description                                                                                                                                                                                               |
-| -------------------------------- | ------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data.type`                      | string  |           | Must be `"state-versions"`.                                                                                                                                                                               |
-| `data.attributes.serial`         | integer |           | The serial of the state version. Must match the serial value extracted from the raw state file.                                                                                                           |
-| `data.attributes.md5`            | string  |           | An MD5 hash of the raw state version                                                                                                                                                                      |
-| `data.attributes.lineage`        | string  | (nothing) | **Optional** Lineage of the state version. Should match the lineage extracted from the raw state file. Early versions of terraform did not have the concept of lineage, so this is an optional attribute. |
-| `data.attributes.state`          | string  |           | Base64 encoded raw state file                                                                                                                                                                             |
-| `data.relationships.run.data.id` | string  | (nothing) | **Optional** The ID of the run to associate with the state version.                                                                                                                                       |
+| Key path                             | Type    | Default   | Description                                                                                                                                                                                                                 |
+|--------------------------------------|---------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `data.type`                          | string  |           | Must be `"state-versions"`.                                                                                                                                                                                                 |
+| `data.attributes.serial`             | integer |           | The serial of the state version. Must match the serial value extracted from the raw state file.                                                                                                                             |
+| `data.attributes.md5`                | string  |           | An MD5 hash of the raw state version                                                                                                                                                                                        |
+| `data.attributes.lineage`            | string  | (nothing) | **Optional** Lineage of the state version. Should match the lineage extracted from the raw state file. Early versions of terraform did not have the concept of lineage, so this is an optional attribute.                   |
+| `data.attributes.state`              | string  |           | Base64 encoded raw state file                                                                                                                                                                                               |
+| `data.attributes.json-state-outputs` | string  | (nothing) | **Optional** Base64 encoded output values as represented by `terraform show -json` (the contents of the values/outputs key). If omitted, Terraform Cloud will populate the workspace outputs from state after a short time. |
+| `data.relationships.run.data.id`     | string  | (nothing) | **Optional** The ID of the run to associate with the state version.                                                                                                                                                         |
 
 ### Sample Payload
 
@@ -91,7 +92,8 @@ Properties without a default value are required.
       "serial": 1,
       "md5": "d41d8cd98f00b204e9800998ecf8427e",
       "lineage": "871d1b4a-e579-fb7c-ffdb-f0c858a647a7",
-      "state": "..."
+      "state": "...",
+      "json-state-outputs": "..."
     },
     "relationships": {
       "run": {
@@ -152,7 +154,7 @@ Listing state versions requires permission to read state versions for the worksp
 This endpoint supports pagination [with standard URL query parameters](/cloud-docs/api-docs/#query-parameters). Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
 
 | Parameter                    | Description                                                                    |
-| ---------------------------- | ------------------------------------------------------------------------------ |
+|------------------------------|--------------------------------------------------------------------------------|
 | `filter[workspace][name]`    | **Required** The name of one workspace to list versions for.                   |
 | `filter[organization][name]` | **Required** The name of the organization that owns the desired workspace.     |
 | `page[number]`               | **Optional.** If omitted, the endpoint will return the first page.             |
@@ -361,7 +363,7 @@ curl \
 `GET /workspaces/:workspace_id/current-state-version`
 
 | Parameter       | Description                                                                                                                                                                                                                          |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `:workspace_id` | The ID for the workspace whose current state version you want to fetch. Obtain this from the [workspace settings](/cloud-docs/workspaces/settings) or the [Show Workspace](/cloud-docs/api-docs/workspaces#show-workspace) endpoint. |
 
 Fetches the current state version for the given workspace. This state version
@@ -372,7 +374,7 @@ Viewing state versions requires permission to read state versions for the worksp
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 | Status  | Response                  | Reason                                                                                                        |
-| ------- | ------------------------- | ------------------------------------------------------------------------------------------------------------- |
+|---------|---------------------------|---------------------------------------------------------------------------------------------------------------|
 | [200][] | [JSON API document][]     | Successfully returned current state version for the given workspace.                                          |
 | [404][] | [JSON API error object][] | Workspace not found, workspace does not have a current state version, or user unauthorized to perform action. |
 
@@ -491,11 +493,11 @@ Viewing state versions requires permission to read state versions for the worksp
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 | Parameter           | Description                          |
-| ------------------- | ------------------------------------ |
+|---------------------|--------------------------------------|
 | `:state_version_id` | The ID of the desired state version. |
 
 | Status  | Response                  | Reason                                                                                                        |
-| ------- | ------------------------- | ------------------------------------------------------------------------------------------------------------- |
+|---------|---------------------------|---------------------------------------------------------------------------------------------------------------|
 | [200][] | [JSON API document][]     | Successfully returned current state version for the given workspace.                                          |
 | [404][] | [JSON API error object][] | Workspace not found, workspace does not have a current state version, or user unauthorized to perform action. |
 


### PR DESCRIPTION
### What
cloud-api (state-versions) create action
cloud-api (state-version-outputs) all actions

### Why
There is an upcoming API change that will introduce a couple of new attributes to better support state outputs, storing and revealing extra type information.

### Notes
This should not be merged until the attributes are available to all users.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [X] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
