### PR TITLE
Remove Community Forum from the sidebar

### DIFF
--- a/website/data/plugin-nav-data.json
+++ b/website/data/plugin-nav-data.json
@@ -22,10 +22,6 @@
     "href": "/docs/partnerships"
   },
   {
-    "title": "Community Forum",
-    "href": "https://discuss.hashicorp.com/c/terraform-providers/tf-plugin-sdk/43"
-  },
-  {
     "title": "Debugging",
     "path": "debugging"
   },


### PR DESCRIPTION
### What
The community forum in the Plugin Development section feels duplicate to the community forum link we have in the resources section, so design has asked us to delete it from the sidebar. 

This PR deletes the plugin forum from the sidebar. However, the Plugin forum actually leads to a different area of Hashicorp Discuss that's specifically relevant to plugins: https://discuss.hashicorp.com/c/terraform-providers/tf-plugin-sdk/43. It's much more relevant to users than the one we have under Resources, which leads to a general area to talk about terraform, tfc, and tfe: https://discuss.hashicorp.com/c/terraform-core/27

---------
**Notes for web development**: Is it possible to update the Community Forum under Resources to point to the Plugin specific one for these docs (for the Plugin Development Section Only?) If not, then maybe we can just find a way to elevate it on the new plugin overview page we'll create.

### Why
This section feels confusingly duplicate and it's a bit odd to link out to a separate side from this position in the docs sidebar. I think this makes sense to remove.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
