### PR TITLE
Updated the list of relevant SNOW instances

### DIFF
--- a/website/docs/cloud-docs/integrations/service-now/index.mdx
+++ b/website/docs/cloud-docs/integrations/service-now/index.mdx
@@ -76,12 +76,9 @@ To start using Terraform with the ServiceNow Catalog Integration, you must have:
 
 This integration has been tested on the following ServiceNow server versions:
 
-- New York
-- Orlando
-- Paris
-- Quebec
 - Rome
 - San Diego
+- Tokyo
 
 It requires the following ServiceNow Plugins as dependencies:
 

--- a/website/docs/cloud-docs/integrations/service-now/index.mdx
+++ b/website/docs/cloud-docs/integrations/service-now/index.mdx
@@ -74,7 +74,7 @@ To start using Terraform with the ServiceNow Catalog Integration, you must have:
   systems](/cloud-docs/vcs#supported-vcs-providers) (VCSs) with read access
   to repositories with Terraform configurations.
 
-This integration has been tested on the following ServiceNow server versions:
+You can use this integration on the following ServiceNow server versions:
 
 - Rome
 - San Diego


### PR DESCRIPTION
### What
Updated **Terraform ServiceNow Service Catalog** documentation with the list of relevant ServiceNow versions:
 - removed New York, Orlando, Paris, Quebec as they have all been deprecated
 - added Tokyo as the Catalog app has recently been certified to run on it

### Why
To deliver the most relevant and up-to-date list of ServiceNow versions to the users.

### Screenshots
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] N/A Description links to related pull requests or issues, if any.

#### Content
- [x] N/A Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] N/A API documentation and the API Changelog have been updated. 
- [x] N/A Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] N/A Pages with related content are updated and link to this content when appropriate.
- [x] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] N/A New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [x] N/A The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
