### PR TITLE
Add TFC Only frontmatter

### DIFF
--- a/website/docs/cloud-docs/api-docs/assessment-results.mdx
+++ b/website/docs/cloud-docs/api-docs/assessment-results.mdx
@@ -1,5 +1,6 @@
 ---
 page_title: Assessments - API Docs - Terraform Cloud
+tfc_only: true
 description: >-
   Assessment results contain information about continuous validation in
   Terraform Cloud, like drift detection.


### PR DESCRIPTION
### What
Adds frontmatter to the assessment results API page so that it will be automatically excluded from the TFE versioned documentation set. This content is not yet relevant to TFE users. We can remove this metadata and include this page as soon as assessments and health checks, etc. get added to TFE.

### Why
TFE users shouldn't have to see content that's not relevant to them!

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
