### PR TITLE
Add 'Reverting to a Previous State' to Workspace / State Manipulation docs

### DIFF
--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -29,7 +29,13 @@ You can view a workspace's state versions from its **States** tab. Each state in
 
 Certain tasks (including importing resources, tainting resources, moving or renaming existing resources to match a changed configuration, and more) require modifying Terraform state outside the context of a run.
 
-Manual state manipulation in Terraform Cloud workspaces requires the use of Terraform CLI, using the same commands as would be used in a local workflow (`terraform import`, `terraform taint`, etc.). To manipulate state, you must configure the [CLI integration](/cli/cloud) and authenticate with a user token that has permission to read and write state versions for the relevant workspace. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions))
+Manual state manipulation in Terraform Cloud workspaces, with the exception of [rolling back to a previous state version](#rolling-back-to-a-previous-state), requires the use of Terraform CLI, using the same commands as would be used in a local workflow (`terraform import`, `terraform taint`, etc.). To manipulate state, you must configure the [CLI integration](/cli/cloud) and authenticate with a user token that has permission to read and write state versions for the relevant workspace. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions))
+
+### Rolling Back to a Previous State
+
+You can rollback to a previous, known good state version using the Terraform Cloud UI. Navigate to the state you want to rollback to and click the **Advanced** toggle button. This option requires that you have access to create new state and that you lock the workspace. It works by duplicating the state that you specify and making it the workspace's current state version. The workspace remains locked. To undo the rollback operation, rollback to the state version that was previously the latest state.
+
+-> **Note:** You can rollback to any prior state, but you should use caution because replacing state improperly can result in orphaned or duplicated infrastructure resources. This feature is provided as a convenient alternative to manually downloading older state and using state manipulation commands in the CLI to push it to Terraform Cloud.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
@@ -68,7 +74,7 @@ By default, new workspaces in Terraform Cloud do not allow other workspaces to a
 
 To configure a `tfe_outputs` data source that references a Terraform Cloud workspace, specify the organization and workspace in the `config` argument.
 
-You must still properly configure the `tfe` provider with a valid authentication token and correct permissions to Terraform Cloud. 
+You must still properly configure the `tfe` provider with a valid authentication token and correct permissions to Terraform Cloud.
 
 ```hcl
 data "tfe_outputs" "vpc" {


### PR DESCRIPTION
### What

An upcoming state manipulation feature of the UI is described.

### Screenshots

![Screenshot 2022-11-22 at 15-29-14 Terraform State - Workspaces - Terraform Cloud Terraform HashiCorp Developer](https://user-images.githubusercontent.com/174332/203434570-c00c7905-c2e1-4807-9572-8f83be36db61.png)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] ~Description links to related pull requests or issues, if any.~ N/A

#### Content
- [x] ~Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.~ N/A
- [x] ~API documentation and the API Changelog have been updated.~ N/A
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] ~New pages have metadata (page name and description) at the top.~ N/A
- [x] ~New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.~ N/A
- [x] ~New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.~ N/A
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
