### PR TITLE
Add callout to Learn guide and Documentation to Which SDK page

### DIFF
--- a/website/docs/plugin/which-sdk.mdx
+++ b/website/docs/plugin/which-sdk.mdx
@@ -18,7 +18,7 @@ This guide helps you decide whether you should continue using SDKv2 or begin usi
 
 If you maintain a large existing provider, we recommend that you begin migrating from SDKv2 to the framework by developing new resources and data sources with the framework. You can use [terraform-plugin-mux](/plugin/mux) to refactor the provider over time. Refer to the [Migrate to Terraform Plugin Framework](/plugin/sdkv2#migrate-to-terraform-plugin-framework) documentation for more details.
 
-If you are developing a new provider, we recommend you build it entirely with the framework.
+If you are developing a new provider, we recommend you build it entirely with the Terraform Plugin Framework. Our HashiCorp Learn platform [offers several tutorials](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework) that can help you get started. We also have [further detailed documentation](/plugin/framework) to help you along the way.
 
 
 ## Do You Need More Features Than SDKv2 Provides?


### PR DESCRIPTION

### What
<!-- Explain what you changed and provide a list of changed page names. -->
Minor addition to include a callout to Learn and documentation collocated with the recommendation to use Framework.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
Offers a link to our tutorials in a convenient location proximal to the recommendation to use the new framework.


### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
