### PR TITLE
Correct the list of workspace permissions granted

### DIFF
--- a/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
@@ -131,7 +131,6 @@ The "write" permission set is for people who do most of the day-to-day work of p
 - Download Sentinel mocks
 - Read and write variables
 - Read and write state versions
-- Manage workspace run tasks
 
 See [General Workspace Permissions][] above for details about specific permissions.
 


### PR DESCRIPTION
### What
Removes "Manage workspace run tasks" from the list of workspace permissions granted to the default Write permission set.

### Why
Only workspace Admins or custom permissions explicitly granted the Manage Workspace Run Tasks permissions have this capability.

### Links
[Jira](https://hashicorp.atlassian.net/browse/TF-1317)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
