### PR TITLE
Fix Link to Policy Docs

### DIFF
--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -5,8 +5,6 @@ description: >-
   configuration for remote CLI runs.
 ---
 
-[sentinel]: /cloud-docs/policy-enforcement
-
 [private]: /cloud-docs/registry
 
 [speculative plan]: /cloud-docs/run/remote-operations#speculative-plans
@@ -27,7 +25,7 @@ Terraform Cloud has three workflows for managing Terraform runs.
 
 The [CLI integration](/cli/cloud) brings Terraform Cloud's collaboration features into the familiar Terraform CLI workflow. It offers the best of both worlds to developers who are already comfortable with using the Terraform CLI, and it can work with existing CI/CD pipelines.
 
-You can start runs with the standard `terraform plan` and `terraform apply` commands and then watch the progress of the run from your terminal. These runs execute remotely in Terraform Cloud; they use variables from the appropriate workspace, enforce any applicable [Sentinel policies][sentinel], and can access Terraform Cloud's [private registry][private] and remote state inputs.
+You can start runs with the standard `terraform plan` and `terraform apply` commands and then watch the progress of the run from your terminal. These runs execute remotely in Terraform Cloud; they use variables from the appropriate workspace, enforce any applicable [Sentinel or OPA policies][/cloud-docs/policy-enforcement], and can access Terraform Cloud's [private registry][private] and remote state inputs.
 
 Terraform Cloud offers two kinds of CLI-driven runs, to support different stages of your workflow:
 

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -206,16 +206,17 @@ If you prefer to use the CLI in a non-interactive environment, we recommend firs
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 
-## Sentinel Policies
+## Policy Enforcement
 
-If the specified workspace uses Sentinel policies, those policies will run against all speculative plans and remote applies in that workspace. Policy output is shown in the terminal.
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
 
-Failed policies can pause or prevent an apply, depending on the enforcement level:
+Policies are rules that Terraform Cloud enforces on Terraform runs. You can use two policy-as-code frameworks to define fine-grained, logic-based policies: Sentinel and Open Policy Agent (OPA). 
 
-- Hard mandatory checks cannot be overridden and they prevent `terraform apply` from applying changes.
-- Soft mandatory checks can be overridden by users with permission to [manage policy overrides](/cloud-docs/users-teams-organizations/permissions#manage-policy-overrides). If your account can override a failed check, Terraform will prompt you to type "override" to confirm. (Note that typing "yes" will not work.) If you override the check, you will be prompted to apply the run (unless auto-apply is enabled).
+If the specified workspace uses policies, Terraform Cloud runs those policies against all speculative plans and remote applies in that workspace. Failed policies can pause or prevent an apply, depending on the enforcement level. Refer to [Policy Enforcement](/cloud-docs/policy-enforcement) for details.
 
-[permissions-citation]: #intentionally-unused---keep-for-maintainers
+For Sentinel, the Terraform CLI prints policy results for CLI-driven runs. CLI support for policy results is not available for OPA.
+
+The following example shows Sentinel policy output in the terminal.  
 
 ```
 $ terraform apply

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -25,7 +25,7 @@ Terraform Cloud has three workflows for managing Terraform runs.
 
 The [CLI integration](/cli/cloud) brings Terraform Cloud's collaboration features into the familiar Terraform CLI workflow. It offers the best of both worlds to developers who are already comfortable with using the Terraform CLI, and it can work with existing CI/CD pipelines.
 
-You can start runs with the standard `terraform plan` and `terraform apply` commands and then watch the progress of the run from your terminal. These runs execute remotely in Terraform Cloud; they use variables from the appropriate workspace, enforce any applicable [Sentinel or OPA policies][/cloud-docs/policy-enforcement], and can access Terraform Cloud's [private registry][private] and remote state inputs.
+You can start runs with the standard `terraform plan` and `terraform apply` commands and then watch the progress of the run from your terminal. These runs execute remotely in Terraform Cloud, use variables from the appropriate workspace, enforce any applicable [Sentinel or OPA policies][/cloud-docs/policy-enforcement], and can access Terraform Cloud's [private registry][private] and remote state inputs.
 
 Terraform Cloud offers two kinds of CLI-driven runs, to support different stages of your workflow:
 


### PR DESCRIPTION
### What
After we redid the policy updates, some old pages still have direct links to the sentinel content. When I initially redirected, I redirected to the new policy enforcement overview page, which talks about the entire policy enforcement workflow and mentions both sentinel and OPA policies.

I actually think this is a reasonable redirect, because 1) The old /sentinel page was an overview of policy enforcement (similar to the new page) it's just that policy enforcement used to be sentinel-only and 2) I want to start helping folks understand there are both types of policies available.

Regardless, This PR:
- Updates the link text on this page to include mention of OPA .
- Removes the [sentinel] link at the top and replacing it with a direct link in the text because I think it's much easier to evaluate things like this in the future when you think about each link in context, rather than just redirecting it at the top of the page like that.
- Reworks the Policies section of this page to include OPA and be less Sentinel-centric. 

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
