### PR TITLE
PATCH state-versions revert API docs

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -7,13 +7,17 @@ page_id: api-changelog
 
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
+## 2023-01-12
+
+* Added new rollback to previous state endpoint to [State Versions API](/cloud-docs/api-docs/state-versions)
+
 ## 2022-12-22
 
 * Updated [Safe Delete a workspace](/cloud-docs/api-docs/workspaces#safe-delete-a-workspace) to fix HTTP verb as `POST`.
 
 ## 2022-11-18
 
-* Update [Policies API](/cloud-docs/api-docs/policies) to fix policy enforcement level defaults. Enforcement level is a required field, so no defaults are available. 
+* Update [Policies API](/cloud-docs/api-docs/policies) to fix policy enforcement level defaults. Enforcement level is a required field, so no defaults are available.
 
 ## 2022-11-03
 

--- a/website/docs/cloud-docs/api-docs/state-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/state-versions.mdx
@@ -99,7 +99,7 @@ Properties without a default value are required.
 | `data.attributes.md5`                | string  |           | An MD5 hash of the raw state version                                                                                                                                                                                                                                                       |
 | `data.attributes.state`              | string  |           | Base64 encoded raw state file                                                                                                                                                                                                                                                              |
 | `data.attributes.lineage`            | string  | (nothing) | **Optional** Lineage of the state version. Should match the lineage extracted from the raw state file. Early versions of terraform did not have the concept of lineage, so this is an optional attribute.                                                                                  |
-| `data.attributes.json-state`         | string  | (nothing) | **Optional** Base64 encoded json state, as expressed by `terraform show -json`. See [JSON Output Format](/internals/json-format) for more details                                                                                                                  |
+| `data.attributes.json-state`         | string  | (nothing) | **Optional** Base64 encoded json state, as expressed by `terraform show -json`. See [JSON Output Format](/internals/json-format) for more details                                                                                                                                          |
 | `data.attributes.json-state-outputs` | string  | (nothing) | **Optional** Base64 encoded output values as represented by `terraform show -json` (the contents of the values/outputs key). If provided, the workspace outputs populate immediately. If omitted, Terraform Cloud populates the workspace outputs from the given state after a short time. |
 | `data.relationships.run.data.id`     | string  | (nothing) | **Optional** The ID of the run to associate with the state version.                                                                                                                                                                                                                        |
 
@@ -621,6 +621,133 @@ curl \
         },
         "links": {
             "self": "/api/v2/state-versions/sv-g4rqST72reoHMM5a"
+        }
+    }
+}
+```
+
+## Rollback to a Previous State Version
+
+`PATCH /workspaces/:workspace_id/state-versions`
+
+| Parameter       | Description                                                                                                                                                                                                       |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `:workspace_id` | The workspace ID to create the new state version in. Obtain this from the [workspace settings](/cloud-docs/workspaces/settings) or the [Show Workspace](/cloud-docs/api-docs/workspaces#show-workspace) endpoint. |
+
+Creates a state version by duplicating the specified state version and sets it as the current state version for the given workspace. The workspace must be locked by the user creating a state version. The workspace may be locked [with the API](/cloud-docs/api-docs/workspaces#lock-a-workspace) or [with the UI](/cloud-docs/workspaces/settings#locking). This is most useful for rolling back to a known-good state after an operation such as a Terraform upgrade didn't go as planned.
+
+Creating state versions requires permission to read and write state versions for the workspace. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions))
+
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
+
+!> **Warning:** Use caution when rolling back to a previous state. Replacing state improperly can result in orphaned or duplicated infrastructure resources.
+
+-> **Note:** You cannot access this endpoint with [organization tokens](/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens). You must access it with a [user token](/cloud-docs/users-teams-organizations/users#api-tokens) or [team token](/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens).
+
+| Status  | Response                  | Reason                                                          |
+|---------|---------------------------|-----------------------------------------------------------------|
+| [201][] | [JSON API document][]     | Successfully rolled back.                                       |
+| [404][] | [JSON API error object][] | Workspace not found, or user unauthorized to perform action.    |
+| [409][] | [JSON API error object][] | Conflict; check the error object for more information.          |
+| [422][] | [JSON API error object][] | Malformed request body (missing attributes, wrong types, etc.). |
+
+### Request Body
+
+This PATCH endpoint requires a JSON object with the following properties as a request payload.
+
+Properties without a default value are required.
+
+| Key path                                            | Type   | Default | Description                                                    |
+|-----------------------------------------------------|--------|---------|----------------------------------------------------------------|
+| `data.type`                                         | string |         | Must be `"state-versions"`.                                    |
+| `data.relationships.rollback-state-version.data.id` | string |         | The ID of the state version to use for the rollback operation. |
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "type":"state-versions",
+    "relationships": {
+      "rollback-state-version": {
+        "data": {
+          "type": "state-versions",
+          "id": "sv-bWfq4Y1YpRKW4mx7"
+        }
+      }
+    }
+  }
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request PATCH \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/workspaces/ws-6fHMCom98SDXSQUv/state-versions
+```
+
+### Sample Response
+
+```json
+{
+    "data": {
+        "id": "sv-DmoXecHePnNznaA4",
+        "type": "state-versions",
+        "attributes": {
+            "created-at": "2022-11-22T01:22:03.794Z",
+            "size": 940,
+            "hosted-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "modules": {
+                "root": {
+                    "null-resource": 1,
+                    "data.terraform-remote-state": 1
+                }
+            },
+            "providers": {
+                "provider[\"terraform.io/builtin/terraform\"]": {
+                    "data.terraform-remote-state": 1
+                },
+                "provider[\"registry.terraform.io/hashicorp/null\"]": {
+                    "null-resource": 1
+                }
+            },
+            "resources": [
+                {
+                    "name": "other_username",
+                    "type": "data.terraform_remote_state",
+                    "count": 1,
+                    "module": "root",
+                    "provider": "provider[\"terraform.io/builtin/terraform\"]"
+                },
+                {
+                    "name": "random",
+                    "type": "null_resource",
+                    "count": 1,
+                    "module": "root",
+                    "provider": "provider[\"registry.terraform.io/hashicorp/null\"]"
+                }
+            ],
+            "resources-processed": false,
+            "serial": 9,
+            "state-version": 4,
+            "terraform-version": "1.3.5"
+        },
+        "relationships": {
+            "rollback-state-version": {
+                "data": {
+                    "id": "sv-YfmFLgTv31VZsP",
+                    "type": "state-versions"
+                }
+            }
+        },
+        "links": {
+            "self": "/api/v2/state-versions/sv-DmoXecHePnNznaA4"
         }
     }
 }


### PR DESCRIPTION
### What
New API endpoint docs.

### Screenshots
![Screenshot 2022-11-22 at 12-15-37 State Versions - API Docs - Terraform Cloud Terraform HashiCorp Developer](https://user-images.githubusercontent.com/174332/203402194-caf17f3f-899d-42c1-bc26-6fe8a40a7eeb.png)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] ~Description links to related pull requests or issues, if any.~ N/A

#### Content
- [x] ~Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.~ N/A
- [x] API documentation and the API Changelog have been updated.
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] ~New pages have metadata (page name and description) at the top.~ N/A
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.~ N/A
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] ~UI elements (button names, page names, etc.) are bolded.~ N/A
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
