### PR TITLE
Unified Cloud Navigation screenshot removal and style edits 2

### DIFF
--- a/website/docs/cloud-docs/cost-estimation/index.mdx
+++ b/website/docs/cloud-docs/cost-estimation/index.mdx
@@ -17,6 +17,7 @@ Terraform Cloud provides cost estimates for many resources found in your Terrafo
 
 The Team & Governance plan enables cost estimation by default. You can enable or disable the feature in your organization's settings.
 
+**SCREENSHOT FOR DELETION**
 ![enable cost estimation](/img/docs/cost-estimation-enable.png)
 
 ## Viewing a Cost Estimate
@@ -27,6 +28,7 @@ The estimate displays a total monthly cost by default; you can expand the estima
 
 Note that this is just an estimate; some resources don't have cost information available or have unpredictable usage-based pricing. Supported resources are listed in this document's sub-pages.
 
+**SCREENSHOT FOR DELETION**
 ![cost estimation run](/img/docs/cost-estimation-run.png)
 
 ## Verifying Costs in Policies

--- a/website/docs/cloud-docs/registry/add.mdx
+++ b/website/docs/cloud-docs/registry/add.mdx
@@ -27,20 +27,24 @@ All members of an organization can view and use public providers and modules. Me
 
 To add a public provider or module:
 
-1. Click **Registry** in the main navigation bar. The organization's private registry appears with a list of available providers and modules.
+1. Click **Registry**. The organization's private registry appears with a list of available providers and modules.
 
+**SCREENSHOT FOR DELETION**
    ![Terraform Cloud screenshot: The "registry" button](/img/docs/registry-button.png)
 
 1. Click **Search public registry**. The **Public Registry Search** page appears.
 
+**SCREENSHOT FOR DELETION**
    ![Terraform Cloud screenshot: the Search Public Modules page](/img/docs/add-search-public-modules-providers.png)
 
 1. Enter any combination of namespaces (e.g. hashicorp), and module or provider names into the search field. You can click **Providers** and **Modules** to toggle between lists of providers and modules that meet the search criteria.
 
 1. Do one of the following to add a provider or module to your private registry:
    - Hover over the provider or module and click **+ Add**.
+   **SCREENSHOT FOR DELETION**
      ![Terraform Cloud screenshot: the "+ Add" button](/img/docs/add-add-button.png)
    - Click the provider or module to view its details and then click **Add to Terraform Cloud**.
+   **SCREENSHOT FOR DELETION**
      ![Terraform Cloud screenshot: the "+ Add" button](/img/docs/add-add-to-terraform-cloud-button.png)
 
 1. Click **Add to organization** in the dialog box. Members of your organization can now  begin using it from the private registry.
@@ -51,9 +55,10 @@ Removing a public provider or module from a private registry does not remove it 
 
 To remove a public provider or module from an organization's private registry:
 
-1. Click **Registry** in the main navigation bar. The organization's private registry appears with a list of available providers and modules.
+1. Click **Registry**. The organization's private registry appears with a list of available providers and modules.
 
 1. Select the provider or module to view its details, open the **Manage for Organization** menu, and click **Remove from organization** (providers) or **Delete module** (modules).
+**SCREENSHOT FOR DELETION**
    ![Terraform Cloud screenshot: the delete module button](/img/docs/add-delete-module-button.png)
 
 1. Enter the provider or module name in the dialog box to confirm and then click **Remove** (providers) or **Delete** (modules). The provider or module is removed from the organization's private registry.

--- a/website/docs/cloud-docs/registry/design.mdx
+++ b/website/docs/cloud-docs/registry/design.mdx
@@ -13,12 +13,14 @@ The configuration designer lets you outline a configuration for a new workspace 
 
 ## Accessing the Configuration Designer
 
-Click the **Registry** button in the main navigation bar, and then click **<\> Design Configuration**.
+Click the **Registry** button, and then click **<\> Design Configuration**.
 
+**SCREENSHOT FOR DELETION**
 ![Terraform Cloud screenshot: the design configuration button](/img/docs/design-start.png)
 
 The **Select Modules** page appears.
 
+**SCREENSHOT FOR DELETION**
 ![Terraform Cloud screenshot: the select modules page](/img/docs/design-select-modules.png)
 
 ## Adding Modules
@@ -34,12 +36,14 @@ Selecting a module adds its most recent version to the configuration. To specify
 1. Click the module's version number from the **Selected Modules** list on the right.
 1. Select an alternate version from the menu.
 
+**SCREENSHOT FOR DELETION**
 ![Terraform Cloud screenshot: setting a module version with the drop-down](/img/docs/design-set-version.png)
 
 ## Setting Variables
 
 When you finish selecting modules, click **Next »** to go to the **Set Variables** page.
 
+**SCREENSHOT FOR DELETION**
 ![Terraform Cloud screenshot: the set variables page](/img/docs/design-variables-finished.png)
 
 The left side of this page lists your chosen modules, and the right side lists all variables for the currently selected module. Each variable is labeled as required or optional.
@@ -53,6 +57,7 @@ Once you set a value for all of a module's required variables, its **Configure**
 Variable values can be literal strings, or can interpolate other values. When you start typing an interpolation token (`${`), the designer displays a help message. As you continue typing, it searches the available outputs in your other selected modules, as well as outputs from workspaces where you are authorized to read state outputs. You can select one of these search results, or type a full name if you need to reference a value Terraform Cloud does not know about.
 \[permissions-citation]: #intentionally-unused---keep-for-maintainers
 
+**SCREENSHOT FOR DELETION**
 ![Terraform Cloud screenshot: interpolation help](/img/docs/design-variables-help.png)
 
 ### Deferring Variables
@@ -67,6 +72,7 @@ When all modules are configured, click **Next »**.
 
 The "Publish" page appears. Use the **Preview configuration** menu to review the generated code.
 
+**SCREENSHOT FOR DELETION**
 ![Terraform Cloud screenshot: configuration designer output](/img/docs/design-verify.png)
 
 The configuration designer does not create any repositories or workspaces. To create workspaces with the configuration, you must download the generated code, save it as the `main.tf` file in a new directory, and commit it to version control. After you download the code, you can make any necessary changes or additions. For example, you may want to add non-module resources.

--- a/website/docs/cloud-docs/registry/publish-modules.mdx
+++ b/website/docs/cloud-docs/registry/publish-modules.mdx
@@ -55,14 +55,16 @@ You can publish modules through the UI as shown below or with the [Registry Modu
 
 To publish a new module:
 
-1. Click **Registry** in the main navigation bar. The **Registry** page appears.
+1. Click **Registry**. The **Registry** page appears.
 
 1. Click **Publish** and select **Module**.
 
+**SCREENSHOT FOR DELETION**
    ![Terraform Cloud screenshot: the "registry" button and the "+Add Module" button](/img/docs/publish-add-button.png)
 
    The **Add Module** page appears with a list of available repositories.
 
+**SCREENSHOT FOR DELETION**
    ![Terraform Cloud screenshot: the "add module" page, with a repository name entered](/img/docs/publish-add-module.png)
 
 1. Select the repository containing the module you want to publish.
@@ -73,6 +75,7 @@ To publish a new module:
 
    Terraform Cloud displays a loading page while it imports the module versions and then takes you to the new module's details page. On the details page, you can view available versions, read documentation, and copy a usage example.
 
+**SCREENSHOT FOR DELETION**
    ![Terraform Cloud screenshot: a module details page](/img/docs/publish-module-details.png)
 
 ## Releasing New Versions of a Module
@@ -99,6 +102,7 @@ You can delete individual versions of a module or the entire module. If deleting
    - **Delete all versions for this provider for this module:** Deletes the entire module for a single provider. This is important if you have modules with the same name but with different providers. For example, if you have module repos named `terraform-aws-appserver` and `terraform-azure-appserver`, the registry treats them as alternate providers of the same `appserver` module.
    - **Delete all providers and versions for this module:** Deletes all modules with this name, even if they are from different providers. For example, both `terraform-aws-appserver` and `terraform-azure-appserver` would be deleted.
 
+**SCREENSHOT FOR DELETION**
    ![Terraform Cloud screenshot: the deletion dialog](/img/docs/publish-delete.png)
 
 1. Type the module name and click **Delete**.

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -89,7 +89,7 @@ The version is available in the Terraform Cloud UI. Consumers can begin using th
 
 Consumers cannot use a private provider version until you upload all required [release files](#release-files). To determine whether these files have been uploaded:
 
-1. Click **Registry** in the top navigation bar and click the private provider to go to its details page.
+1. Click **Registry** and click the private provider to go to its details page.
 1. Use the version menu to navigate to the version you want to check. The UI shows a warning banner for versions that do not have all required release files.
 1. Open the **Manage Provider** menu and select **Show release files**. The **Release Files** page appears containing lists of uploaded and missing files for the current version.
 
@@ -106,14 +106,15 @@ Use the Terraform Cloud API to create, read, update, and delete the following:
 
 In addition to the [Registry Providers API](/cloud-docs/api-docs/private-registry/providers#delete-a-provider), you can delete providers and provider versions through the Terraform Cloud UI. To delete providers and versions in the UI:
 
-1. Click **Registry** in the top navigation bar and click the private provider to go to its details page.
+1. Click **Registry** and click the private provider to go to its details page.
 1. If you want to delete a single version, use the **Versions** menu to select it.
 1. Open the **Manage Provider** menu and select **Delete Provider**. The **Delete Provider from Organization** box appears.
 1. Select an action from the menu:
 
     - **Delete only this provider version:** Deletes only the version of the provider you are currently viewing.
     - **Delete all versions for this provider:** Deletes the entire provider and all associated versions.
-
+    
+**SCREENSHOT FOR DELETION**
     ![Terraform Cloud screenshot: the deletion dialog](/img/docs/publish-providers-delete.png)
 
 1. Type the provider name into the confirmation box and click **Delete**.

--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -14,8 +14,9 @@ All users in an organization can view the Terraform Cloud private registry and u
 
 ## Finding Providers and Modules
 
-To find available providers and modules, click the **Registry** button in the main navigation bar. The **Registry** page appears.
+To find available providers and modules, click the **Registry** button. The **Registry** page appears.
 
+**SCREENSHOT FOR DELETION**
 ![Terraform Cloud screenshot: a filtered list of available providers](/img/docs/registry-page-filtered.png)
 
 Click **Providers** and **Modules** to toggle back and forth between lists of available providers and modules in the private registry. You can also use the search field to filter for titles that contain a specific keyword. The search does not include READMEs or resource details.
@@ -30,12 +31,14 @@ On Terraform Enterprise, your [module sharing](/enterprise/admin/application/mod
 
 Click a provider or module to view its details page. Use the **Versions** menu in the upper right to switch between the available versions, and use the **Readme**, **Inputs**, **Outputs**, **Dependencies**, and **Resources** tabs to view more information about the selected version.
 
+**SCREENSHOT FOR DELETION**
 ![Terraform Cloud screenshot: a module details page](/img/docs/publish-module-details.png)
 
 ### Viewing Nested Modules and Examples
 
 Use the **Submodules** menu to navigate to the detail pages for any nested modules. Use the **Examples** menu to navigate to the detail pages for any available example modules.
 
+**SCREENSHOT FOR DELETION**
 ![Terraform Cloud screenshot: a module submodules button](/img/docs/using-submodules-dropdown.png)
 
 ## Using Public Providers and Modules in Configurations

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -93,6 +93,7 @@ There are three ways to run speculative plans:
 
 If a speculative plan fails due to an external factor, you can run it again using the "Retry Run" button on its page:
 
+**SCREENSHOT FOR DELETION**
 ![Screenshot: Clicking on the "Retry Run" button to trigger a new run](/img/docs/retry.gif)
 
 Retrying a plan requires permission to queue plans for that workspace. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions)) Only failed or canceled plans can be retried.


### PR DESCRIPTION
### What

This PR is meant to address style and screenshot issues related to the unified cloud navigation effort on certain pages. The pages affected by this PR are:

https://www.terraform.io/cloud-docs/run/remote-operations
https://www.terraform.io/cloud-docs/registry/add
https://www.terraform.io/cloud-docs/registry/publish-providers
https://www.terraform.io/cloud-docs/registry/publish-modules
https://www.terraform.io/cloud-docs/registry/using
https://www.terraform.io/cloud-docs/registry/design
https://www.terraform.io/cloud-docs/cost-estimation

Additional PRs will be coming to address similar screenshot and other style issue on other Terraform Cloud documentation pages.

### Why

Language style issues

Removes references to variations of a "sidebar", a "navigation bar", a "top navigation bar", and other directional language such as "upper right corner". With the UI changes, removing specific references to a navigation bar and specific directional references makes the text more agnostic.

Removes unnecessary screenshots

Screenshots are a potential hazard in documentation. Maintaining them is difficult because, as the product changes, screenshots must also change, sometimes drastically or with relative frequency. The maintenance effort places a time and resource burden on both developers and technical writers that takes away from other projects. Screenshots also present potential accessibility challenges, both for disabled users and for potential future translation for non-English speaking users.

Our stance is that screenshots are typically not needed in the documentation because text should clearly, accurately, and succinctly describe processes and results a user may encounter. Our stance is similar to the guidance in the [Google Developers Style Guide](https://developers.google.com/style/images?hl=en), which technical writing uses as a supplement to HashiCorp's own guidance.

If contributors want to include a screenshot, they must provide a rationale explaining why the screenshot provides significant value for users beyond the text. We typically use screenshots when the information in the screenshot is very difficult to explain in words. Screenshots may be helpful when the UI is non-intuitive or especially complex. They may also be useful to show the results of a complex action, like pushing metadata to the UI.

The specific screenshots to be removed have been marked in the text and will be properly removed following review.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
