### PR TITLE
Add new query parameter to Teams API docs

### DIFF
--- a/website/docs/cloud-docs/api-docs/teams.mdx
+++ b/website/docs/cloud-docs/api-docs/teams.mdx
@@ -62,9 +62,10 @@ This endpoint supports pagination [with standard URL query parameters](/cloud-do
 
 | Parameter       | Description                                                                                                                                                                  |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `filter[names]` | **Optional**: If specified, restricts results to a team with a matching name. If multiple comma separated values are specified, teams matching any of the names are returned.|
+| `q`             | **Optional.** Allows querying a list of teams by name. This search is case-insensitive.                                                                                      |
+| `filter[names]` | **Optional.** If specified, restricts results to a team with a matching name. If multiple comma separated values are specified, teams matching any of the names are returned.|
 | `page[number]`  | **Optional.** If omitted, the endpoint will return the first page.                                                                                                           |
-| `page[size]`    | **Optional.** If omitted, the endpoint will return 20 runs per page.                                                                                                         |
+| `page[size]`    | **Optional.** If omitted, the endpoint will return 20 teams per page.                                                                                                        |
 
 ### Sample Request
 


### PR DESCRIPTION
### What
This PR updates the `GET organizations/:organization_name/teams` API documentation to include the new `q` query parameter. This was added in PR: https://github.com/hashicorp/atlas/pull/14212. 

**Note:** I also fixed a spelling mistake and formatting.

### Why
Users can now query a list of teams by name.

### Screenshots

<img width="881" alt="Screen Shot 2022-12-15 at 2 34 40 PM" src="https://user-images.githubusercontent.com/30316203/207981515-e52686ac-4c1b-4c06-a580-2f74b3a7510e.png">

----------

### Merge Checklist

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] **(N/A)** Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated.
- [x] **(N/A)** Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] **(N/A)** Pages with related content are updated and link to this content when appropriate.
- [x] **(N/A)** Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] **(N/A)** New pages have metadata (page name and description) at the top.
- [x] **(N/A)** New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] **(N/A)** New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] **(N/A)** UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
