### PR TITLE
correct speculative plans blurb

### DIFF
--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -67,7 +67,7 @@ To help you review proposed changes, Terraform Cloud can automatically run [spec
 
 You can view speculative plans in a workspace's list of normal runs. Additionally, Terraform Cloud adds a link to the run in the pull request itself, along with an indicator of the run's status.
 
-A single pull request can include links to multiple plans, depending on how many workspaces are connected to the destination branch. If a pull request is updated, Terraform Cloud will perform new speculative plans and update the links.
+A single pull request can include links to multiple plans, depending on how many workspaces connect to the destination branch. If you update a pull request, Terraform Cloud performs new speculative plans and update the links.
 
 Although any contributor to the repository can see the status indicators for pull request plans, only members of your Terraform Cloud organization with permission to read runs for the affected workspaces can click through and view the complete plan output. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions))
 

--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -65,7 +65,7 @@ To help you review proposed changes, Terraform Cloud can automatically run [spec
 
 ### Viewing Pull Request Plans
 
-Speculative plans can be viewed in a workspace's list of normal runs. Additionally, Terraform Cloud adds a link to the run in the pull request itself, along with an indicator of the run's status.
+You can view speculative plans in a workspace's list of normal runs. Additionally, Terraform Cloud adds a link to the run in the pull request itself, along with an indicator of the run's status.
 
 A single pull request can include links to multiple plans, depending on how many workspaces are connected to the destination branch. If a pull request is updated, Terraform Cloud will perform new speculative plans and update the links.
 

--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -65,7 +65,7 @@ To help you review proposed changes, Terraform Cloud can automatically run [spec
 
 ### Viewing Pull Request Plans
 
-Speculative plans don't appear in a workspace's list of normal runs. Instead, Terraform Cloud adds a link to the run in the pull request itself, along with an indicator of the run's status.
+Speculative plans can be viewed in a workspace's list of normal runs. Additionally, Terraform Cloud adds a link to the run in the pull request itself, along with an indicator of the run's status.
 
 A single pull request can include links to multiple plans, depending on how many workspaces are connected to the destination branch. If a pull request is updated, Terraform Cloud will perform new speculative plans and update the links.
 


### PR DESCRIPTION
### What
Corrected a blurb that states that speculative runs cannot be viewed in the workspace runs index
### Why
<!-- Explain why this change is necessary and how it benefits users. -->

Speculative plans can now be viewed in the workspace runs index

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
