### PR TITLE
Add managed resources content

### DIFF
--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -49,6 +49,7 @@ On Terraform Cloud, any user can create a new organization. If you do not belong
 
 Terraform Cloud shows the new organization and prompts you to create a new workspace. You can also [invite other users](#users) to join the organization.
 
+<!-- BEGIN: TFC:only name:managed-resources -->
 ## Managed Resources
 
 -> **Note:** A managed resources count for each organization is available in the [Terraform Cloud Business tier](https://cloud.hashicorp.com/products/terraform/pricing).
@@ -58,6 +59,8 @@ Your organization’s managed resource count helps you understand the number of 
 Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource created with the `count` or `for_each` meta-arguments. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
 
 You can view your organization's managed resource count on the **Usage** page.
+
+<!-- END: TFC:only name:managed-resources -->
 
 ## Managing Settings
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -55,7 +55,7 @@ Terraform Cloud shows the new organization and prompts you to create a new works
 
 Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
 
-Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource instance created with the `count` or `for_each` meta-arguments. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource created with the `count` or `for_each` meta-arguments. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
 
 You can view your organization's managed resource count on the **Usage** page.
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -55,9 +55,7 @@ Terraform Cloud shows the new organization and prompts you to create a new works
 
 Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
 
-Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource instance created with the `count` or `for_each` meta-arguments. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
-
-Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource instance created with the `count` or `for_each` meta-arguments. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
 
 You can view your organization's managed resource count on the **Usage** page.
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -55,7 +55,7 @@ Terraform Cloud shows the new organization and prompts you to create a new works
 
 Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
 
-Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each instance of resources created with the `count` or `for_each` meta-arguments. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource instance created with the `count` or `for_each` meta-arguments. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
 
 Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -55,7 +55,7 @@ Terraform Cloud shows the new organization and prompts you to create a new works
 
 Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
 
-Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource.  Terraform Cloud includes resources in modules and each instance of resources created with the `count` or `for_each` meta-arguments. For example, `"aws_instance" "servers" { count = 10 }` creates ten separate managed resources in state. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each instance of resources created with the `count` or `for_each` meta-arguments. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
 
 Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -55,7 +55,9 @@ Terraform Cloud shows the new organization and prompts you to create a new works
 
 Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
 
-Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud does not include [data sources](/language/data-sources) in the count. Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource.  Terraform Cloud includes resources in modules and each instance of resources created with the `count` or `for_each` meta-arguments. For example, `"aws_instance" "servers" { count = 10 }` creates ten separate managed resources in state. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
+
+Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
 
 You can view your organization's managed resource count on the **Usage** page.
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -49,6 +49,16 @@ On Terraform Cloud, any user can create a new organization. If you do not belong
 
 Terraform Cloud shows the new organization and prompts you to create a new workspace. You can also [invite other users](#users) to join the organization.
 
+## Managed Resources
+
+-> **Note:** A managed resources count for each organization is available in the [Terraform Cloud Business tier](https://cloud.hashicorp.com/products/terraform/pricing).
+
+Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
+
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud does not include [data sources](/language/data-sources) in the count. Refer to [Managed Resources Count](/terraform/cloud-docs/workspaces/state#managed-resources-count) in the workspace state documentation for more details.
+
+You can view your organization's managed resource count on the **Usage** page.
+
 ## Managing Settings
 
 To view and manage an organization's settings, click **Settings**.

--- a/website/docs/cloud-docs/workspaces/index.mdx
+++ b/website/docs/cloud-docs/workspaces/index.mdx
@@ -32,6 +32,8 @@ In addition to the basic Terraform content, Terraform Cloud keeps some additiona
 
 - **Run history:** When Terraform Cloud manages a workspace's Terraform runs, it retains a record of all run activity, including summaries, logs, a reference to the changes that caused the run, and user comments. Refer to [Viewing and Managing Runs](/cloud-docs/run/manage) for more details.
 
+The top of each workspace shows a resource count, which reflects the number of resources recorded in the workspace’s state file. This includes both managed [resources](/language/resources/syntax) and [data sources](/language/data-sources.
+
 ## Terraform Runs
 
 For workspaces with remote operations enabled (the default), Terraform Cloud performs Terraform runs on its own disposable virtual machines, using that workspace's configuration, variables, and state.

--- a/website/docs/cloud-docs/workspaces/index.mdx
+++ b/website/docs/cloud-docs/workspaces/index.mdx
@@ -32,7 +32,9 @@ In addition to the basic Terraform content, Terraform Cloud keeps some additiona
 
 - **Run history:** When Terraform Cloud manages a workspace's Terraform runs, it retains a record of all run activity, including summaries, logs, a reference to the changes that caused the run, and user comments. Refer to [Viewing and Managing Runs](/cloud-docs/run/manage) for more details.
 
+<!-- BEGIN: TFC:only name:managed-resources -->
 The top of each workspace shows a resource count, which reflects the number of resources recorded in the workspace’s state file. This includes both managed [resources](/language/resources/syntax) and [data sources](/language/data-sources.
+<!-- END: TFC:only name:managed-resources -->
 
 ## Terraform Runs
 

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -37,7 +37,7 @@ Terraform Cloud reads all the workspaces’ state files to determine the total n
 
 The following Terraform state excerpt describes a  `random` resource. Terraform Cloud counts  `random` as one managed resource because `“mode”: “managed”`.
 ```json
-“resources” : [
+"resources": [
 {
       "mode": "managed",
       "type": "random_pet",

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -36,6 +36,7 @@ Terraform Cloud reads all the workspaces’ state files to determine the total n
 ### Examples - Managed Resources
 
 The following Terraform state excerpt describes a  `random` resource. Terraform Cloud counts  `random` as one managed resource because `“mode”: “managed”`.
+
 ```json
 "resources": [
 {

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -127,7 +127,6 @@ The following example shows a Terraform state excerpt with 2 instances of a `aws
         }
       ]
     }
-##...
 ```
 
 ### Example - Excluded Data Source

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -126,7 +126,7 @@ The following example shows a Terraform state excerpt with 2 instances of a `aws
         }
       ]
     }
-…
+#...
 ```
 
 ### Example - Excluded Data Source

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -126,7 +126,7 @@ The following example shows a Terraform state excerpt with 2 instances of a `aws
         }
       ]
     }
-#...
+##...
 ```
 
 ### Example - Excluded Data Source

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -31,7 +31,7 @@ You can view a workspace's state versions from its **States** tab. Each state in
 
 Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
 
-Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource instance created with the `count` or `for_each` meta-arguments. For example, `"aws_instance" "servers" { count = 10 }` creates ten separate managed resources in state. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource instance created with the `count` or `for_each` meta-arguments. For example, `"aws_instance" "servers" { count = 10 }` creates ten separate managed resources in state. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
 
 ### Examples - Managed Resources
 

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -125,8 +125,8 @@ The following example shows a Terraform state excerpt with 2 instances of a `aws
             "module.vpc.aws_vpc_ipv4_cidr_block_association.this"
           ]
         }
-      ]
-    }
+     ]
+}
 ```
 
 ### Example - Excluded Data Source

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -125,7 +125,7 @@ The following example shows a Terraform state excerpt with 2 instances of a `aws
             "module.vpc.aws_vpc_ipv4_cidr_block_association.this"
           ]
         }
-     ]
+      ]
 }
 ```
 

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -31,7 +31,7 @@ You can view a workspace's state versions from its **States** tab. Each state in
 
 Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
 
-Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count.
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource.  Terraform Cloud includes resources in modules and each instance of resources created with the `count` or `for_each` meta-arguments. For example, `"aws_instance" "servers" { count = 10 }` creates ten separate managed resources in state. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
 
 ### Examples - Managed Resources
 

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -25,6 +25,7 @@ In addition to the current state, Terraform Cloud retains historical state versi
 
 You can view a workspace's state versions from its **States** tab. Each state in the list indicates which run and which VCS commit (if applicable) it was associated with. Click a state in the list for more details, including a diff against the previous state and a link to the raw state file.
 
+<!-- BEGIN: TFC:only name:managed-resources -->
 ## Managed Resources Count
 
 -> **Note:** A managed resources count for each organization is available in the [Terraform Cloud Business tier](https://cloud.hashicorp.com/products/terraform/pricing).
@@ -170,6 +171,7 @@ The following Terraform state excerpt describes a `aws_availability_zones` data 
      }
    ]
 ```
+<!-- END: TFC:only name:managed-resources -->
 
 ## State Manipulation
 

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -25,6 +25,152 @@ In addition to the current state, Terraform Cloud retains historical state versi
 
 You can view a workspace's state versions from its **States** tab. Each state in the list indicates which run and which VCS commit (if applicable) it was associated with. Click a state in the list for more details, including a diff against the previous state and a link to the raw state file.
 
+## Managed Resources Count
+
+-> **Note:** A managed resources count for each organization is available in the [Terraform Cloud Business tier](https://cloud.hashicorp.com/products/terraform/pricing).
+
+Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
+
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count.
+
+### Examples - Managed Resources
+
+The following Terraform state excerpt describes a  `random` resource. Terraform Cloud counts  `random` as one managed resource because `“mode”: “managed”`.
+```json
+“resources” : [
+{
+      "mode": "managed",
+      "type": "random_pet",
+      "name": "random",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "puma",
+            "keepers": null,
+            "length": 1,
+            "prefix": null,
+            "separator": "-"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    }
+]
+```
+
+A single resource configuration block can describe multiple resource instances with the [`count`](language/meta-arguments/count) or [`for_each`](/language/meta-arguments/for_each) meta-arguments. Each of these instances counts as a managed resource.
+
+The following example shows a Terraform state excerpt with 2 instances of a `aws_subnet` resource. Terraform Cloud counts each instance of `aws_subnet` as a separate managed resource.
+
+```json
+{
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:561656980159:subnet/subnet-024b05c4fba9c9733",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "us-east-2a",
+            ##...
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "-public-us-east-2a"
+            },
+            "tags_all": {
+              "Name": "-public-us-east-2a"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0f693f9721b61333b"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "data.aws_availability_zones.available",
+            "module.vpc.aws_vpc.this",
+            "module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:us-east-2:561656980159:subnet/subnet-08924f16617e087b2",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "us-east-2b",
+            ##...
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "tags": {
+              "Name": "-public-us-east-2b"
+            },
+            "tags_all": {
+              "Name": "-public-us-east-2b"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-0f693f9721b61333b"
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "data.aws_availability_zones.available",
+            "module.vpc.aws_vpc.this",
+            "module.vpc.aws_vpc_ipv4_cidr_block_association.this"
+          ]
+        }
+      ]
+    }
+…
+```
+
+### Example - Excluded Data Source
+
+The following Terraform state excerpt describes a `aws_availability_zones` data source. Terraform Cloud does not include `aws_availability_zones` in the managed resource count because `”mode”: “data”`.
+
+```json
+ "resources": [
+    {
+      "mode": "data",
+      "type": "aws_availability_zones",
+      "name": "available",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "all_availability_zones": null,
+            "exclude_names": null,
+            "exclude_zone_ids": null,
+            "filter": null,
+            "group_names": [
+              "us-east-2"
+            ],
+            "id": "us-east-2",
+            "names": [
+              "us-east-2a",
+              "us-east-2b",
+              "us-east-2c"
+            ],
+            "state": null,
+            "zone_ids": [
+              "use2-az1",
+              "use2-az2",
+              "use2-az3"
+            ]
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    }
+]
+```
+
 ## State Manipulation
 
 Certain tasks (including importing resources, tainting resources, moving or renaming existing resources to match a changed configuration, and more) require modifying Terraform state outside the context of a run.

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -167,8 +167,8 @@ The following Terraform state excerpt describes a `aws_availability_zones` data 
           "sensitive_attributes": []
         }
       ]
-    }
-]
+     }
+   ]
 ```
 
 ## State Manipulation

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -31,7 +31,7 @@ You can view a workspace's state versions from its **States** tab. Each state in
 
 Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
 
-Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource.  Terraform Cloud includes resources in modules and each instance of resources created with the `count` or `for_each` meta-arguments. For example, `"aws_instance" "servers" { count = 10 }` creates ten separate managed resources in state. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) instance in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource instance created with the `count` or `for_each` meta-arguments. For example, `"aws_instance" "servers" { count = 10 }` creates ten separate managed resources in state. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
 
 ### Examples - Managed Resources
 


### PR DESCRIPTION
### What

Terraform Cloud calculates managed resources by analyzing the Terraform state file in each of an organization’s workspaces. All resources are counted toward the total (data sources are not included). 

Soon, we’ll be releasing a UI change to show users the number of RUM in their organization. As part of that UI element, we want to link to documentation providing more details about RUM and how they are calculated. 

### Why
Make sure users aren't confused when they see the managed resources count in their Usage page.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
