### PR TITLE
Update Docs for DevDot Migration

### DIFF
--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -41,8 +41,6 @@ description: >-
 
 Terraform Cloud provides an API for a subset of its features. If you have any questions or want to request new API features, please email <support@hashicorp.com>.
 
-See the navigation sidebar for the list of available endpoints.
-
 -> **Note:** Before planning an API integration, consider whether [the `tfe` Terraform provider](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs) meets your needs. It can't create or approve runs in response to arbitrary events, but it's a useful tool for managing your organizations, teams, and workspaces as code.
 
 HashiCorp provides a [stability policy](/cloud-docs/api-docs/stability-policy) for the Terraform Cloud API, ensuring backwards compatibility for stable endpoints. The [changelog](/cloud-docs/api-docs/changelog) tracks changes to the API for Terraform Cloud and Terraform Enterprise.

--- a/website/docs/cloud-docs/api-docs/state-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/state-versions.mdx
@@ -38,7 +38,7 @@ page_title: State Versions - API Docs - Terraform Cloud
 
 ## Create a State Version
 
-> **Hands-on:** Try the [Version Remote State with the Terraform Cloud API](https://learn.hashicorp.com/tutorials/terraform/cloud-state-api?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Version Remote State with the Terraform Cloud API](https://learn.hashicorp.com/tutorials/terraform/cloud-state-api?in=terraform/cloud) tutorial to download a remote state file and use the Terraform API to create a new state version.
 
 `POST /workspaces/:workspace_id/state-versions`
 

--- a/website/docs/cloud-docs/cost-estimation/index.mdx
+++ b/website/docs/cloud-docs/cost-estimation/index.mdx
@@ -9,7 +9,7 @@ description: >-
 
 -> **Note:** Cost estimation is a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
-> **Hands-on:** Try the [Control Costs with Policies](https://learn.hashicorp.com/tutorials/terraform/cost-estimation?in=terraform/cloud-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Control Costs with Policies](https://learn.hashicorp.com/tutorials/terraform/cost-estimation?in=terraform/cloud-get-started) tutorial to practice enabling cost estimation and define a policy to check the total monthly delta.
 
 Terraform Cloud provides cost estimates for many resources found in your Terraform configuration. For each resource an hourly and monthly cost is shown, along with the monthly delta. The total cost and delta of all estimable resources is also shown.
 

--- a/website/docs/cloud-docs/index.mdx
+++ b/website/docs/cloud-docs/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # What is Terraform Cloud?
 
-> **Hands On:** Try our [What is Terraform Cloud - Intro and Sign Up](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started) tutorial on HashiCorp Learn.
+> **Hands On:** Try our [What is Terraform Cloud - Intro and Sign Up](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started) tutorial.
 
 [Terraform Cloud](/cloud) is an application that helps teams use Terraform together. It manages Terraform runs in a consistent and reliable environment, and includes easy access to shared state and secret data, access controls for approving changes to infrastructure, a private registry for sharing Terraform modules, detailed policy controls for governing the contents of Terraform configurations, and more.
 

--- a/website/docs/cloud-docs/integrations/run-tasks/index.mdx
+++ b/website/docs/cloud-docs/integrations/run-tasks/index.mdx
@@ -83,7 +83,7 @@ $ echo -n $WEBHOOK_BODY | openssl dgst -sha512 -hmac "$HMAC_KEY"
 ```
 
 ## HCP Packer Run Task
-> **Hands On:** Try the [Set Up Terraform Cloud Run Task for HCP Packer](https://learn.hashicorp.com/tutorials/packer/setup-tfc-run-task), [Standard tier run task image validation](https://learn.hashicorp.com/tutorials/packer/run-tasks-data-source-image-validation), and [Plus tier run task image validation](https://learn.hashicorp.com/tutorials/packer/run-tasks-resource-image-validation) tutorials on HashiCorp Learn to set up and test the Terraform Cloud Run Task integration end to end.
+> **Hands On:** Try the [Set Up Terraform Cloud Run Task for HCP Packer](https://learn.hashicorp.com/tutorials/packer/setup-tfc-run-task), [Standard tier run task image validation](https://learn.hashicorp.com/tutorials/packer/run-tasks-data-source-image-validation), and [Plus tier run task image validation](https://learn.hashicorp.com/tutorials/packer/run-tasks-resource-image-validation) tutorials to set up and test the Terraform Cloud Run Task integration end to end.
 
 [Packer](https://www.packer.io/) lets you create identical machine images for multiple platforms from a single source template. The [HCP Packer registry](https://cloud.hashicorp.com/docs/packer) lets you track golden images, designate images for test and production environments, and query images to use in Packer and Terraform configurations.
 
@@ -151,7 +151,7 @@ The [Snyk](https://snyk.io/) integration for Terraform Cloud allows teams using 
 
 To get started, [create a free Snyk account](https://snyk.io/) and follow the instructions in the [Integrating Snyk with Terraform Cloud](https://docs.snyk.io/features/integrations/ci-cd-integrations/integrating-snyk-with-terraform-cloud) user documentation.
 
-> **Hands-on:** Try the [Configure Snyk Run Task in Terraform Cloud tutorial](https://learn.hashicorp.com/tutorials/terraform/cloud-run-tasks-snyk?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on HashiCorp Learn.
+> **Hands-on:** Try the [Configure Snyk Run Task in Terraform Cloud tutorial](https://learn.hashicorp.com/tutorials/terraform/cloud-run-tasks-snyk?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS).
 
 ### Sophos
 

--- a/website/docs/cloud-docs/migrate/index.mdx
+++ b/website/docs/cloud-docs/migrate/index.mdx
@@ -9,7 +9,7 @@ description: >-
 
 You can begin using Terraform Cloud to manage existing resources without de-provisioning them. This requires migrating the Terraform [state files](/language/state) for those resources to one or more Terraform Cloud workspaces. You can perform this migration with either the Terraform CLI or the Terraform Cloud API.
 
-> **Hands-on:** Try the [Migrate State to Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-migrate?in=terraform/state) tutorial on HashiCorp Learn for a walkthrough using the CLI method.
+> **Hands-on:** Try the [Migrate State to Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-migrate?in=terraform/state) tutorial to practice using the CLI method.
 
 ## Requirements
 

--- a/website/docs/cloud-docs/overview.mdx
+++ b/website/docs/cloud-docs/overview.mdx
@@ -21,7 +21,7 @@ description: >-
 
 Terraform Cloud is a platform that performs Terraform runs to provision infrastructure, either on demand or in response to various events. Unlike a general-purpose continuous integration (CI) system, it is deeply integrated with Terraform's workflows and data, which allows it to make Terraform significantly more convenient and powerful.
 
-> **Hands On:** Try our [What is Terraform Cloud - Intro and Sign Up](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started) tutorial on HashiCorp Learn.
+> **Hands On:** Try our [What is Terraform Cloud - Intro and Sign Up](https://learn.hashicorp.com/tutorials/terraform/cloud-sign-up?in=terraform/cloud-get-started) tutorial.
 
 ## Free and Paid Plans
 

--- a/website/docs/cloud-docs/recommended-practices/part3.1.mdx
+++ b/website/docs/cloud-docs/recommended-practices/part3.1.mdx
@@ -22,7 +22,7 @@ Write your first [Terraform Configuration file](https://learn.hashicorp.com/tuto
 
 ## 3. Follow the Getting Started Tutorials
 
-Follow the rest of the [Terraform: Get Started collection](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on HashiCorp Learn. These tutorials will walk you through [changing](https://learn.hashicorp.com/tutorials/terraform/aws-change?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [destroying](https://learn.hashicorp.com/tutorials/terraform/aws-destroy?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) resources, and more.
+Follow the rest of the [Terraform: Get Started tutorials](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS). These tutorials will walk you through [changing](https://learn.hashicorp.com/tutorials/terraform/aws-change?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [destroying](https://learn.hashicorp.com/tutorials/terraform/aws-destroy?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) resources, and more.
 
 ## 4. Implement a Real Infrastructure Project
 

--- a/website/docs/cloud-docs/recommended-practices/part3.1.mdx
+++ b/website/docs/cloud-docs/recommended-practices/part3.1.mdx
@@ -22,7 +22,7 @@ Write your first [Terraform Configuration file](https://learn.hashicorp.com/tuto
 
 ## 3. Follow the Getting Started Tutorials
 
-Follow the rest of the [Terraform: Get Started tutorials](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS). These tutorials will walk you through [changing](https://learn.hashicorp.com/tutorials/terraform/aws-change?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [destroying](https://learn.hashicorp.com/tutorials/terraform/aws-destroy?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) resources, and more.
+Follow the rest of the [Terraform: Get Started tutorials](https://learn.hashicorp.com/collections/terraform/aws-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS). These tutorials walk you through [changing](https://learn.hashicorp.com/tutorials/terraform/aws-change?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [destroying](https://learn.hashicorp.com/tutorials/terraform/aws-destroy?in=terraform/aws-get-started&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) resources, and more.
 
 ## 4. Implement a Real Infrastructure Project
 

--- a/website/docs/cloud-docs/registry/add.mdx
+++ b/website/docs/cloud-docs/registry/add.mdx
@@ -23,7 +23,7 @@ All members of an organization can view and use public providers and modules. Me
 
 ## Adding a Public Provider or Module
 
-> **Hands-on:** Try the [Add Public Providers and Modules to your Private Registry](https://learn.hashicorp.com/tutorials/terraform/private-registry-add) tutorial and [Share Modules in the Private Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules) tutorials on HashiCorp Learn.
+> **Hands-on:** Try the [Add Public Providers and Modules to your Private Registry](https://learn.hashicorp.com/tutorials/terraform/private-registry-add) tutorial and [Share Modules in the Private Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules) tutorials.
 
 To add a public provider or module:
 

--- a/website/docs/cloud-docs/registry/index.mdx
+++ b/website/docs/cloud-docs/registry/index.mdx
@@ -9,7 +9,7 @@ description: >-
 
 Terraform Cloud's private registry works similarly to the [public Terraform Registry](/registry) and helps you share [Terraform providers](/language/providers) and [Terraform modules](/language/modules) across your organization. It includes support for versioning and a searchable list of available providers and modules.
 
-> **Hands-on:** Try the [Add Public Providers and Modules to your Private Registry](https://learn.hashicorp.com/tutorials/terraform/private-registry-add) tutorial and [Share Modules in the Private Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules) tutorials on HashiCorp Learn.
+> **Hands-on:** Try the [Add Public Providers and Modules to your Private Registry](https://learn.hashicorp.com/tutorials/terraform/private-registry-add) tutorial and [Share Modules in the Private Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry?in=terraform/modules) tutorials.
 
 ## Public Providers and Modules
 

--- a/website/docs/cloud-docs/registry/publish-modules.mdx
+++ b/website/docs/cloud-docs/registry/publish-modules.mdx
@@ -9,7 +9,7 @@ description: >-
 
 # Publishing Private Modules to the Terraform Cloud Private Registry
 
-> **Hands-on:** Try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry-share) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Share Modules in the Private Module Registry](https://learn.hashicorp.com/tutorials/terraform/module-private-registry-share) tutorial.
 
 In addition to [adding modules from the Terraform Registry](/cloud-docs/registry/add), you can publish private modules to an organization's Terraform Cloud private registry. The registry handles downloads and controls access with Terraform Cloud API tokens, so consumers don't need access to the module's source repository, even when running Terraform from the command line.
 

--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -40,7 +40,7 @@ Use the **Submodules** menu to navigate to the detail pages for any nested modul
 
 ## Using Public Providers and Modules in Configurations
 
-> **Hands-on:** Try the [Use Modules from the Registry](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Use Modules from the Registry](https://learn.hashicorp.com/tutorials/terraform/module-use?in=terraform/modules) tutorial.
 
 The syntax for public providers in a private registry is the same as for providers that you use directly from the public Terraform Registry. The syntax for the [provider block](/language/providers/configuration#provider-configuration-1) `source` argument is `<NAMESPACE>/<PROVIDER_NAME>`.
 
@@ -111,7 +111,7 @@ A workspace can only use private providers and modules from its own organization
 
 - **Terraform Cloud:** [Add providers and modules to the registry](/cloud-docs/registry/publish#sharing-modules-across-organizations) for each organization that requires access.
 
-- **Terraform Enterprise:** Check your site's [module sharing](/enterprise/admin/application/module-sharing) configuration. Workspaces can also use private modules from organizations that are sharing modules with the workspace's organization. 
+- **Terraform Enterprise:** Check your site's [module sharing](/enterprise/admin/application/module-sharing) configuration. Workspaces can also use private modules from organizations that are sharing modules with the workspace's organization.
 
 ## Running Configurations with Private Providers and Modules
 

--- a/website/docs/cloud-docs/run/api.mdx
+++ b/website/docs/cloud-docs/run/api.mdx
@@ -138,8 +138,6 @@ chmod +x ./terraform-enterprise-push.sh
 #!/bin/bash
 
 # Complete script for API-driven runs.
-# Documentation can be found at:
-# https://www.terraform.io/docs/cloud/run/api.html
 
 # 1. Define Variables
 

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -15,7 +15,7 @@ description: >-
 
 # The CLI-driven Run Workflow
 
-> **Hands-on:** Try the [Log in to Terraform Cloud from the CLI](https://learn.hashicorp.com/tutorials/terraform/cloud-login?in=terraform/0-13) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Log in to Terraform Cloud from the CLI](https://learn.hashicorp.com/tutorials/terraform/cloud-login?in=terraform/0-13) tutorial.
 
 Terraform Cloud has three workflows for managing Terraform runs.
 
@@ -194,16 +194,16 @@ Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
 ### Non-Interactive Workflows
 
-> **Hands On:** Try the [Deploy Infrastructure with Terraform Cloud and CircleCI](https://learn.hashicorp.com/tutorials/terraform/circle-ci) tutorial on HashiCorp Learn.
+> **Hands On:** Try the [Deploy Infrastructure with Terraform Cloud and CircleCI](https://learn.hashicorp.com/tutorials/terraform/circle-ci) tutorial.
 
 External systems cannot run the traditional apply workflow because Terraform requires console input from the user to approve plans. We recommend using the [API-driven Run Workflow](/cloud-docs/run/api) for non-interactive workflows when possible.
 
 If you prefer to use the CLI in a non-interactive environment, we recommend first running a [speculative plan](/cloud-docs/run#speculative-plans) to preview the changes Terraform will make to your infrastructure. Then, use one of the following approaches with the `-auto-approve` flag based on the [execution mode](/cloud-docs/workspaces/settings#execution-mode) of your workspace. The [`-auto-approve`](/cli/commands/apply#auto-approve) flag skips prompting you to approve the plan.
 
 - **Local Execution:**  Save the approved speculative plan and then run `terraform apply -auto-approve` with the saved plan.
-- **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` immediately after approving the speculative plan to prevent the plan from becoming stale. 
+- **Remote Execution:** Terraform Cloud does not support uploading saved plans for remote execution, so we recommend running `terraform apply -auto-approve` immediately after approving the speculative plan to prevent the plan from becoming stale.
 
-  !> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize the risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline. 
+  !> **Warning:** Remote execution with non-interactive workflows requires auto-approved deployments. Minimize the risk of unpredictable infrastructure changes and configuration drift by making sure that no one can change your infrastructure outside of your automated build pipeline.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -19,7 +19,7 @@ Terraform Cloud runs support many of the same modes and options available in the
 
 ## Refresh-Only Mode
 
-> **Hands-on:** Try the [Use Refresh-Only Mode to Sync Terraform State](https://learn.hashicorp.com/tutorials/terraform/refresh) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Use Refresh-Only Mode to Sync Terraform State](https://learn.hashicorp.com/tutorials/terraform/refresh) tutorial.
 
 -> **Version note:** Refresh-only support requires a workspace using at least Terraform CLI v0.15.4.
 

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Remote Operations
 
-> **Hands-on:** Try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Get Started — Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials.
 
 Terraform Cloud provides a central interface for running Terraform within a large collaborative organization. If you're accustomed to running Terraform from your workstation, the way Terraform Cloud manages runs can be unfamiliar.
 

--- a/website/docs/cloud-docs/sentinel/enforce.mdx
+++ b/website/docs/cloud-docs/sentinel/enforce.mdx
@@ -9,7 +9,7 @@ description: >-
 
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
-> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials.
 
 You can define individual policies within larger policy sets and apply those policy sets to all or a subset of workspaces in an organization. Terraform Cloud then enforces all of those policies on every workspace run.
 

--- a/website/docs/cloud-docs/sentinel/examples.mdx
+++ b/website/docs/cloud-docs/sentinel/examples.mdx
@@ -9,7 +9,7 @@ description: >-
 
 -> **Note:** Terraform policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
-> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials.
 
 This page lists some example policies. These examples are not exhaustive, but they demonstrate some of the most common use cases of policies with Terraform Cloud. For more examples, see the [Governance section of the hashicorp/terraform-guides repository](https://github.com/hashicorp/terraform-guides/tree/master/governance/third-generation).
 

--- a/website/docs/cloud-docs/sentinel/index.mdx
+++ b/website/docs/cloud-docs/sentinel/index.mdx
@@ -9,7 +9,7 @@ description: >-
 
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
-> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials.
 
 [Sentinel](https://www.hashicorp.com/sentinel) is an embedded policy-as-code
 framework integrated with the HashiCorp Enterprise products. It enables

--- a/website/docs/cloud-docs/sentinel/manage-policies.mdx
+++ b/website/docs/cloud-docs/sentinel/manage-policies.mdx
@@ -9,7 +9,7 @@ description: >-
 
 -> **Note:** Sentinel policies are a paid feature, available as part of the **Team & Governance** upgrade package. [Learn more about Terraform Cloud pricing here](https://www.hashicorp.com/products/terraform/pricing).
 
-> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Enforce Policy with Sentinel](https://learn.hashicorp.com/collections/terraform/policy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials.
 
 Sentinel Policies are rules which are enforced on Terraform runs to validate that the plan and corresponding resources are in compliance with company policies.
 

--- a/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
@@ -11,7 +11,7 @@ description: >-
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-> **Hands-on:** Try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial.
 
 Terraform Cloud's access model is team-based. In order to perform an action within a Terraform Cloud organization, users must belong to a team that has been granted the appropriate permissions.
 

--- a/website/docs/cloud-docs/users-teams-organizations/teams.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/teams.mdx
@@ -19,7 +19,7 @@ Teams are groups of Terraform Cloud [users][] within an [organization][organizat
 
 The organization can [grant workspace permissions to teams](#managing-workspace-access) that allow its members to start Terraform runs, create workspace variables, read and write state, etc. Teams can only have permissions on workspaces within their organization, although individual users can belong to teams in other organizations.
 
-> **Hands-on:** Try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Manage Permissions in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-permissions?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial.
 
 ## API and Terraform Enterprise Provider
 
@@ -84,7 +84,7 @@ To delete a team:
 
 ### Managing Team Membership
 
-Team structure often resembles your company's organizational structure. 
+Team structure often resembles your company's organizational structure.
 
 #### Add Users
 

--- a/website/docs/cloud-docs/users-teams-organizations/users.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/users.mdx
@@ -19,7 +19,7 @@ Use the [Account API](/cloud-docs/api-docs/account) to get account details, upda
 
 ## Log In With Your HashiCorp Cloud Platform Account
 
-We recommend using a [HashiCorp Cloud Platform (HCP)](https://portal.cloud.hashicorp.com/sign-up) account to log in to Terraform Cloud. Your HCP Account grants access to every HashiCorp product, HashiCorp Learn, and the Terraform Registry. If you use your HCP Account, you will manage user settings like multi-factor authentication and password resets from within HCP instead of the Terraform Cloud UI.
+We recommend using a [HashiCorp Cloud Platform (HCP)](https://portal.cloud.hashicorp.com/sign-up) account to log in to Terraform Cloud. Your HCP Account grants access to every HashiCorp product and the Terraform Registry. If you use your HCP Account, you will manage user settings like multi-factor authentication and password resets from within HCP instead of the Terraform Cloud UI.
 
 To log in with your HCP account, go to the [Sign In to Terraform Cloud](https://app.terraform.io/) page and click **Continue with HCP account**. Terraform Cloud may ask if you want to link your account.
 

--- a/website/docs/cloud-docs/users-teams-organizations/users.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/users.mdx
@@ -19,7 +19,7 @@ Use the [Account API](/cloud-docs/api-docs/account) to get account details, upda
 
 ## Log In With Your HashiCorp Cloud Platform Account
 
-We recommend using a [HashiCorp Cloud Platform (HCP)](https://portal.cloud.hashicorp.com/sign-up) account to log in to Terraform Cloud. Your HCP Account grants access to every HashiCorp product and the Terraform Registry. If you use your HCP Account, you will manage user settings like multi-factor authentication and password resets from within HCP instead of the Terraform Cloud UI.
+We recommend using a [HashiCorp Cloud Platform (HCP)](https://portal.cloud.hashicorp.com/sign-up) account to log in to Terraform Cloud. Your HCP Account grants access to every HashiCorp product and the Terraform Registry. If you use your HCP Account, you manage user settings like multi-factor authentication and password resets from within HCP instead of the Terraform Cloud UI.
 
 To log in with your HCP account, go to the [Sign In to Terraform Cloud](https://app.terraform.io/) page and click **Continue with HCP account**. Terraform Cloud may ask if you want to link your account.
 

--- a/website/docs/cloud-docs/workspaces/creating.mdx
+++ b/website/docs/cloud-docs/workspaces/creating.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Creating Workspaces
 
-> **Hands-on:** Try the [Get Started - Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn.
+> **Hands-on:** Try the [Get Started - Terraform Cloud](https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials.
 
 Workspaces organize infrastructure into meaningful groups. Create new workspaces when you need to manage a new collection of infrastructure resources. You can use the following methods to create workspaces:
 
@@ -56,11 +56,11 @@ For CLI and API-driven workspaces, the workspace overview page appears. For vers
 
 ### Configure Terraform Variables (Version Control Only)
 
-After you create a new workspace from a version control repository, Terraform Cloud scans its configuration files for [Terraform variables](/cloud-docs/workspaces/variables#terraform-variables) and displays any that do not have a default value and are not defined in an existing global [variable set](/cloud-docs/api-docs/variable-sets). Terraform cannot perform successful runs in the workspace until you set values for these variables. 
+After you create a new workspace from a version control repository, Terraform Cloud scans its configuration files for [Terraform variables](/cloud-docs/workspaces/variables#terraform-variables) and displays any that do not have a default value and are not defined in an existing global [variable set](/cloud-docs/api-docs/variable-sets). Terraform cannot perform successful runs in the workspace until you set values for these variables.
 
 Choose one of the following actions:
 
-- To skip this step, click **Go to workspace overview**. You can [load these variables from files](/cloud-docs/workspaces/variables/managing-variables#loading-variables-from-files) or create and set values for them later from within the workspace. Terraform Cloud will not automatically scan your configuration again; you can only add variables from within the workspace individually. 
+- To skip this step, click **Go to workspace overview**. You can [load these variables from files](/cloud-docs/workspaces/variables/managing-variables#loading-variables-from-files) or create and set values for them later from within the workspace. Terraform Cloud will not automatically scan your configuration again; you can only add variables from within the workspace individually.
 - To configure variables, enter a value for each variable on the page. You may want to leave a variable empty if you know you will provide it through another source, like an `auto.tfvars` file. Click **Save variables** to add these variables to the workspace.
 
 ## After Creating a Workspace

--- a/website/docs/cloud-docs/workspaces/creating.mdx
+++ b/website/docs/cloud-docs/workspaces/creating.mdx
@@ -56,7 +56,7 @@ For CLI and API-driven workspaces, the workspace overview page appears. For vers
 
 ### Configure Terraform Variables (Version Control Only)
 
-After you create a new workspace from a version control repository, Terraform Cloud scans its configuration files for [Terraform variables](/cloud-docs/workspaces/variables#terraform-variables) and displays any that do not have a default value and are not defined in an existing global [variable set](/cloud-docs/api-docs/variable-sets). Terraform cannot perform successful runs in the workspace until you set values for these variables.
+After you create a new workspace from a version control repository, Terraform Cloud scans its configuration files for [Terraform variables](/cloud-docs/workspaces/variables#terraform-variables) and displays any that do not have a default value and do not have a definition in an existing global [variable set](/cloud-docs/api-docs/variable-sets). Terraform cannot perform successful runs in the workspace until you set values for these variables.
 
 Choose one of the following actions:
 

--- a/website/docs/cloud-docs/workspaces/creating.mdx
+++ b/website/docs/cloud-docs/workspaces/creating.mdx
@@ -60,8 +60,8 @@ After you create a new workspace from a version control repository, Terraform Cl
 
 Choose one of the following actions:
 
-- To skip this step, click **Go to workspace overview**. You can [load these variables from files](/cloud-docs/workspaces/variables/managing-variables#loading-variables-from-files) or create and set values for them later from within the workspace. Terraform Cloud will not automatically scan your configuration again; you can only add variables from within the workspace individually.
-- To configure variables, enter a value for each variable on the page. You may want to leave a variable empty if you know you will provide it through another source, like an `auto.tfvars` file. Click **Save variables** to add these variables to the workspace.
+- To skip this step, click **Go to workspace overview**. You can [load these variables from files](/cloud-docs/workspaces/variables/managing-variables#loading-variables-from-files) or create and set values for them later from within the workspace. Terraform Cloud does not automatically scan your configuration again; you can only add variables from within the workspace individually.
+- To configure variables, enter a value for each variable on the page. You may want to leave a variable empty if you plan to provide it through another source, like an `auto.tfvars` file. Click **Save variables** to add these variables to the workspace.
 
 ## After Creating a Workspace
 

--- a/website/docs/cloud-docs/workspaces/index.mdx
+++ b/website/docs/cloud-docs/workspaces/index.mdx
@@ -13,7 +13,7 @@ When run locally, Terraform manages each collection of infrastructure with a per
 
 Terraform Cloud manages infrastructure collections with _workspaces_ instead of directories. A workspace contains everything Terraform needs to manage a given collection of infrastructure, and separate workspaces function like completely separate working directories.
 
-> **Hands-on:** Try the [Create a Workspace](https://learn.hashicorp.com/tutorials/terraform/cloud-workspace-create?in=terraform/cloud-get-started) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Create a Workspace](https://learn.hashicorp.com/tutorials/terraform/cloud-workspace-create?in=terraform/cloud-get-started) tutorial.
 
 ## Workspace Contents
 

--- a/website/docs/cloud-docs/workspaces/settings/drift-detection.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/drift-detection.mdx
@@ -11,7 +11,7 @@ description: >-
 
 Infrastructure drift means that your real-world infrastructure no longer matches the configuration in your Terraform state file. Drift occurs when a user modifies resources outside of the Terraform workflow. For example, a colleague may update resource configuration directly in the cloud provider console during a production incident, changing the resource attributes from those in tracked in your state file.
 
-> **Hands On:** Try our [Manage Resource Drift](https://learn.hashicorp.com/tutorials/terraform/resource-drift) tutorial on HashiCorp Learn to review how to detect and resolve drift.
+> **Hands On:** Try our [Manage Resource Drift](https://learn.hashicorp.com/tutorials/terraform/resource-drift) tutorial to review how to detect and resolve drift.
 
 Drift detection is a workspace-level setting. When enabled, Terraform Cloud will automatically run a drift detection assessment for that workspace every 24 hours. The assessment checks the actual settings of your infrastructure against those tracked in your workspace's state file.
 

--- a/website/docs/cloud-docs/workspaces/settings/drift-detection.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/drift-detection.mdx
@@ -13,7 +13,7 @@ Infrastructure drift means that your real-world infrastructure no longer matches
 
 > **Hands On:** Try our [Manage Resource Drift](https://learn.hashicorp.com/tutorials/terraform/resource-drift) tutorial to review how to detect and resolve drift.
 
-Drift detection is a workspace-level setting. When enabled, Terraform Cloud will automatically run a drift detection assessment for that workspace every 24 hours. The assessment checks the actual settings of your infrastructure against those tracked in your workspace's state file.
+Drift detection is a workspace-level setting. When enabled, Terraform Cloud automatically runs a drift detection assessment for that workspace every 24 hours. The assessment checks the actual settings of your infrastructure against those tracked in your workspace's state file.
 
 ## Requirements
 

--- a/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
@@ -10,7 +10,7 @@ Run Tasks allow you to directly integrate third-party tools and services at cert
 
 You can manage run tasks through the UI or through the [Run Tasks APIs](/cloud-docs/api-docs/run-tasks/run-tasks).
 
-> **Hands-on:** Try the [Configure Snyk Run Task in Terraform Cloud tutorial](https://learn.hashicorp.com/tutorials/terraform/cloud-run-tasks-snyk?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) on HashiCorp Learn.
+> **Hands-on:** Try the [Configure Snyk Run Task in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-run-tasks-snyk?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial.
 
 ## Requirements
 

--- a/website/docs/cloud-docs/workspaces/settings/run-triggers.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-triggers.mdx
@@ -4,7 +4,7 @@ page_title: Run Triggers - Workspaces - Terraform Cloud
 
 # Run Triggers
 
-> **Hands-on:** Try the [Connect Workspaces with Run Triggers](https://learn.hashicorp.com/tutorials/terraform/cloud-run-triggers?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Connect Workspaces with Run Triggers](https://learn.hashicorp.com/tutorials/terraform/cloud-run-triggers?in=terraform/cloud&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial.
 
 Terraform Cloud provides a way to connect your workspace to one or more workspaces within your organization, known as "source workspaces". These connections, called run triggers, allow runs to queue automatically in your workspace on successful apply of runs in any of the source workspaces. You can connect each workspace to up to 20 source workspaces.
 

--- a/website/docs/cloud-docs/workspaces/variables/index.mdx
+++ b/website/docs/cloud-docs/workspaces/variables/index.mdx
@@ -17,7 +17,7 @@ You can set variables specifically for each workspace or you can create variable
 
 You can create both  environment variables and Terraform variables in Terraform Cloud.
 
-> **Hands-on:** Try the [Create and Use a Variable Sets](https://learn.hashicorp.com/tutorials/terraform/cloud-create-variable-set?in=terraform/cloud-get-started) and [Create Infrastructure](https://learn.hashicorp.com/tutorials/terraform/cloud-workspace-configure?in=terraform/cloud-get-started) tutorials on HashiCorp Learn to set environment and Terraform variables in Terraform Cloud.
+> **Hands-on:** Try the [Create and Use a Variable Sets](https://learn.hashicorp.com/tutorials/terraform/cloud-create-variable-set?in=terraform/cloud-get-started) and [Create Infrastructure](https://learn.hashicorp.com/tutorials/terraform/cloud-workspace-configure?in=terraform/cloud-get-started) tutorials to set environment and Terraform variables in Terraform Cloud.
 
 ### Environment Variables
 
@@ -69,7 +69,7 @@ Each environment and Terraform variable can have one of the following scopes:
 
 ## Precedence
 
-> **Hands On:** The [Manage Multiple Variable Sets in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-multiple-variable-sets) tutorial on HashiCorp Learn shows how to manage multiple variable sets and demonstrates variable precedence.
+> **Hands On:** The [Manage Multiple Variable Sets in Terraform Cloud](https://learn.hashicorp.com/tutorials/terraform/cloud-multiple-variable-sets) tutorial shows how to manage multiple variable sets and demonstrates variable precedence.
 
 There may be cases when a workspace contains conflicting variables of the same type with the same key. Terraform Cloud marks overwritten variables in the UI.
 

--- a/website/docs/cloud-docs/workspaces/variables/managing-variables.mdx
+++ b/website/docs/cloud-docs/workspaces/variables/managing-variables.mdx
@@ -84,7 +84,7 @@ You can only do this with files ending in `auto.tfvars`; Terraform Cloud does no
 
 ## Variable Sets
 
-> **Hands On:** Try the [Manage Variable Sets in Terraform Cloud tutorial](https://learn.hashicorp.com/tutorials/terraform/cloud-multiple-variable-sets) on HashiCorp Learn.
+> **Hands On:** Try the [Manage Variable Sets in Terraform Cloud tutorial](https://learn.hashicorp.com/tutorials/terraform/cloud-multiple-variable-sets) tutorial.
 
 Only members of the [Owners Team](/cloud-docs/users-teams-organizations/permissions#organization-owners) or members of a team with the [Manage Workspaces](/cloud-docs/users-teams-organizations/permissions#manage-workspaces) permission can create, update, and delete variable sets.
 

--- a/website/docs/docs/index.mdx
+++ b/website/docs/docs/index.mdx
@@ -16,7 +16,7 @@ Terraform is an infrastructure as code (IaC) tool that allows you to build, chan
 ### Get Started
 
 - Learn how Terraform [solves infrastructure challenges](/intro) and how it [compares to other tools and services](/intro/vs).
-- Install Terraform and explore use cases with the [hands-on tutorials on HashiCorp Learn](https://learn.hashicorp.com/collections/terraform/aws-get-started).
+- Install Terraform and explore use cases with the [hands-on tutorials](https://learn.hashicorp.com/terraform).
 
 ### Manage Infrastructure
 

--- a/website/docs/plugin/index.mdx
+++ b/website/docs/plugin/index.mdx
@@ -18,7 +18,7 @@ Terraform is logically split into two main parts:
 - Learn more about [how Terraform Core interacts with plugins](/plugin/how-terraform-works).
 - Learn the [design principles](/plugin/hashicorp-provider-design-principles) HashiCorp developers follow when creating providers.
 - Decide [which SDK](/plugin/which-sdk) is right for your provider.
-- Try these hands-on tutorials on HashiCorp Learn: [Call APIs with Terraform Providers (SDKv2)](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [Implement Create and Read (Framework)](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?in=terraform/providers)
+- Try these hands-on tutorials: [Call APIs with Terraform Providers (SDKv2)](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) and [Implement Create and Read (Framework)](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?in=terraform/providers)
 - Clone these template repositories on GitHub: [terraform-provider-scaffolding (SDKv2)](https://github.com/hashicorp/terraform-provider-scaffolding) and [terraform-provider-scaffolding-framework (Framework)](https://github.com/hashicorp/terraform-provider-scaffolding-framework)
 
 ## Develop and Share Providers

--- a/website/docs/registry/providers/docs.mdx
+++ b/website/docs/registry/providers/docs.mdx
@@ -48,7 +48,7 @@ Provider documentation should be a directory of Markdown documents in the provid
 | `docs/resources/`    | `<resource>.md`    | Information for a Resource. Filename should not include a `<PROVIDER NAME>_` prefix. |
 | `docs/data-sources/` | `<data_source>.md` | Information on a provider data source.                                               |
 
--> **Note:** In order to support provider docs which have already been formatted for publishing to [terraform.io][terraform-io-providers], the Terraform Registry also supports docs in a `website/docs/` legacy directory with file extensions of `.html.markdown` or `.html.md`.
+-> **Note:** In order to support provider docs which have already been formatted for publishing to [the website][terraform-io-providers], the Terraform Registry also supports docs in a `website/docs/` legacy directory with file extensions of `.html.markdown` or `.html.md`.
 
 ### Headers
 
@@ -250,11 +250,11 @@ Guides without a subcategory are always rendered before guides with subcategorie
 
 ## Migrating Legacy Providers Docs
 
-For most provider docs already published to [terraform.io][terraform-io-providers], no changes are required to publish them to the Terraform Registry.
+For most provider docs already published to [the website][terraform-io-providers], no changes are required to publish them to the Terraform Registry.
 
 ~> **Important:** The only exceptions are providers which organize resources, data sources, or guides into subcategories. See the [Subcategories](#subcategories) section above for more information.
 
-If you want to publish docs on the Terraform Registry that are not currently published to terraform.io, take the following steps to migrate to the newer format:
+If you want to publish docs on the Terraform Registry that are not currently published to the website, take the following steps to migrate to the newer format:
 
 1. Move the `website/docs/` folder to `docs/`
 1. Expand the folder names to match the Terraform Registry's expected format:

--- a/website/docs/registry/providers/docs.mdx
+++ b/website/docs/registry/providers/docs.mdx
@@ -48,7 +48,7 @@ Provider documentation should be a directory of Markdown documents in the provid
 | `docs/resources/`    | `<resource>.md`    | Information for a Resource. Filename should not include a `<PROVIDER NAME>_` prefix. |
 | `docs/data-sources/` | `<data_source>.md` | Information on a provider data source.                                               |
 
--> **Note:** In order to support provider docs which have already been formatted for publishing to [the website][terraform-io-providers], the Terraform Registry also supports docs in a `website/docs/` legacy directory with file extensions of `.html.markdown` or `.html.md`.
+-> **Note:** To support provider docs already formatted for publishing to [the website][terraform-io-providers], the Terraform Registry also supports docs in a `website/docs/` legacy directory with file extensions of `.html.markdown` or `.html.md`.
 
 ### Headers
 

--- a/website/docs/registry/providers/docs.mdx
+++ b/website/docs/registry/providers/docs.mdx
@@ -254,7 +254,7 @@ For most provider docs already published to [the website][terraform-io-providers
 
 ~> **Important:** The only exceptions are providers which organize resources, data sources, or guides into subcategories. See the [Subcategories](#subcategories) section above for more information.
 
-If you want to publish docs on the Terraform Registry that are not currently published to the website, take the following steps to migrate to the newer format:
+If you want to publish docs on the Terraform Registry that are not available on the website, take the following steps to migrate to the newer format:
 
 1. Move the `website/docs/` folder to `docs/`
 1. Expand the folder names to match the Terraform Registry's expected format:

--- a/website/docs/registry/providers/docs.mdx
+++ b/website/docs/registry/providers/docs.mdx
@@ -250,7 +250,7 @@ Guides without a subcategory are always rendered before guides with subcategorie
 
 ## Migrating Legacy Providers Docs
 
-For most provider docs already published to [the website][terraform-io-providers], no changes are required to publish them to the Terraform Registry.
+For most provider docs already published to [the website][terraform-io-providers], no changes are necessary to publish them to the Terraform Registry.
 
 ~> **Important:** The only exceptions are providers which organize resources, data sources, or guides into subcategories. See the [Subcategories](#subcategories) section above for more information.
 

--- a/website/docs/registry/providers/publishing.mdx
+++ b/website/docs/registry/providers/publishing.mdx
@@ -9,7 +9,7 @@ Anyone can publish and share a provider by signing into the Registry using their
 
 This page describes how to prepare a [Terraform provider](/language/providers) for publishing, and how to publish a prepared provider using the Registry's interface.
 
-> **Hands-on:** Try the [Release and Publish a Provider to the Terraform Registry](https://learn.hashicorp.com/tutorials/terraform/provider-release-publish?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial. In this tutorial, you will create a release for your custom Terraform provider and prepare your provider to publish to the Terraform Registry.
+> **Hands-on:** Try the [Release and Publish a Provider to the Terraform Registry](https://learn.hashicorp.com/tutorials/terraform/provider-release-publish?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial. In this tutorial, you create a release for your custom Terraform provider and prepare your provider to publish to the Terraform Registry.
 
 ## Preparing your Provider
 

--- a/website/docs/registry/providers/publishing.mdx
+++ b/website/docs/registry/providers/publishing.mdx
@@ -9,7 +9,7 @@ Anyone can publish and share a provider by signing into the Registry using their
 
 This page describes how to prepare a [Terraform provider](/language/providers) for publishing, and how to publish a prepared provider using the Registry's interface.
 
-> **Hands-on:** Try the [Release and Publish a Provider to the Terraform Registry](https://learn.hashicorp.com/tutorials/terraform/provider-release-publish?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn. In this tutorial, you will create a release for your custom Terraform provider and prepare your provider to publish to the Terraform Registry.
+> **Hands-on:** Try the [Release and Publish a Provider to the Terraform Registry](https://learn.hashicorp.com/tutorials/terraform/provider-release-publish?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial. In this tutorial, you will create a release for your custom Terraform provider and prepare your provider to publish to the Terraform Registry.
 
 ## Preparing your Provider
 
@@ -17,7 +17,7 @@ This page describes how to prepare a [Terraform provider](/language/providers) f
 
 Providers published to the Terraform Registry are written and built in the same way as other Terraform providers. A variety of resources are available to help our contributors build a quality integration:
 
-> **Hands-on:** Try the [Call APIs with Terraform Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) collection on HashiCorp Learn. In these tutorials, you will create a custom Terraform provider, complete with authentication and create/read/update/delete/import functionality.
+> **Hands-on:** Try the [Call APIs with Terraform Providers](https://learn.hashicorp.com/collections/terraform/providers?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorials to create a custom Terraform provider, complete with authentication and create/read/update/delete/import functionality.
 
 - [How to build a provider – Video](https://www.youtube.com/watch?v=2BvpqmFpchI)
 - [Sample provider developed by a HashiCorp partner](https://blog.container-solutions.com/write-terraform-provider-part-1)


### PR DESCRIPTION
### What
Docs changes to support migration to devdot. Updated with the following goals:

- Remove "Learn" and "Collection" as a term from docs
- Remove references to docs nav itself
- Remove user-facing URLs that contain the learn or docs domain ([learn.hashicorp.com](https://learn.hashicorp.com/) or [terraform.io](https://terraform.io/)/docs)

### Why
These things will create a bad user experience after the migration, as Learn and the current docs site will no longer exist.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
