### PR TITLE
Remove Duplicate Divider

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -476,6 +476,5 @@
   {
     "title": "Terraform Cloud Agents",
     "href": "/cloud-docs/agents"
-  },
-  { "divider": true }
+  }
 ]


### PR DESCRIPTION
### What
The Dev Portal UI is showing weird behavior where the divider between the last section in the layout file and the next section is duplicated. I believe that is because the devdot platform automatically adds dividers between sections --> no need to add them manually anymore. This PR removes the duplicate dividers from these  navigation sidebar layout files:
- Terraform Cloud

<img width="282" alt="Screen Shot 2022-08-31 at 6 15 09 PM" src="https://user-images.githubusercontent.com/83350965/187794819-8298f20a-4456-4d93-a8d0-9a5fed995ee9.png">


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
