### PR TITLE
Add pre-apply task stage information for a Run

### DIFF
--- a/website/docs/cloud-docs/api-docs/notification-configurations.mdx
+++ b/website/docs/cloud-docs/api-docs/notification-configurations.mdx
@@ -50,11 +50,11 @@ Notifications are sent as the run progresses, and can be triggered on one or mor
 | ------------------ | ----------------------- | -------------------------------------------------------------------------------------------------------- |
 | Created            | `"run:created"`         | A run is created and enters the [Pending stage](/cloud-docs/run/states#1-the-pending-stage)                                                    |
 | Planning           | `"run:planning"`        | A run acquires the lock and starts to execute.                                                      |
-| Needs Attention    | `"run:needs_attention"` | A plan has changes and Terraform requires user input to continue. This may include approving the plan or a [policy override](/cloud-docs/run/states#7-the-policy-check-stage). |
-| Applying           | `"run:applying"`        | A run enters the [Apply stage](/cloud-docs/run/states#8-the-apply-stage), where Terraform makes the infrastructure changes described in the plan.                            |
-| Completed          | `"run:completed"`       | A run has completed successfully.                                     |
-| Errored            | `"run:errored"`         | A run has terminated early due to error or cancellation.                                          |
-| Drifted            | `"assessment:drifted"`  | Terraform Cloud detected configuration drift. This option is only available if drift detection is enabled for the workspace.  Not available in Terraform Enterprise.                                                   |
+| Needs Attention    | `"run:needs_attention"` | A plan has changes and Terraform requires user input to continue. This input may include approving the plan or a [policy override](/cloud-docs/run/states#7-the-policy-check-stage). |
+| Applying           | `"run:applying"`        | A run enters the [Apply stage](/cloud-docs/run/states#9-the-apply-stage), where Terraform makes the infrastructure changes described in the plan.                            |
+| Completed          | `"run:completed"`       | A run completes successfully.                                     |
+| Errored            | `"run:errored"`         | A run terminates early due to error or cancellation.                                          |
+| Drifted            | `"assessment:drifted"`  | Terraform Cloud detected configuration drift. This option is only available if you enabled drift detection for the workspace.  Not available in Terraform Enterprise.                                                   |
 | Drift Check Failed | `"assessment:failed`"   | A drift detection assessment failed. This option is only available if you enable drift detection for the workspace.  Not available in Terraform Enterprise.                                       |
 
 ## Notification Payload

--- a/website/docs/cloud-docs/api-docs/run-tasks/run-task-stages-and-results.mdx
+++ b/website/docs/cloud-docs/api-docs/run-tasks/run-task-stages-and-results.mdx
@@ -20,9 +20,9 @@ page_title: Run Task Stages and Results - API Docs - Terraform Cloud
 
 Terraform Cloud uses run task stages and run task results to track [run task](/cloud-docs/workspaces/settings/run-tasks) execution.
 
-When Terraform Cloud creates a [run][], it reads the run tasks associated to the workspace. Each run task in the workspace is configured to begin during a specific [run stage](/cloud-docs/run/states). Terraform Cloud creates a run task stage object for each run stage that will trigger run tasks. You can configure run tasks during the [Pre-Plan Stage](/cloud-docs/run/states#3-the-pre-plan-stage) and [Post-Plan Stage](/cloud-docs/run/states#5-the-post-plan-stage).
+When Terraform Cloud creates a [run][], it reads the run tasks associated to the workspace. Each run task in the workspace is configured to begin during a specific [run stage](/cloud-docs/run/states). Terraform Cloud creates a run task stage object for each run stage that will trigger run tasks. You can configure run tasks during the [Pre-Plan Stage](/cloud-docs/run/states#3-the-pre-plan-stage), [Post-Plan Stage](/cloud-docs/run/states#5-the-post-plan-stage) and [Pre-Apply Stage](/cloud-docs/run/states#8-the-pre-apply-stage).
 
--> **Note:** Pre-plan run tasks are in beta.
+-> **Note:** Pre-plan and pre-apply run tasks are in beta.
 
 Run task stages then create a run task result for each run task. For example, a workspace has two run tasks called `alpha` and `beta`. For each run, Terraform Cloud creates one run task stage called `post-plan`. That run task stage has two run task results: one for the `alpha` run task and one for the `beta` run task.
 

--- a/website/docs/cloud-docs/api-docs/run-tasks/run-tasks.mdx
+++ b/website/docs/cloud-docs/api-docs/run-tasks/run-tasks.mdx
@@ -441,13 +441,13 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-| Key path                            | Type   | Default       | Description                                                                                           |
-|-------------------------------------|--------|---------------|-------------------------------------------------------------------------------------------------------|
-| `data.type`                         | string |               | Must be `"workspace-tasks"`.                                                                          |
-| `data.attributes.enforcement-level` | string |               | The enforcement level of the workspace task. Must be `"advisory"` or `"mandatory"`.                   |
-| `data.attributes.stage`             | string | `"post_plan"` | The stage in the run lifecycle when the run task should begin. Must be `"pre_plan"` or `"post_plan"`. |
-| `data.relationships.task.data.id`   | string |               | The ID of the run task.                                                                               |
-| `data.relationships.task.data.type` | string |               | Must be `"tasks"`.                                                                                    |
+| Key path                            | Type   | Default       | Description                                                                                                        |
+|-------------------------------------|--------|---------------|--------------------------------------------------------------------------------------------------------------------|
+| `data.type`                         | string |               | Must be `"workspace-tasks"`.                                                                                       |
+| `data.attributes.enforcement-level` | string |               | The enforcement level of the workspace task. Must be `"advisory"` or `"mandatory"`.                                |
+| `data.attributes.stage`             | string | `"post_plan"` | The stage in the run lifecycle when the run task should begin. Must be `"pre_plan"`, `"post_plan"`, or `"pre_apply"`. |
+| `data.relationships.task.data.id`   | string |               | The ID of the run task.                                                                                            |
+| `data.relationships.task.data.type` | string |               | Must be `"tasks"`.                                                                                                 |
 
 -> **Note:** The `data.attributes.stage` key is in beta
 

--- a/website/docs/cloud-docs/run/states.mdx
+++ b/website/docs/cloud-docs/run/states.mdx
@@ -136,7 +136,27 @@ _Leaving this stage:_
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-## 8. The Apply Stage
+## 8. The Pre-Apply Stage
+
+The pre-apply phase only occurs if there are enabled [run tasks](/cloud-docs/workspaces/settings/run-tasks) in the workspace that are configured to begin before Terraform creates the apply. Terraform Cloud sends information about the run to the configured external system and waits for a `passed` or `failed` response to determine whether the run can continue. The information sent to the external system includes the configuration version of the run.
+
+-> **Note:** Pre-apply run tasks are in beta.
+
+Only confirmed runs can enter this phase.
+
+_States in this stage:_
+
+- **Pre-apply running:** Terraform Cloud is waiting for a response from the configured external system(s).
+  - External systems must respond initially with a `200 OK` acknowledging the request is in progress. After that, they have 10 minutes to return a status of `passed`, `running`, or `failed`. If the timeout expires, Terraform Cloud assumes that the run tasks is in the `failed` status.
+
+_Leaving this stage:_
+
+- If any mandatory tasks failed, the run skips to completion.
+- If any advisory tasks failed, the run proceeds to the **Applying** state, with a visible warning regarding the failed task.
+- If a single run has a combination of mandatory and advisory tasks, Terraform takes the most restrictive action. For example, the run fails if there are two advisory tasks that succeed and one mandatory task that fails.
+- If a user canceled the run, the run ends in the **Canceled** state.
+
+## 9. The Apply Stage
 
 _States in this stage:_
 
@@ -148,11 +168,11 @@ After applying, the run proceeds automatically to completion.
 
 - If the apply succeeded, the run ends in the **Applied** state.
 - If the apply failed, the run ends in the **Apply Errored** state.
-- If a user canceled the apply by pressing the "Cancel Run" button, the run ends in the **Canceled** state.
+- If a user canceled the apply by pressing **Cancel Run**, the run ends in the **Canceled** state.
 
-## 9. Completion
+## 10. Completion
 
-A run is considered completed if it finishes applying, if any part of the run fails, if there's nothing to do, or if a user chooses not to continue. Once a run is completed, the next run in the queue can enter the plan stage.
+A run is complete if it finishes applying, if any part of the run fails, if there is nothing to do, or if a user chooses not to continue. Once a run completes, the next run in the queue can enter the plan stage.
 
 _States in this stage:_
 

--- a/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
@@ -62,9 +62,9 @@ To create a new run task:
 
 ## Understanding Run Tasks Within a Run
 
-Run tasks perform actions between the [plan](/cloud-docs/run/states#4-the-plan-stage) and [apply](/cloud-docs/run/states#8-the-apply-stage) stages of a [Terraform run](/cloud-docs/run). Once all run tasks have completed, the run will end based on the most restrictive enforcement level in each associated run task.
+Run tasks perform actions between the [plan](/cloud-docs/run/states#4-the-plan-stage) and [apply](/cloud-docs/run/states#9-the-apply-stage) stages of a [Terraform run](/cloud-docs/run). Once all run tasks complete, the run ends based on the most restrictive enforcement level in each associated run task.
 
-For example, if a mandatory task fails and an advisory task succeeds, the run will fail. If an advisory task fails, but a mandatory task succeeds, the run will succeed and proceed to the apply stage. Regardless of the exit status of a task, Terraform Cloud displays the status and any related message data in the UI.
+For example, if a mandatory task fails and an advisory task succeeds, the run fails. If an advisory task fails, but a mandatory task succeeds, the run succeeds and proceeds to the apply stage. Regardless of the exit status of a task, Terraform Cloud displays the status and any related message data in the UI.
 
 The following example shows a run that failed due to a mandatory run task.
 


### PR DESCRIPTION
Previously pre-apply was undocumented.  This commit adds the pre-apply stage
for the Workspace Task Associations and the run stage overview.

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
