### PR TITLE
Update frontmatter for devdot

### DIFF
--- a/website/docs/plugin/index.mdx
+++ b/website/docs/plugin/index.mdx
@@ -1,6 +1,6 @@
 ---
 page_title: Home - Plugin Development
-description: Learn about developing plugins that connect Terraform to external services.
+description: Design, develop, and test plugins that connect Terraform to external services.
 ---
 
 # Plugin Development

--- a/website/docs/registry/index.mdx
+++ b/website/docs/registry/index.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: Terraform Registry Publishing
 description: >-
-  The Terraform Registry is a public repository of Terraform integrations, modules, and policies. 
+  The Terraform Registry is a public repository of Terraform providers, modules, and policies. 
 ---
 
 # Terraform Registry Publishing

--- a/website/docs/registry/index.mdx
+++ b/website/docs/registry/index.mdx
@@ -1,8 +1,7 @@
 ---
 page_title: Terraform Registry Publishing
 description: >-
-  The Terraform Registry is a repository of providers and modules written by the
-  Terraform community.
+  The Terraform Registry is a public repository of Terraform integrations, modules, and policies. 
 ---
 
 # Terraform Registry Publishing

--- a/website/docs/registry/index.mdx
+++ b/website/docs/registry/index.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: Terraform Registry Publishing
 description: >-
-  The Terraform Registry is a public repository of Terraform providers, modules, and policies. 
+  Publish Terraform providers, modules, and policies to the public Terraform Registry. 
 ---
 
 # Terraform Registry Publishing


### PR DESCRIPTION
### What
Updating the frontmatter for both the Plugin Development landing page and the Terraform Registry Publishing landing page so they are more concise and descriptive for SEO and for the devdot page banner :) 

Current banners:
<img width="754" alt="Screen Shot 2022-09-07 at 5 41 05 PM" src="https://user-images.githubusercontent.com/83350965/188987659-92d4eedf-72d1-430f-ab89-26418de01fde.png">

<img width="927" alt="Screen Shot 2022-09-07 at 5 53 51 PM" src="https://user-images.githubusercontent.com/83350965/188990398-0ef6ea5d-5335-4b7a-91ae-ff8e8b39ec11.png">


New proposed text:
"Design, develop, and test plugins that connect Terraform to external services."

"The Terraform Registry is a public repository of Terraform integrations, modules, and policies."

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
