### PR TITLE
Add list gpg-keys endpoint to private registry docs

### DIFF
--- a/website/docs/cloud-docs/api-docs/private-registry/gpg-keys.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/gpg-keys.mdx
@@ -235,8 +235,7 @@ Gets the content of a GPG key.
 
 | Status  | Response                                                   | Reason                                                         |
 | ------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
-| [201][] | [JSON API document][] (`type: "gpg-keys"`)                 | Successfully uppdates a GPG key                                |
-| [422][] | [JSON API error object][]                                  | Malformed request body (missing attributes, wrong types, etc.) |
+| [200][] | [JSON API document][] (`type: "gpg-keys"`)                 | Successfully fetched GPG key                                   |
 | [403][] | [JSON API error object][]                                  | Forbidden - not available for public providers                 |
 | [404][] | [JSON API error object][]                                  | GPG key not found or user not authorized                       |
 
@@ -247,7 +246,6 @@ curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request GET \
-  --data @payload.json \
   https://app.terraform.io/api/registry/private/v2/gpg-keys/hashicorp/32966F3FB5AC1129
 ```
 
@@ -289,7 +287,7 @@ Updates the specified GPG key. Only the `namespace` attribute can be updated, an
 
 | Status  | Response                                                   | Reason                                                         |
 | ------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
-| [201][] | [JSON API document][] (`type: "gpg-keys"`)                 | Successfully uppdates a GPG key                                |
+| [201][] | [JSON API document][] (`type: "gpg-keys"`)                 | Successfully updates a GPG key                                 |
 | [422][] | [JSON API error object][]                                  | Malformed request body (missing attributes, wrong types, etc.) |
 | [403][] | [JSON API error object][]                                  | Forbidden - not available for public providers                 |
 | [404][] | [JSON API error object][]                                  | GPG key not found or user not authorized                       |

--- a/website/docs/cloud-docs/api-docs/private-registry/gpg-keys.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/gpg-keys.mdx
@@ -55,13 +55,13 @@ You need [owners team](/cloud-docs/users-teams-organizations/permissions#organiz
 
 ### Query Parameters
 
-This endpoint supports pagination [with standard URL query parameters](/cloud-docs/api-docs/#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+This endpoint supports pagination [with standard URL query parameters](/cloud-docs/api-docs/#query-parameters). Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling does not automatically encode URLs.
 
 | Parameter           | Description                                                                                                          |
 |---------------------|----------------------------------------------------------------------------------------------------------------------|
-| `filter[namespace]` | **Required.** A comma-seperated list of one or more namespaces. These must be authorized TFC/TFE organization names. |
-| `page[number]`      | **Optional.** If omitted, the endpoint will return the first page.                                                   |
-| `page[size]`        | **Optional.** If omitted, the endpoint will return 20 GPG keys per page.                                             |
+| `filter[namespace]` | **Required.** A comma-separated list of one or more namespaces. The namespaces must be authorized TFC/TFE organization names. |
+| `page[number]`      | **Optional.** If omitted, the endpoint returns the first page.                                                   |
+| `page[size]`        | **Optional.** If omitted, the endpoint returns 20 GPG keys per page.                                             |
 
 Gets a list of GPG keys belonging to the specified namespaces.
 

--- a/website/docs/cloud-docs/api-docs/private-registry/gpg-keys.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/gpg-keys.mdx
@@ -43,6 +43,103 @@ These endpoints are only relevant to private providers. When you [publish a priv
 
 You need [owners team](/cloud-docs/users-teams-organizations/permissions#organization-owners) or [Manage Private Registry](/cloud-docs/users-teams-organizations/permissions#manage-private-registry) permissions to add, update, or delete GPG keys in a private registry.
 
+## List GPG Keys
+
+`GET /api/registry/:registry_name/v2/gpg-keys`
+
+### Parameters
+
+| Parameter        | Description        |
+|------------------|--------------------|
+| `:registry_name` | Must be `private`. |
+
+### Query Parameters
+
+This endpoint supports pagination [with standard URL query parameters](/cloud-docs/api-docs/#query-parameters); remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
+| Parameter           | Description                                                                                                          |
+|---------------------|----------------------------------------------------------------------------------------------------------------------|
+| `filter[namespace]` | **Required.** A comma-seperated list of one or more namespaces. These must be authorized TFC/TFE organization names. |
+| `page[number]`      | **Optional.** If omitted, the endpoint will return the first page.                                                   |
+| `page[size]`        | **Optional.** If omitted, the endpoint will return 20 GPG keys per page.                                             |
+
+Gets a list of GPG keys belonging to the specified namespaces.
+
+| Status  | Response                                   | Reason                                                    |
+|---------|--------------------------------------------|-----------------------------------------------------------|
+| [200][] | [JSON API document][] (`type: "gpg-keys"`) | Successfully fetched GPG keys                             |
+| [400][] | [JSON API error object][]                  | Error - missing namespaces in request                     |
+| [403][] | [JSON API error object][]                  | Forbidden - no authorized namespaces specified in request |
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  "https://app.terraform.io/api/registry/private/v2/gpg-keys?filter%5Bnamespace%5D=my-organization,my-other-organization"
+```
+
+### Sample Response
+
+```json
+{
+  "data": [
+    {
+      "type": "gpg-keys",
+      "id": "1",
+      "attributes": {
+        "ascii-armor": "-----BEGIN PGP PUBLIC KEY BLOCK-----...",
+        "created-at": "2022-02-08T19:15:47Z",
+        "key-id": "C4E5E6C66C79C778",
+        "namespace": "my-other-organization",
+        "source": "",
+        "source-url": null,
+        "trust-signature": "",
+        "updated-at": "2022-02-08T19:15:47Z"
+      },
+      "links": {
+        "self": "/v2/gpg-keys/1"
+      }
+    },
+    {
+      "type": "gpg-keys",
+      "id": "140",
+      "attributes": {
+        "ascii-armor": "-----BEGIN PGP PUBLIC KEY BLOCK-----...",
+        "created-at": "2022-04-28T21:32:11Z",
+        "key-id": "C4E5E6C66C79C778",
+        "namespace": "my-organization",
+        "source": "",
+        "source-url": null,
+        "trust-signature": "",
+        "updated-at": "2022-04-28T21:32:11Z"
+      },
+      "links": {
+        "self": "/v2/gpg-keys/140"
+      }
+    }
+  ],
+  "links": {
+    "first": "/v2/gpg-keys?filter%5Bnamespace%5D=my-organization%2Cmy-other-organization&page%5Bnumber%5D=1&page%5Bsize%5D=15",
+    "last": "/v2/gpg-keys?filter%5Bnamespace%5D=my-organization%2Cmy-other-organization&page%5Bnumber%5D=1&page%5Bsize%5D=15",
+    "next": null,
+    "prev": null
+  },
+  "meta": {
+    "pagination": {
+      "page-size": 15,
+      "current-page": 1,
+      "next-page": null,
+      "prev-page": null,
+      "total-pages": 1,
+      "total-count": 2
+    }
+  }
+}
+```
+
 ## Add a GPG Key
 
 `POST /api/registry/:registry_name/v2/gpg-keys`


### PR DESCRIPTION
### What
- Added documentation for the list gpg-keys endpoint (https://app.terraform.io/api/registry/private/v2/gpg-keys?filter%5Bnamespace%5D=hashicorp). It's not a new API endpoint but it wasn't included with the original docs for private providers: https://github.com/hashicorp/terraform-website/pull/2162
- Fixed a couple of typos

### Why
If a user wants to interact with a GPG key but they don't know its id, it may be beneficial to see all the GPG keys associated with an organization. This question came up internally when assisting a customer with a support ticket.


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog (N/A) have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
