### PR TITLE
Fix HTTP verb for safe-delete workspace

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -7,6 +7,10 @@ page_id: api-changelog
 
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
+## 2022-12-22
+
+* Updated [Safe Delete a workspace](/cloud-docs/api-docs/workspaces#safe-delete-a-workspace) to fix HTTP verb as `POST`.
+
 ## 2022-11-18
 
 * Update [Policies API](/cloud-docs/api-docs/policies) to fix policy enforcement level defaults. Enforcement level is a required field, so no defaults are available. 

--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -1117,7 +1117,7 @@ You can safe delete a workspace using two endpoints that behave identically. The
 | --------------- | --------------------------------- |
 | `:workspace_id` | The ID of the workspace to delete. |
 
-`DELETE /organizations/:organization_name/workspaces/:name/actions/safe-delete`
+`POST /organizations/:organization_name/workspaces/:name/actions/safe-delete`
 
 | Parameter            | Description                                                                                 |
 | -------------------- | ------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
### What

- Corrected HTTP verb from `DELETE` to `POST` for [safe deleting a workspace](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#safe-delete-a-workspace). This request was added in https://github.com/hashicorp/terraform-docs-common/pull/146.

### Why

- The second form of safe delete (`/organizations/:organization_name/workspaces/:name/actions/safe-delete`) incorrectly used the `DELETE` verb. Application code shows that this should actually be a `POST`.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc). (N/A)
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file. (N/A)
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate. (N/A)
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A)
- [x] New pages have metadata (page name and description) at the top. (N/A)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. (N/A)
- [x] UI elements (button names, page names, etc.) are bolded. (N/A)
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
