### PR TITLE
Update to Terraform Cloud Only

### DIFF
--- a/website/docs/cloud-docs/api-docs/account.mdx
+++ b/website/docs/cloud-docs/api-docs/account.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Account - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Account - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/agent-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/agent-tokens.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Agent Tokens - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Agent Tokens - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/agents.mdx
+++ b/website/docs/cloud-docs/api-docs/agents.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Agent Pools and Agents - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Agent Pools and Agents - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/applies.mdx
+++ b/website/docs/cloud-docs/api-docs/applies.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Applies - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Applies - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/assessment-results.mdx
+++ b/website/docs/cloud-docs/api-docs/assessment-results.mdx
@@ -1,7 +1,8 @@
 ---
 page_title: Assessments - API Docs - Terraform Cloud
 description: >-
-  Assessment results contain information about continuous validation in Terraform Cloud, like drift detection. 
+  Assessment results contain information about continuous validation in
+  Terraform Cloud, like drift detection.
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: API Changelog - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: API Changelog - API Docs - Terraform Cloud
 page_id: api-changelog
 ---
 

--- a/website/docs/cloud-docs/api-docs/comments.mdx
+++ b/website/docs/cloud-docs/api-docs/comments.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Comments - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Comments - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/configuration-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/configuration-versions.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Configuration Versions - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Configuration Versions - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/cost-estimates.mdx
+++ b/website/docs/cloud-docs/api-docs/cost-estimates.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Cost Estimates - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Cost Estimates - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/feature-sets.mdx
+++ b/website/docs/cloud-docs/api-docs/feature-sets.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Feature Sets - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Feature Sets - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: API Docs - Terraform Cloud and Terraform Enterprise
+page_title: API Docs - Terraform Cloud
 description: >-
   Use the API to manage runs, workspaces, policies, and more. This introduction
   includes authentication, features, and formatting.

--- a/website/docs/cloud-docs/api-docs/invoices.mdx
+++ b/website/docs/cloud-docs/api-docs/invoices.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Invoices - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Invoices - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/ip-ranges.mdx
+++ b/website/docs/cloud-docs/api-docs/ip-ranges.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: IP Ranges - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: IP Ranges - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/notification-configurations.mdx
+++ b/website/docs/cloud-docs/api-docs/notification-configurations.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Notification Configurations - API Docs - Terraform Cloud and Terraform
-  Enterprise
+page_title: Notification Configurations - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/oauth-clients.mdx
+++ b/website/docs/cloud-docs/api-docs/oauth-clients.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: OAuth Clients - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: OAuth Clients - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/oauth-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/oauth-tokens.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: OAuth Tokens - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: OAuth Tokens - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/organization-memberships.mdx
+++ b/website/docs/cloud-docs/api-docs/organization-memberships.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Organization Memberships - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Organization Memberships - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/organization-tags.mdx
+++ b/website/docs/cloud-docs/api-docs/organization-tags.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Organization Tags - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Organization Tags - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/organization-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/organization-tokens.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Organization Tokens - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Organization Tokens - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/organizations.mdx
+++ b/website/docs/cloud-docs/api-docs/organizations.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Organizations - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Organizations - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/plan-exports.mdx
+++ b/website/docs/cloud-docs/api-docs/plan-exports.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Plan Exports - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Plan Exports - API Docs - Terraform Cloud
 ---
 
 # Plan Exports API

--- a/website/docs/cloud-docs/api-docs/plans.mdx
+++ b/website/docs/cloud-docs/api-docs/plans.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Plans - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Plans - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/policies.mdx
+++ b/website/docs/cloud-docs/api-docs/policies.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Policies - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Policies - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/policy-checks.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-checks.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Policy Checks - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Policy Checks - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/policy-set-params.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-set-params.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Policy Set Parameters - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Policy Set Parameters - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/policy-sets.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-sets.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Policy Sets - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Policy Sets - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/private-registry/gpg-keys.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/gpg-keys.mdx
@@ -1,7 +1,8 @@
 ---
-page_title: Providers - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Providers - API Docs - Terraform Cloud
 description: >-
-  GPG signing is required for custom providers. Create, read, update, and delete GPG keys with the Terraform Cloud API.
+  GPG signing is required for custom providers. Create, read, update, and delete
+  GPG keys with the Terraform Cloud API.
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Modules - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Modules - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/provider-versions-platforms.mdx
@@ -1,7 +1,8 @@
 ---
-page_title: Private Provider Versions and Platforms - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Private Provider Versions and Platforms - API Docs - Terraform Cloud
 description: >-
-  Create, read, update, and delete provider versions and platforms with the Terraform Cloud API.
+  Create, read, update, and delete provider versions and platforms with the
+  Terraform Cloud API.
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/private-registry/providers.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/providers.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Providers - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Providers - API Docs - Terraform Cloud
 description: >-
   You can add public providers to your organization's private registry. Create,
   read, update, and delete public providers with the Terraform Cloud API.

--- a/website/docs/cloud-docs/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/website/docs/cloud-docs/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Run Task Stages and Results - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Run Task Stages and Results - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/run-tasks/run-tasks-integration.mdx
+++ b/website/docs/cloud-docs/api-docs/run-tasks/run-tasks-integration.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Run Tasks Integration - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Run Tasks Integration - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/run-tasks/run-tasks.mdx
+++ b/website/docs/cloud-docs/api-docs/run-tasks/run-tasks.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Run Tasks - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Run Tasks - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/run-triggers.mdx
+++ b/website/docs/cloud-docs/api-docs/run-triggers.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Run Triggers - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Run Triggers - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/run.mdx
+++ b/website/docs/cloud-docs/api-docs/run.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Runs - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Runs - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/ssh-keys.mdx
+++ b/website/docs/cloud-docs/api-docs/ssh-keys.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: SSH Keys - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: SSH Keys - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/stability-policy.mdx
+++ b/website/docs/cloud-docs/api-docs/stability-policy.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: API Stability Policy - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: API Stability Policy - API Docs - Terraform Cloud
 ---
 
 # API Stability Policy

--- a/website/docs/cloud-docs/api-docs/state-version-outputs.mdx
+++ b/website/docs/cloud-docs/api-docs/state-version-outputs.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: State Version Outputs - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: State Version Outputs - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/state-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/state-versions.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: State Versions - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: State Versions - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/subscriptions.mdx
+++ b/website/docs/cloud-docs/api-docs/subscriptions.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Subscriptions - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Subscriptions - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/team-access.mdx
+++ b/website/docs/cloud-docs/api-docs/team-access.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Team Access - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Team Access - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/team-members.mdx
+++ b/website/docs/cloud-docs/api-docs/team-members.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Team Membership - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Team Membership - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/team-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/team-tokens.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Team Tokens - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Team Tokens - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/teams.mdx
+++ b/website/docs/cloud-docs/api-docs/teams.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Teams - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Teams - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/user-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/user-tokens.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: User Tokens - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: User Tokens - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/users.mdx
+++ b/website/docs/cloud-docs/api-docs/users.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Users - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Users - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/variable-sets.mdx
+++ b/website/docs/cloud-docs/api-docs/variable-sets.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Variable Sets - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Variable Sets - API Docs - Terraform Cloud
 description: >-
   Variable sets allow you to reuse variables across multiple workspaces. Create,
   read, update, and delete variable sets with the Terraform Cloud API.

--- a/website/docs/cloud-docs/api-docs/variables.mdx
+++ b/website/docs/cloud-docs/api-docs/variables.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Variables - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Variables - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/vcs-events.mdx
+++ b/website/docs/cloud-docs/api-docs/vcs-events.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: VCS Events - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: VCS Events - API Docs - Terraform Cloud
 ---
 
 # VCS Events API

--- a/website/docs/cloud-docs/api-docs/workspace-resources.mdx
+++ b/website/docs/cloud-docs/api-docs/workspace-resources.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Workspace Resources - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Workspace Resources - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/workspace-variables.mdx
+++ b/website/docs/cloud-docs/api-docs/workspace-variables.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Workspace Variables - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Workspace Variables - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Workspaces - API Docs - Terraform Cloud and Terraform Enterprise
+page_title: Workspaces - API Docs - Terraform Cloud
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/architectural-details/data-security.mdx
+++ b/website/docs/cloud-docs/architectural-details/data-security.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Data Security - Architectural Details - Terraform Cloud and Terraform
-  Enterprise
+page_title: Data Security - Architectural Details - Terraform Cloud
 description: >-
   Learn which parts of the application contain sensitive data and what storage
   and encryption methods we use.

--- a/website/docs/cloud-docs/architectural-details/index.mdx
+++ b/website/docs/cloud-docs/architectural-details/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Architectural Details - Terraform Cloud and Terraform Enterprise
+page_title: Architectural Details - Terraform Cloud
 description: >-
   A collection of information about Terraform Cloud architecture and operational
   characteristics.

--- a/website/docs/cloud-docs/architectural-details/ip-ranges.mdx
+++ b/website/docs/cloud-docs/architectural-details/ip-ranges.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: IP Ranges - Terraform Cloud and Terraform Enterprise
+page_title: IP Ranges - Terraform Cloud
 description: >-
   Terraform Cloud uses static IP ranges for features like notifications and VCS
   connections. These ranges may change.

--- a/website/docs/cloud-docs/cost-estimation/aws.mdx
+++ b/website/docs/cloud-docs/cost-estimation/aws.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: AWS - Cost Estimation - Terraform Cloud and Terraform Enterprise
+page_title: AWS - Cost Estimation - Terraform Cloud
 ---
 
 # Supported AWS resources in Terraform Cloud Cost Estimation

--- a/website/docs/cloud-docs/cost-estimation/azure.mdx
+++ b/website/docs/cloud-docs/cost-estimation/azure.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Azure - Cost Estimation - Terraform Cloud and Terraform Enterprise
+page_title: Azure - Cost Estimation - Terraform Cloud
 ---
 
 # Supported Azure resources in Terraform Cloud Cost Estimation

--- a/website/docs/cloud-docs/cost-estimation/gcp.mdx
+++ b/website/docs/cloud-docs/cost-estimation/gcp.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: GCP - Cost Estimation - Terraform Cloud and Terraform Enterprise
+page_title: GCP - Cost Estimation - Terraform Cloud
 ---
 
 # Supported GCP resources in Terraform Cloud Cost Estimation

--- a/website/docs/cloud-docs/cost-estimation/index.mdx
+++ b/website/docs/cloud-docs/cost-estimation/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Overview - Cost Estimation - Terraform Cloud and Terraform Enterprise
+page_title: Overview - Cost Estimation - Terraform Cloud
 description: >-
   Terraform Cloud displays hourly and monthly cost estimates for each resource
   and the total cost and delta of all resources.

--- a/website/docs/cloud-docs/integrations/service-now/admin-guide.mdx
+++ b/website/docs/cloud-docs/integrations/service-now/admin-guide.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Administrator Guide - ServiceNow Service Catalog Integration - Terraform Cloud
-  and Terraform Enterprise
+page_title: Administrator Guide - ServiceNow Service Catalog Integration - Terraform Cloud
 description: Administrator guide for the ServiceNow Service Catalog Integration.
 ---
 

--- a/website/docs/cloud-docs/integrations/service-now/developer-reference.mdx
+++ b/website/docs/cloud-docs/integrations/service-now/developer-reference.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Developer Reference - ServiceNow Service Catalog Integration - Terraform Cloud
-  and Terraform Enterprise
+page_title: Developer Reference - ServiceNow Service Catalog Integration - Terraform Cloud
 description: Developer reference for the ServiceNow Service Catalog Integration.
 ---
 

--- a/website/docs/cloud-docs/integrations/service-now/example-customizations.mdx
+++ b/website/docs/cloud-docs/integrations/service-now/example-customizations.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: >-
   Example Customizations - ServiceNow Service Catalog Integration - Terraform
-  Cloud and Terraform Enterprise
+  Cloud
 description: Example customizations for the ServiceNow Service Catalog Integration.
 ---
 

--- a/website/docs/cloud-docs/integrations/service-now/index.mdx
+++ b/website/docs/cloud-docs/integrations/service-now/index.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Setup Instructions - ServiceNow Service Catalog Integration - Terraform Cloud
-  and Terraform Enterprise
+page_title: Setup Instructions - ServiceNow Service Catalog Integration - Terraform Cloud
 description: >-
   ServiceNow integration enables your users to order Terraform-built
   infrastructure from ServiceNow.

--- a/website/docs/cloud-docs/integrations/service-now/service-catalog.mdx
+++ b/website/docs/cloud-docs/integrations/service-now/service-catalog.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Service Catalog - ServiceNow Service Catalog Integration - Terraform Cloud and
-  Terraform Enterprise
+page_title: Service Catalog - ServiceNow Service Catalog Integration - Terraform Cloud
 description: |-
   Configure Service Catalogs and VCS repositories to allow end users to
   provision infrastructure using ServiceNow and Terraform Cloud.

--- a/website/docs/cloud-docs/integrations/service-now/service-now-v1/index.mdx
+++ b/website/docs/cloud-docs/integrations/service-now/service-now-v1/index.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Setup Instructions - ServiceNow Service Catalog Integration - Terraform Cloud
-  and Terraform Enterprise
+page_title: Setup Instructions - ServiceNow Service Catalog Integration - Terraform Cloud
 description: >-
   ServiceNow integration to enable your users to order Terraform-built
   infrastructure from ServiceNow

--- a/website/docs/cloud-docs/migrate/index.mdx
+++ b/website/docs/cloud-docs/migrate/index.mdx
@@ -1,7 +1,8 @@
 ---
-page_title: Migrating to Terraform Cloud or Terraform Enterprise - Terraform Cloud and Terraform Enterprise
+page_title: Migrating to Terraform Cloud or Terraform Enterprise - Terraform Cloud
 description: >-
-  Migrate state to Terraform Cloud or Terraform Enterprise to continue managing existing infrastructure without de-provisioning.
+  Migrate state to Terraform Cloud or Terraform Enterprise to continue managing
+  existing infrastructure without de-provisioning.
 ---
 
 # Migrating to Terraform Cloud or Terraform Enterprise

--- a/website/docs/cloud-docs/overview.mdx
+++ b/website/docs/cloud-docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Plans and Features - Terraform Cloud and Terraform Enterprise
+page_title: Plans and Features - Terraform Cloud
 description: >-
   How Terraform Cloud and Terraform Enterprise help teams use Terraform to
   manage infrastructure at scale.

--- a/website/docs/cloud-docs/registry/add.mdx
+++ b/website/docs/cloud-docs/registry/add.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Adding Public Providers and Modules - Private Registry - Terraform Cloud and
-  Terraform Enterprise
+page_title: Adding Public Providers and Modules - Private Registry - Terraform Cloud
 description: >-
   Add providers and modules from the public Terraform Registry to your
   organization's private registry.

--- a/website/docs/cloud-docs/registry/design.mdx
+++ b/website/docs/cloud-docs/registry/design.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Using the Configuration Designer - Private Registry - Terraform Cloud and
-  Terraform Enterprise
+page_title: Using the Configuration Designer - Private Registry - Terraform Cloud
 description: >-
   The configuration designer lets you outline a configuration with private
   modules and helps you quickly define variables.

--- a/website/docs/cloud-docs/registry/index.mdx
+++ b/website/docs/cloud-docs/registry/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Private Registry - Terraform Cloud and Terraform Enterprise
+page_title: Private Registry - Terraform Cloud
 description: >-
   Use the Terraform Cloud private registry to share Terraform providers and
   modules across your organization.

--- a/website/docs/cloud-docs/registry/publish-modules.mdx
+++ b/website/docs/cloud-docs/registry/publish-modules.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Publishing Private Modules - Private Registry - Terraform Cloud and Terraform
-  Enterprise
+page_title: Publishing Private Modules - Private Registry - Terraform Cloud
 description: >-
   Learn to prepare private modules for publishing, add them to the registry, and
   release new versions.

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -1,9 +1,8 @@
 ---
-page_title: >-
-  Publishing Private Providers - Private Registry
+page_title: Publishing Private Providers - Private Registry
 description: >-
-  Prepare private providers for publishing, add them to the private registry, and
-  release new versions.
+  Prepare private providers for publishing, add them to the private registry,
+  and release new versions.
 ---
 
 # Publishing Private Providers to the Terraform Cloud Private Registry

--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -1,9 +1,6 @@
 ---
-page_title: >-
-  Using Providers and Modules - Private Module Registry - Terraform Cloud and Terraform
-  Enterprise
-description: >-
-  Find available providers and modules and include them in configurations.
+page_title: Using Providers and Modules - Private Module Registry - Terraform Cloud
+description: Find available providers and modules and include them in configurations.
 ---
 
 # Using Providers and Modules from the Private Registry

--- a/website/docs/cloud-docs/run/api.mdx
+++ b/website/docs/cloud-docs/run/api.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: API-driven Runs - Runs - Terraform Cloud and Terraform Enterprise
+page_title: API-driven Runs - Runs - Terraform Cloud
 description: >-
   External tools communicate with Terraform Cloud to upload configurations and
   trigger runs.

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: CLI-driven Runs - Runs - Terraform Cloud and Terraform Enterprise
+page_title: CLI-driven Runs - Runs - Terraform Cloud
 description: >-
   Trigger runs from your terminal using the Terraform CLI. Learn the required
   configuration for remote CLI runs.

--- a/website/docs/cloud-docs/run/install-software.mdx
+++ b/website/docs/cloud-docs/run/install-software.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Installing Software in the Run Environment - Runs - Terraform Cloud and
-  Terraform Enterprise
+page_title: Installing Software in the Run Environment - Runs - Terraform Cloud
 description: >-
   Learn how to install Terraform providers and additional software on Terraform
   Cloud workers, including cloud CLIs or configuration management tools.

--- a/website/docs/cloud-docs/run/manage.mdx
+++ b/website/docs/cloud-docs/run/manage.mdx
@@ -1,8 +1,8 @@
 ---
-page_title: Viewing and Managing Runs - Runs - Terraform Cloud and Terraform Enterprise
+page_title: Viewing and Managing Runs - Runs - Terraform Cloud
 description: >-
-  Workspaces list current, pending, and historical runs. View run
-  information and lock workspaces to prevent new runs.
+  Workspaces list current, pending, and historical runs. View run information
+  and lock workspaces to prevent new runs.
 ---
 
 # Viewing and Managing Runs

--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Run Modes and Options - Runs - Terraform Cloud and Terraform Enterprise
+page_title: Run Modes and Options - Runs - Terraform Cloud
 description: >-
   Learn the effect of the Destroy and Refresh-Only modes as well as options to
   customize behavior during runs.

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -1,9 +1,8 @@
 ---
-page_title: >-
-  Remote Operations - Terraform Cloud and Terraform
-  Enterprise
+page_title: Remote Operations - Terraform Cloud
 description: >-
-  Run Terraform remotely through the UI, API, or CLI. Learn how Terraform Cloud manages runs.
+  Run Terraform remotely through the UI, API, or CLI. Learn how Terraform Cloud
+  manages runs.
 ---
 
 # Remote Operations

--- a/website/docs/cloud-docs/run/run-environment.mdx
+++ b/website/docs/cloud-docs/run/run-environment.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Terraform Cloud's Run Environment - Runs - Terraform Cloud and Terraform
-  Enterprise
+page_title: Terraform Cloud's Run Environment - Runs - Terraform Cloud
 description: >-
   Learn about worker virtual machines, network access, concurrency for run
   queueing, state access authentication, and environment variables.

--- a/website/docs/cloud-docs/run/states.mdx
+++ b/website/docs/cloud-docs/run/states.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Run States and Stages - Runs - Terraform Cloud and Terraform Enterprise
+page_title: Run States and Stages - Runs - Terraform Cloud
 description: >-
   Learn what happens during each stage of a run: pending, plan, cost estimation,
   policy check, apply, and complete.

--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: UI/VCS-driven Runs - Runs - Terraform Cloud and Terraform Enterprise
+page_title: UI/VCS-driven Runs - Runs - Terraform Cloud
 description: >-
   Workspaces are associated with a VCS repository branch, and Terraform Cloud
   automatically queues runs when new commits are merged.

--- a/website/docs/cloud-docs/sentinel/enforce.mdx
+++ b/website/docs/cloud-docs/sentinel/enforce.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Enforce and Override Policies - Sentinel - Terraform Cloud and Terraform
-  Enterprise
+page_title: Enforce and Override Policies - Sentinel - Terraform Cloud
 description: >-
   Learn when Terraform Cloud performs policy checks and what happens when
   different types of policy checks fail.

--- a/website/docs/cloud-docs/sentinel/examples.mdx
+++ b/website/docs/cloud-docs/sentinel/examples.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Example Policies - Policies - Terraform Cloud and Terraform Enterprise
+page_title: Example Policies - Policies - Terraform Cloud
 description: >-
   Review policy examples that demonstrate some of the most common use cases
   within Terraform Cloud.

--- a/website/docs/cloud-docs/sentinel/import/index.mdx
+++ b/website/docs/cloud-docs/sentinel/import/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Defining Policies - Sentinel - Terraform Cloud and Terraform Enterprise
+page_title: Defining Policies - Sentinel - Terraform Cloud
 description: >-
   Learn how to use Sentinel policy language to create policies, including
   imports to define rules, useful functions, and more.

--- a/website/docs/cloud-docs/sentinel/import/tfconfig-v2.mdx
+++ b/website/docs/cloud-docs/sentinel/import/tfconfig-v2.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tfconfig/v2 - Imports - Sentinel - Terraform Cloud and Terraform Enterprise
+page_title: tfconfig/v2 - Imports - Sentinel - Terraform Cloud
 description: The tfconfig/v2 import provides access to a Terraform configuration.
 ---
 

--- a/website/docs/cloud-docs/sentinel/import/tfconfig.mdx
+++ b/website/docs/cloud-docs/sentinel/import/tfconfig.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tfconfig - Imports - Sentinel - Terraform Cloud and Terraform Enterprise
+page_title: tfconfig - Imports - Sentinel - Terraform Cloud
 description: The tfconfig import provides access to a Terraform configuration.
 ---
 

--- a/website/docs/cloud-docs/sentinel/import/tfplan-v2.mdx
+++ b/website/docs/cloud-docs/sentinel/import/tfplan-v2.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tfplan/v2 - Imports - Sentinel - Terraform Cloud and Terraform Enterprise
+page_title: tfplan/v2 - Imports - Sentinel - Terraform Cloud
 description: The tfplan/v2 import provides access to a Terraform plan.
 ---
 

--- a/website/docs/cloud-docs/sentinel/import/tfplan.mdx
+++ b/website/docs/cloud-docs/sentinel/import/tfplan.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tfplan - Imports - Sentinel - Terraform Cloud and Terraform Enterprise
+page_title: tfplan - Imports - Sentinel - Terraform Cloud
 description: >-
   The tfplan import provides access to a Terraform plan. A Terraform plan is the
   file created as a result of `terraform plan` and is the input to `terraform

--- a/website/docs/cloud-docs/sentinel/import/tfrun.mdx
+++ b/website/docs/cloud-docs/sentinel/import/tfrun.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tfrun - Imports - Sentinel - Terraform Cloud and Terraform Enterprise
+page_title: tfrun - Imports - Sentinel - Terraform Cloud
 description: The `tfrun` import provides access to data associated with a Terraform run.
 ---
 

--- a/website/docs/cloud-docs/sentinel/import/tfstate-v2.mdx
+++ b/website/docs/cloud-docs/sentinel/import/tfstate-v2.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tfstate/v2 - Imports - Sentinel - Terraform Cloud and Terraform Enterprise
+page_title: tfstate/v2 - Imports - Sentinel - Terraform Cloud
 description: The tfstate/v2 import provides access to a Terraform state.
 ---
 

--- a/website/docs/cloud-docs/sentinel/import/tfstate.mdx
+++ b/website/docs/cloud-docs/sentinel/import/tfstate.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: tfstate - Imports - Sentinel - Terraform Cloud and Terraform Enterprise
+page_title: tfstate - Imports - Sentinel - Terraform Cloud
 description: The tfstate import provides access to a Terraform state.
 ---
 

--- a/website/docs/cloud-docs/sentinel/index.mdx
+++ b/website/docs/cloud-docs/sentinel/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Sentinel - Terraform Cloud and Terraform Enterprise
+page_title: Sentinel - Terraform Cloud
 description: >-
   Sentinel is a policy-as-code framework that enables logic-based policy
   decisions. Learn how you can use Sentinel with Terraform Cloud.

--- a/website/docs/cloud-docs/sentinel/json.mdx
+++ b/website/docs/cloud-docs/sentinel/json.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Working With JSON Result Data - Sentinel - Terraform Cloud and Terraform
-  Enterprise
+page_title: Working With JSON Result Data - Sentinel - Terraform Cloud
 description: Learn how to view and filter Sentinel JSON data.
 ---
 

--- a/website/docs/cloud-docs/sentinel/manage-policies.mdx
+++ b/website/docs/cloud-docs/sentinel/manage-policies.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Managing Sentinel Policies - Sentinel - Terraform Cloud and Terraform
-  Enterprise
+page_title: Managing Sentinel Policies - Sentinel - Terraform Cloud
 description: >-
   Policies are rules that are enforced on Terraform runs. Learn how to create
   and manage versioned policy sets.

--- a/website/docs/cloud-docs/sentinel/mock.mdx
+++ b/website/docs/cloud-docs/sentinel/mock.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Mocking Terraform Sentinel Data - Sentinel - Terraform Cloud and Terraform
-  Enterprise
+page_title: Mocking Terraform Sentinel Data - Sentinel - Terraform Cloud
 description: >-
   Learn how to use the UI or API to generate mock Sentinel data and how to use
   that data for testing.

--- a/website/docs/cloud-docs/sentinel/sentinel-tf-012.mdx
+++ b/website/docs/cloud-docs/sentinel/sentinel-tf-012.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Using Sentinel with Terraform 0.12 - Terraform Cloud and Terraform Enterprise
+page_title: Using Sentinel with Terraform 0.12 - Terraform Cloud
 description: Read about the changes made to Sentinel in Terraform 0.12.
 ---
 

--- a/website/docs/cloud-docs/users-teams-organizations/2fa.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/2fa.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Two-factor Authentication - Terraform Cloud and Terraform Enterprise
+page_title: Two-factor Authentication - Terraform Cloud
 description: >-
   Learn how to set up and require two-factor authentication. Also learn how to
   log in with two-factor authentication.

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: API Tokens - Terraform Cloud and Terraform Enterprise
+page_title: API Tokens - Terraform Cloud
 description: >-
   Learn about the level of access granted by user, team, and organization API
   tokens.

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Organizations - Terraform Cloud and Terraform Enterprise
+page_title: Organizations - Terraform Cloud
 description: >-
   Organizations allow teams to collaborate on workspaces. Learn about
   organization membership, organization settings, and more.

--- a/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Permissions - Terraform Cloud and Terraform Enterprise
+page_title: Permissions - Terraform Cloud
 description: >-
   Learn the difference between workspace-level and organization-level
   permissions and what permissions you can grant to users.

--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/azure-ad.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Microsoft Azure AD - Single Sign-on - Terraform Cloud and Terraform Enterprise
+page_title: Microsoft Azure AD - Single Sign-on - Terraform Cloud
 ---
 
 -> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).

--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/index.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Single Sign-on - Terraform Cloud and Terraform Enterprise
+page_title: Single Sign-on - Terraform Cloud
 description: >-
   Learn how single sign-on (SSO) works in Terraform Cloud, how to sign in with
   SSO, and more.

--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/linking-user-account.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/linking-user-account.mdx
@@ -1,7 +1,6 @@
 ---
 page_title: Single Sign-on - Linking a User Account
-description: >-
- Manage the user account linked to an SSO identity.
+description: Manage the user account linked to an SSO identity.
 ---
 
 # Linking a User Account

--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/okta.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/okta.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Okta - Single Sign-on - Terraform Cloud and Terraform Enterprise
+page_title: Okta - Single Sign-on - Terraform Cloud
 ---
 
 -> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).

--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/saml.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/saml.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: SAML - Single Sign-on - Terraform Cloud and Terraform Enterprise
+page_title: SAML - Single Sign-on - Terraform Cloud
 ---
 
 -> **Note:** Single sign-on is a paid feature, available as part of the **Business** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).

--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/testing.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/testing.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Testing - Single Sign-on - Terraform Cloud and Terraform Enterprise
+page_title: Testing - Single Sign-on - Terraform Cloud
 ---
 
 # Single Sign-on: Testing

--- a/website/docs/cloud-docs/users-teams-organizations/teams.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/teams.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Teams - Terraform Cloud and Terraform Enterprise
+page_title: Teams - Terraform Cloud
 description: >-
   Teams are a group of users within an organization. Learn about managing teams,
   team membership, team permissions, and more.

--- a/website/docs/cloud-docs/users-teams-organizations/users.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/users.mdx
@@ -1,8 +1,8 @@
 ---
-page_title: Users - Terraform Cloud and Terraform Enterprise
+page_title: Users - Terraform Cloud
 description: >-
-  Create an account, edit settings, set up two-factor
-  authentication, create API tokens, and more.
+  Create an account, edit settings, set up two-factor authentication, create API
+  tokens, and more.
 ---
 
 [organizations]: /cloud-docs/users-teams-organizations/organizations

--- a/website/docs/cloud-docs/vcs/azure-devops-server.mdx
+++ b/website/docs/cloud-docs/vcs/azure-devops-server.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Azure DevOps Server - VCS Providers - Terraform Cloud and Terraform Enterprise
+page_title: Azure DevOps Server - VCS Providers - Terraform Cloud
 ---
 
 # Configuring Azure DevOps Server Access

--- a/website/docs/cloud-docs/vcs/azure-devops-services.mdx
+++ b/website/docs/cloud-docs/vcs/azure-devops-services.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Azure DevOps Services - VCS Providers - Terraform Cloud and Terraform
-  Enterprise
+page_title: Azure DevOps Services - VCS Providers - Terraform Cloud
 ---
 
 # Configuring Azure DevOps Services Access

--- a/website/docs/cloud-docs/vcs/bitbucket-cloud.mdx
+++ b/website/docs/cloud-docs/vcs/bitbucket-cloud.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Bitbucket Cloud - VCS Providers - Terraform Cloud and Terraform Enterprise
+page_title: Bitbucket Cloud - VCS Providers - Terraform Cloud
 ---
 
 # Configuring Bitbucket Cloud Access

--- a/website/docs/cloud-docs/vcs/bitbucket-server.mdx
+++ b/website/docs/cloud-docs/vcs/bitbucket-server.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Bitbucket Server and Data Center - VCS Providers - Terraform Cloud and
-  Terraform Enterprise
+page_title: Bitbucket Server and Data Center - VCS Providers - Terraform Cloud
 ---
 
 # Configuring Bitbucket Server/Data Center Access

--- a/website/docs/cloud-docs/vcs/github-app.mdx
+++ b/website/docs/cloud-docs/vcs/github-app.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  GitHub.com (GitHub App) - VCS Providers - Terraform Cloud and Terraform
-  Enterprise
+page_title: GitHub.com (GitHub App) - VCS Providers - Terraform Cloud
 ---
 
 [private module registry]: /cloud-docs/registry

--- a/website/docs/cloud-docs/vcs/github-enterprise.mdx
+++ b/website/docs/cloud-docs/vcs/github-enterprise.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: GitHub Enterprise - VCS Providers - Terraform Cloud and Terraform Enterprise
+page_title: GitHub Enterprise - VCS Providers - Terraform Cloud
 ---
 
 # Configuring GitHub Enterprise Access

--- a/website/docs/cloud-docs/vcs/github.mdx
+++ b/website/docs/cloud-docs/vcs/github.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: GitHub.com (OAuth) - VCS Providers - Terraform Cloud and Terraform Enterprise
+page_title: GitHub.com (OAuth) - VCS Providers - Terraform Cloud
 ---
 
 # Configuring GitHub.com Access (OAuth)

--- a/website/docs/cloud-docs/vcs/gitlab-com.mdx
+++ b/website/docs/cloud-docs/vcs/gitlab-com.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: GitLab.com - VCS Providers - Terraform Cloud and Terraform Enterprise
+page_title: GitLab.com - VCS Providers - Terraform Cloud
 ---
 
 # Configuring GitLab.com Access

--- a/website/docs/cloud-docs/vcs/gitlab-eece.mdx
+++ b/website/docs/cloud-docs/vcs/gitlab-eece.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: GitLab EE and CE - VCS Providers - Terraform Cloud and Terraform Enterprise
+page_title: GitLab EE and CE - VCS Providers - Terraform Cloud
 ---
 
 # Configuring GitLab EE and CE Access

--- a/website/docs/cloud-docs/vcs/index.mdx
+++ b/website/docs/cloud-docs/vcs/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Connecting VCS Providers - Terraform Cloud and Terraform Enterprise
+page_title: Connecting VCS Providers - Terraform Cloud
 description: >-
   Learn to connect a version control system (VCS) to gain additional features
   and better workflows in Terraform Cloud.

--- a/website/docs/cloud-docs/vcs/troubleshooting.mdx
+++ b/website/docs/cloud-docs/vcs/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Troubleshooting - VCS Providers - Terraform Cloud and Terraform Enterprise
+page_title: Troubleshooting - VCS Providers - Terraform Cloud
 ---
 
 # Troubleshooting VCS Integration in Terraform Cloud

--- a/website/docs/cloud-docs/workspaces/configurations.mdx
+++ b/website/docs/cloud-docs/workspaces/configurations.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  Terraform Configurations - Workspaces - Terraform Cloud and Terraform
-  Enterprise
+page_title: Terraform Configurations - Workspaces - Terraform Cloud
 description: >-
   Workspaces organize infrastructure. Learn how to provide configuration
   versions for a workspace and organize multiple environments.

--- a/website/docs/cloud-docs/workspaces/creating.mdx
+++ b/website/docs/cloud-docs/workspaces/creating.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Creating Workspaces - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Creating Workspaces - Workspaces - Terraform Cloud
 description: >-
   Workspaces organize infrastructure into meaningful groups. Learn how to create
   and configure workspaces through the UI.

--- a/website/docs/cloud-docs/workspaces/index.mdx
+++ b/website/docs/cloud-docs/workspaces/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Workspaces - Terraform Cloud
 description: >-
   Workspaces enable Terraform Cloud to manage collections of infrastructure
   resources. Learn basics and recommended organization.

--- a/website/docs/cloud-docs/workspaces/json-filtering.mdx
+++ b/website/docs/cloud-docs/workspaces/json-filtering.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: JSON Filtering - Terraform Cloud and Terraform Enterprise
+page_title: JSON Filtering - Terraform Cloud
 description: Learn how to create custom datasets on pages that display JSON data.
 ---
 

--- a/website/docs/cloud-docs/workspaces/naming.mdx
+++ b/website/docs/cloud-docs/workspaces/naming.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Naming - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Naming - Workspaces - Terraform Cloud
 description: >-
   Workspaces organize infrastructure into meaningful groups. Learn our
   recommendations for consistent, informative names.

--- a/website/docs/cloud-docs/workspaces/settings/access.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/access.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Managing Access - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Managing Access - Workspaces - Terraform Cloud
 ---
 
 # Managing Access to Workspaces

--- a/website/docs/cloud-docs/workspaces/settings/drift-detection.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/drift-detection.mdx
@@ -1,7 +1,8 @@
 ---
-page_title: Drift Detection - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Drift Detection - Workspaces - Terraform Cloud
 description: >-
-  Enable automatic jobs to check whether your real-world infrastructure matches your Terraform state file.
+  Enable automatic jobs to check whether your real-world infrastructure matches
+  your Terraform state file.
 ---
 
 # Drift Detection

--- a/website/docs/cloud-docs/workspaces/settings/index.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Settings - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Settings - Workspaces - Terraform Cloud
 description: >-
   Workspaces organize infrastructure. Find documentation about workspace
   settings for notifications, permissions, and more.

--- a/website/docs/cloud-docs/workspaces/settings/notifications.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/notifications.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Notifications - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Notifications - Workspaces - Terraform Cloud
 ---
 
 # Notifications

--- a/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Run Tasks - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Run Tasks - Workspaces - Terraform Cloud
 ---
 
 # Run Tasks

--- a/website/docs/cloud-docs/workspaces/settings/run-triggers.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-triggers.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Run Triggers - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Run Triggers - Workspaces - Terraform Cloud
 ---
 
 # Run Triggers

--- a/website/docs/cloud-docs/workspaces/settings/ssh-keys.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/ssh-keys.mdx
@@ -1,7 +1,5 @@
 ---
-page_title: >-
-  SSH Keys for Cloning Modules - Workspaces - Terraform Cloud and Terraform
-  Enterprise
+page_title: SSH Keys for Cloning Modules - Workspaces - Terraform Cloud
 ---
 
 # Using SSH Keys for Cloning Modules

--- a/website/docs/cloud-docs/workspaces/settings/vcs.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/vcs.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: VCS Connections - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: VCS Connections - Workspaces - Terraform Cloud
 ---
 
 # Configuring Workspace VCS Connections

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Terraform State - Workspaces - Terraform Cloud and Terraform Enterprise
+page_title: Terraform State - Workspaces - Terraform Cloud
 description: >-
   Workspaces have their own separate state data. Learn how state is used and how
   to access state from other workspaces.

--- a/website/docs/cloud-docs/workspaces/variables/index.mdx
+++ b/website/docs/cloud-docs/workspaces/variables/index.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Workspace Variables - Terraform Cloud and Terraform Enterprise
+page_title: Workspace Variables - Terraform Cloud
 description: >-
   Terraform Cloud workspace variables let you customize configurations, modify
   Terraform's behavior, and store information like provider credentials.

--- a/website/docs/cloud-docs/workspaces/variables/managing-variables.mdx
+++ b/website/docs/cloud-docs/workspaces/variables/managing-variables.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Managing Variables - Terraform Cloud and Terraform Enterprise
+page_title: Managing Variables - Terraform Cloud
 description: >-
   Configure Terraform input variables and environment variables and create
   reusable variable sets that apply to multiple workspaces.


### PR DESCRIPTION
# Description

This updates all `cloud-docs` `page_title` frontmatter to be Terraform Cloud only

### The script

<details>

```ts
import * as fs from "fs";

import walk from "klaw-sync";
import matter from "gray-matter";

const MATCH = "Terraform Cloud and Terraform Enterprise";
const REPLACE = "Terraform Cloud";

function main() {
  const files = walk("./docs/cloud-docs", {
    nodir: true,
    traverseAll: true,
    filter: (item) => !item.path.includes("_template"),
  });
  for (const file of files) {
    console.log(file.path);

    const original = fs.readFileSync(file.path, "utf8");

    const { content, data } = matter(original);
    console.log("\t", data.page_title);
    data.page_title = data.page_title.replace(MATCH, REPLACE);
    const newContents = matter.stringify(content, data);

    // continue;
    fs.writeFileSync(file.path, newContents);
  }
}

main();

```

</details>