### PR TITLE
Remove reference to timeouts being unavailable in the Framework

### DIFF
--- a/website/docs/plugin/which-sdk.mdx
+++ b/website/docs/plugin/which-sdk.mdx
@@ -48,7 +48,7 @@ should consider using the framework if you would benefit from the ability to:
 ## Do You Need Any Features That the Framework Doesn't Provide (Yet)?
 
 The framework is still under development, and so it may not yet support some
-features that are available in SDKv2. If this is the case , SDKv2 may be a
+features that are available in SDKv2. If this is the case, SDKv2 may be a
 better choice.
 
 ## Can't I Just Wait Until the Framework Is Stable?

--- a/website/docs/plugin/which-sdk.mdx
+++ b/website/docs/plugin/which-sdk.mdx
@@ -48,12 +48,8 @@ should consider using the framework if you would benefit from the ability to:
 ## Do You Need Any Features That the Framework Doesn't Provide (Yet)?
 
 The framework is still under development, and so it may not yet support some
-features that are available in SDKv2. These include the ability to:
-
-* Use timeouts.
-
-These features are on our roadmap to implement and support, but if you need
-them _today_, SDKv2 may be a better choice.
+features that are available in SDKv2. If this is the case , SDKv2 may be a
+better choice.
 
 ## Can't I Just Wait Until the Framework Is Stable?
 

--- a/website/docs/plugin/which-sdk.mdx
+++ b/website/docs/plugin/which-sdk.mdx
@@ -51,7 +51,7 @@ The framework is still under development, and so it may not yet support some
 features that are available in SDKv2. In that case, SDKv2 may be a
 better choice.
 
-## Can't I Just Wait Until the Framework Is Stable?
+## Can I Just Wait Until the Framework Is Stable?
 
 The framework doesn't have as strong a compatibility guarantee as SDKv2, so you
 may be tempted to wait until the framework matures before using it to develop

--- a/website/docs/plugin/which-sdk.mdx
+++ b/website/docs/plugin/which-sdk.mdx
@@ -45,12 +45,6 @@ should consider using the framework if you would benefit from the ability to:
 * Return warning or error diagnostics during resource destruction.
 * Read or write managed resource private state data.
 
-## Do You Need Any Features That the Framework Does Not Provide (Yet)?
-
-The framework is still under development, and so it may not yet support some
-features that are available in SDKv2. In that case, SDKv2 may be a
-better choice.
-
 ## Can I Just Wait Until the Framework Is Stable?
 
 The framework doesn't have as strong a compatibility guarantee as SDKv2, so you

--- a/website/docs/plugin/which-sdk.mdx
+++ b/website/docs/plugin/which-sdk.mdx
@@ -45,10 +45,10 @@ should consider using the framework if you would benefit from the ability to:
 * Return warning or error diagnostics during resource destruction.
 * Read or write managed resource private state data.
 
-## Do You Need Any Features That the Framework Doesn't Provide (Yet)?
+## Do You Need Any Features That the Framework Does Not Provide (Yet)?
 
 The framework is still under development, and so it may not yet support some
-features that are available in SDKv2. If this is the case, SDKv2 may be a
+features that are available in SDKv2. In that case, SDKv2 may be a
 better choice.
 
 ## Can't I Just Wait Until the Framework Is Stable?


### PR DESCRIPTION
### What
Remove reference to timeouts being unavailable in the Framework
- which-sdk.mdx 

### Why
Support for timeouts is being added to the Framework
- https://github.com/hashicorp/terraform-plugin-framework/pull/487
- https://github.com/hashicorp/terraform-plugin-framework-timeouts/pull/5

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] **NA** Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] **NA** **API** documentation and the API Changelog have been updated. 
- [x] **NA** Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] **NA** Pages with related content are updated and link to this content when appropriate.
- [x] **NA** Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] **NA** New pages have metadata (page name and description) at the top.
- [x] **NA** New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] **NA** New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] **NA** UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
