### PR TITLE
add query parameters language to organizations API List Org endpoint

### DIFF
--- a/website/docs/cloud-docs/api-docs/organizations.mdx
+++ b/website/docs/cloud-docs/api-docs/organizations.mdx
@@ -55,9 +55,9 @@ Currently, this endpoint returns a full, unpaginated list of organizations (with
 
 | Parameter      | Description                                                                   |
 | -------------- | ----------------------------------------------------------------------------- |
-| `q`            | **Optional.** A search query string. Organizations are searchable by name and notification email. This takes precedence over the attribute specific searches `q[email]` or `q[name]`. |
-| `q[email]`     | **Optional.** A search query string. This will search organizations by notification email. If used with `q[name]`, it will return organizations that match both queries. |
-| `q[name]`      | **Optional.** A search query string. This will search organizations by name. If used with `q[email]`, it will return organizations that match both queries. |
+| `q`            | **Optional.** A search query string. Organizations are searchable by name and notification email. This query takes precedence over the attribute specific searches `q[email]` or `q[name]`. |
+| `q[email]`     | **Optional.** A search query string. This query searches organizations by notification email. If used with `q[name]`, it returns organizations that match both queries. |
+| `q[name]`      | **Optional.** A search query string. This query searches organizations by name. If used with `q[email]`, it returns organizations that match both queries. |
 | `page[number]` | **Optional.** Defaults to the first page, if omitted when `page[size]` is provided. |
 | `page[size]`   | **Optional.** Defaults to 20 organizations per page, if omitted when `page[number]` is provided. |
 

--- a/website/docs/cloud-docs/api-docs/organizations.mdx
+++ b/website/docs/cloud-docs/api-docs/organizations.mdx
@@ -55,6 +55,9 @@ Currently, this endpoint returns a full, unpaginated list of organizations (with
 
 | Parameter      | Description                                                                   |
 | -------------- | ----------------------------------------------------------------------------- |
+| `q`            | **Optional.** A search query string. Organizations are searchable by name and notification email. This takes precedence over the attribute specific searches `q[email]` or `q[name]`. |
+| `q[email]`     | **Optional.** A search query string. This will search organizations by notification email. If used with `q[name]`, it will return organizations that match both queries. |
+| `q[name]`      | **Optional.** A search query string. This will search organizations by name. If used with `q[email]`, it will return organizations that match both queries. |
 | `page[number]` | **Optional.** Defaults to the first page, if omitted when `page[size]` is provided. |
 | `page[size]`   | **Optional.** Defaults to 20 organizations per page, if omitted when `page[number]` is provided. |
 


### PR DESCRIPTION
### What

This PR updates the TFC [API docs](https://www.terraform.io/cloud-docs/api-docs/organizations#list-organizations) to allow the /organizations endpoint to handle query parameters on name and email. Originally, this feature was exclusive to the admin/org endpoint in [TFE](https://www.terraform.io/enterprise/api-docs/admin/organizations#list-all-organizations).

### Why

This was a feature request that was approved.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202792241783399

--
<img width="1013" alt="Screen Shot 2022-08-22 at 6 19 06 PM" src="https://user-images.githubusercontent.com/29918071/186028847-d63b21f8-415d-4b8e-98d7-e49847e9b2ef.png">
