### PR TITLE
nits for style

### DIFF
--- a/website/docs/cloud-docs/workspaces/settings/index.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/index.mdx
@@ -128,7 +128,7 @@ By default, new workspaces in Terraform Cloud do not allow other workspaces to a
 
 ~> **Note:** Health assessments are available in the [Terraform Cloud Business tier](https://www.hashicorp.com/products/terraform/pricing).
 
-When you enable health assessments, Terraform Cloud automatically runs an assessment for the workspace every 24 hours. The assessment checks the actual settings of your infrastructure against those tracked in your workspace's state file. Presently, this entails checking for resource drift (ie. drift detection).
+Health assessment describes the regular, automatic inspection of a workspace to surface resource lifecycle concerns. When you enable health assessments, Terraform Cloud automatically runs an assessment for the workspace every 24 hours. You can enable health assessments to check your workspace for infrastructure drift.
 
 Refer to [Health Assessments](/cloud-docs/workspaces/settings/health-assessments) for details.
 


### PR DESCRIPTION
### What
quick PR to fix a couple of style nits in the way we're explaining health assessments. Specifically, let's use the language from the page that helps differentiate what health assessments are related to drift detection. We also shouldn't use future-facing language (currently) or things like i.e. (we want to write out the full words when possible.

### Why
Updating copy to reflect our style guide :) 

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
