### PR TITLE
Show "agent-count" field in Agent Pools response

### DIFF
--- a/website/docs/cloud-docs/api-docs/agents.mdx
+++ b/website/docs/cloud-docs/api-docs/agents.mdx
@@ -90,7 +90,8 @@ curl \
       "attributes": {
         "name": "example-pool",
         "created-at": "2020-08-05T18:10:26.964Z",
-        "organization-scoped": false
+        "organization-scoped": false,
+        "agent-count": 3
       },
       "relationships": {
         "agents": {


### PR DESCRIPTION
### What
I noticed this field was missing from the API docs

----------
