### PR TITLE
Clarify Environment Variables in Remote CLI Runs

### DIFF
--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -101,7 +101,7 @@ Automatically created workspaces might not be immediately ready to use, so use T
 
 Remote runs in Terraform Cloud use:
 
-- Run-specific variables set via the command line or in your local environment. Terraform only uses the environment variables from your shell environment that are prefixed with `TF_VAR`.
+- Run-specific variables set through the command line or in your local environment. Terraform can use shell environment variables prefixed with `TF_VAR` as input variables for the run, but you must still set all required environment variables, like provider credentials, inside the workspace.
 - Workspace-specific Terraform and environment variables set in the workspace.
 - Variable sets applied to the workspace.
 - Terraform variables from any `*.auto.tfvars` files included in the configuration.

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -101,7 +101,7 @@ Automatically created workspaces might not be immediately ready to use, so use T
 
 Remote runs in Terraform Cloud use:
 
-- Run-specific variables set through the command line or in your local environment. Terraform can use shell environment variables prefixed with `TF_VAR` as input variables for the run, but you must still set all required environment variables, like provider credentials, inside the workspace.
+- Run-specific variables set through the command line or in your local environment. Terraform can use shell environment variables prefixed with `TF_VAR_` as input variables for the run, but you must still set all required environment variables, like provider credentials, inside the workspace.
 - Workspace-specific Terraform and environment variables set in the workspace.
 - Variable sets applied to the workspace.
 - Terraform variables from any `*.auto.tfvars` files included in the configuration.


### PR DESCRIPTION
### What
This page was a bit misleading about how you need to set environment variables when performing remote, cli-driven runs. This PR fixes the language to explain that Terraform can use `TF_VAR` prefixed variables in your shell environment as input variables for that run, but that you still need to actually set all required environment variables inside the actual TFC workspace.

### Why
Help users be less confused 🥳 

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
