### PR TITLE
Add Dividers into Navigation Sidebar

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1,17 +1,16 @@
 [
   { "title": "Intro to Terraform", "href": "/intro" },
+  { "divider": true },
   { "title": "Configuration Language", "href": "/language" },
-  { "title": "Terraform CLI", "href": "/cli" },
+  { "title": "CLI", "href": "/cli" },
   { "title": "Terraform Cloud", "href": "/cloud-docs" },
   { "title": "Terraform Enterprise", "href": "/enterprise" },
-  { "title": "Provider Use", "href": "/language/providers" },
-  { "title": "Plugin Development", "href": "/plugin" },
-  { "title": "Registry Publishing", "href": "/registry" },
-  {
-    "title": "Integration Program",
-    "path": "partnerships"
-  },
-  { "title": "Terraform Tools", "path": "terraform-tools" },
   { "title": "CDK for Terraform", "href": "/cdktf" },
+  { "divider": true },
+  { "title": "Use Providers", "href": "/language/providers" },
+  { "title": "Develop Plugins", "href": "/plugin" },
+  { "title": "Publish to the Registry", "href": "/registry" },
+  { "divider": true },
+  { "title": "Terraform Tools", "path": "terraform-tools" },
   { "title": "Glossary", "path": "glossary" }
 ]

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -2,7 +2,7 @@
   { "title": "Intro to Terraform", "href": "/intro" },
   { "divider": true },
   { "title": "Configuration Language", "href": "/language" },
-  { "title": "CLI", "href": "/cli" },
+  { "title": "Terraform CLI", "href": "/cli" },
   { "title": "Terraform Cloud", "href": "/cloud-docs" },
   { "title": "Terraform Enterprise", "href": "/enterprise" },
   { "title": "CDK for Terraform", "href": "/cdktf" },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -11,6 +11,10 @@
   { "title": "Develop Plugins", "href": "/plugin" },
   { "title": "Publish to the Registry", "href": "/registry" },
   { "divider": true },
+    {
+    "title": "Integration Program",
+    "path": "partnerships"
+    },
   { "title": "Terraform Tools", "path": "terraform-tools" },
   { "title": "Glossary", "path": "glossary" }
 ]

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -7,9 +7,9 @@
   { "title": "Terraform Enterprise", "href": "/enterprise" },
   { "title": "CDK for Terraform", "href": "/cdktf" },
   { "divider": true },
-  { "title": "Use Providers", "href": "/language/providers" },
-  { "title": "Develop Plugins", "href": "/plugin" },
-  { "title": "Publish to the Registry", "href": "/registry" },
+  { "title": "Provider Use", "href": "/language/providers" },
+  { "title": "Plugin Development", "href": "/plugin" },
+  { "title": "Registry Publishing", "href": "/registry" },
   { "divider": true },
     {
     "title": "Integration Program",


### PR DESCRIPTION
### What
We need to add dividers into the highest level docs sidebar for the devdot launch. This PR adds sidebar dividers to:
- Group elements into logical categories
- Differentiate product names (Terraform Cloud) from parts of the documentation that let you accomplish a specific task (Develop Plugins)

### Why
Required for devdot launch.

### Screenshots
#### Before Edits
<img width="175" alt="Screen Shot 2022-08-31 at 5 34 07 PM" src="https://user-images.githubusercontent.com/83350965/187789176-f6f0e971-796e-4fa2-9a76-2a1145149b91.png">

#### After Edits
<img width="290" alt="Screen Shot 2022-08-31 at 6 48 01 PM" src="https://user-images.githubusercontent.com/83350965/187798290-4c39040b-52cd-4d6c-9589-0a0721b311cb.png">


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
