### PR TITLE
Remove beta flags for OPA

### DIFF
--- a/website/docs/cloud-docs/api-docs/policies.mdx
+++ b/website/docs/cloud-docs/api-docs/policies.mdx
@@ -36,7 +36,7 @@ page_title: Policies - API Docs - Terraform Cloud
 
 # Policies API
 
--> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA Policies are not available in Terraform Enterprise.
 
 Policies are rules that Terraform Cloud enforces on Terraform runs. You can use policies to validate that the Terraform plan complies with security rules and best practices. Terraform Cloud policy enforcement lets you use the policy-as-code frameworks Sentinel and Open Policy Agent (OPA) to apply policy checks to Terraform Cloud workspaces. Refer to [Policy Enforcement]((/cloud-docs/policy-enforcement) for more details.
 

--- a/website/docs/cloud-docs/api-docs/policies.mdx
+++ b/website/docs/cloud-docs/api-docs/policies.mdx
@@ -36,7 +36,7 @@ page_title: Policies - API Docs - Terraform Cloud
 
 # Policies API
 
--> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA Policies are not available in Terraform Enterprise.
+-> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 Policies are rules that Terraform Cloud enforces on Terraform runs. You can use policies to validate that the Terraform plan complies with security rules and best practices. Terraform Cloud policy enforcement lets you use the policy-as-code frameworks Sentinel and Open Policy Agent (OPA) to apply policy checks to Terraform Cloud workspaces. Refer to [Policy Enforcement]((/cloud-docs/policy-enforcement) for more details.
 

--- a/website/docs/cloud-docs/api-docs/policy-checks.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-checks.mdx
@@ -36,7 +36,7 @@ page_title: Policy Checks - API Docs - Terraform Cloud
 
 # Policy Checks API
 
--> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 ## List Policy Checks
 

--- a/website/docs/cloud-docs/api-docs/policy-checks.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-checks.mdx
@@ -36,7 +36,7 @@ page_title: Policy Checks - API Docs - Terraform Cloud
 
 # Policy Checks API
 
--> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 ## List Policy Checks
 

--- a/website/docs/cloud-docs/api-docs/policy-set-params.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-set-params.mdx
@@ -36,7 +36,7 @@ page_title: Policy Set Parameters - API Docs - Terraform Cloud
 
 # Policy Set Parameters API
 
--> **Note:** Sentinel and OPA policies available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Sentinel and OPA policies available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 [Sentinel parameters](https://docs.hashicorp.com/sentinel/language/parameters) are a list of key/value pairs that Terraform Cloud sends to the Sentinel runtime when performing policy checks on workspaces. They can help you avoid hardcoding sensitive parameters into a policy. 
 

--- a/website/docs/cloud-docs/api-docs/policy-set-params.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-set-params.mdx
@@ -36,7 +36,7 @@ page_title: Policy Set Parameters - API Docs - Terraform Cloud
 
 # Policy Set Parameters API
 
--> **Note:** Sentinel and OPA policies available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Sentinel and OPA policies available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 [Sentinel parameters](https://docs.hashicorp.com/sentinel/language/parameters) are a list of key/value pairs that Terraform Cloud sends to the Sentinel runtime when performing policy checks on workspaces. They can help you avoid hardcoding sensitive parameters into a policy. 
 

--- a/website/docs/cloud-docs/api-docs/policy-sets.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-sets.mdx
@@ -36,7 +36,7 @@ page_title: Policy Sets - API Docs - Terraform Cloud
 
 # Policy Sets API
 
--> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 [Policy Enforcement](/cloud-docs/policy-enforcement) lets you use the policy-as-code frameworks Sentinel and Open Policy Agent (OPA) to apply policy checks to Terraform Cloud workspaces.
 

--- a/website/docs/cloud-docs/api-docs/policy-sets.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-sets.mdx
@@ -36,7 +36,7 @@ page_title: Policy Sets - API Docs - Terraform Cloud
 
 # Policy Sets API
 
--> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Sentinel and OPA policies are available in the [Terraform Cloud Team & Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 [Policy Enforcement](/cloud-docs/policy-enforcement) lets you use the policy-as-code frameworks Sentinel and Open Policy Agent (OPA) to apply policy checks to Terraform Cloud workspaces.
 

--- a/website/docs/cloud-docs/overview.mdx
+++ b/website/docs/cloud-docs/overview.mdx
@@ -178,7 +178,7 @@ With Terraform Cloud's team management, you can define groups of users that matc
 
 ### Policy Enforcement
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 Policy-as-code lets you define and enforce granular policies for how your organization provisions infrastructure. You can limit the size of compute VMs, confine major updates to defined maintenance windows, and much more.
 

--- a/website/docs/cloud-docs/overview.mdx
+++ b/website/docs/cloud-docs/overview.mdx
@@ -178,7 +178,7 @@ With Terraform Cloud's team management, you can define groups of users that matc
 
 ### Policy Enforcement
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 Policy-as-code lets you define and enforce granular policies for how your organization provisions infrastructure. You can limit the size of compute VMs, confine major updates to defined maintenance windows, and much more.
 

--- a/website/docs/cloud-docs/policy-enforcement/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/index.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Policy Enforcement
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 Policies are rules that Terraform Cloud enforces on Terraform runs. You can use policies to validate that the Terraform plan complies with security rules and best practices.
 

--- a/website/docs/cloud-docs/policy-enforcement/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/index.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Policy Enforcement
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 Policies are rules that Terraform Cloud enforces on Terraform runs. You can use policies to validate that the Terraform plan complies with security rules and best practices.
 

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Managing Policy Sets
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 Policies are rules that Terraform Cloud enforces on Terraform runs. You can define policies using either the [Sentinel](/cloud-docs/policy-enforcement/sentinel) or [Open Policy Agent (OPA)](/cloud-docs/policy-enforcement/opa) policy-as-code frameworks.
 

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Managing Policy Sets
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 Policies are rules that Terraform Cloud enforces on Terraform runs. You can define policies using either the [Sentinel](/cloud-docs/policy-enforcement/sentinel) or [Open Policy Agent (OPA)](/cloud-docs/policy-enforcement/opa) policy-as-code frameworks.
 

--- a/website/docs/cloud-docs/policy-enforcement/opa/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/opa/index.mdx
@@ -6,7 +6,7 @@ description: Use the Rego policy language to define Open Policy Agent (OPA) poli
 
 # Defining OPA Policies
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA Policies are not available in Terraform Enterprise.
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 Policies are rules that Terraform Cloud enforces on runs. You use the [Rego policy language](https://www.openpolicyagent.org/docs/latest/policy-language/) to write policies for the Open Policy Agent (OPA) framework. After you define policies, you must add them to [policy sets](/cloud-docs/policy-enforcement/manage-policy-sets) that Terraform Cloud can enforce on workspaces.
 

--- a/website/docs/cloud-docs/policy-enforcement/opa/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/opa/index.mdx
@@ -6,7 +6,7 @@ description: Use the Rego policy language to define Open Policy Agent (OPA) poli
 
 # Defining OPA Policies
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 Policies are rules that Terraform Cloud enforces on runs. You use the [Rego policy language](https://www.openpolicyagent.org/docs/latest/policy-language/) to write policies for the Open Policy Agent (OPA) framework. After you define policies, you must add them to [policy sets](/cloud-docs/policy-enforcement/manage-policy-sets) that Terraform Cloud can enforce on workspaces.
 

--- a/website/docs/cloud-docs/policy-enforcement/opa/vcs.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/opa/vcs.mdx
@@ -6,7 +6,7 @@ tfc_only: true
 
 # OPA Policy Set VCS Repositories
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 To enable policy enforcement, you must group OPA policies into policy sets and apply those policy sets to one or more workspaces.
 

--- a/website/docs/cloud-docs/policy-enforcement/opa/vcs.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/opa/vcs.mdx
@@ -6,7 +6,7 @@ tfc_only: true
 
 # OPA Policy Set VCS Repositories
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 To enable policy enforcement, you must group OPA policies into policy sets and apply those policy sets to one or more workspaces.
 

--- a/website/docs/cloud-docs/policy-enforcement/policy-results.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/policy-results.mdx
@@ -5,7 +5,7 @@ description: Learn when Terraform Cloud evaluates policies during a run, how to 
 
 # Policy Results
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 When you add [policy sets](/cloud-docs/policy-enforcement/manage-policy-sets) to a workspace, Terraform Cloud enforces those policy sets on every Terraform run. Terraform Cloud displays the results of policy checks in the UI for each run. Depending on each policy’s [enforcement level](/cloud-docs/policy-enforcement/manage-policy-sets#policy-enforcement-levels), policy failures can also stop the run and prevent Terraform from provisioning infrastructure.
 

--- a/website/docs/cloud-docs/policy-enforcement/policy-results.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/policy-results.mdx
@@ -5,7 +5,7 @@ description: Learn when Terraform Cloud evaluates policies during a run, how to 
 
 # Policy Results
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 When you add [policy sets](/cloud-docs/policy-enforcement/manage-policy-sets) to a workspace, Terraform Cloud enforces those policy sets on every Terraform run. Terraform Cloud displays the results of policy checks in the UI for each run. Depending on each policy’s [enforcement level](/cloud-docs/policy-enforcement/manage-policy-sets#policy-enforcement-levels), policy failures can also stop the run and prevent Terraform from provisioning infrastructure.
 

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -208,7 +208,7 @@ If you prefer to use the CLI in a non-interactive environment, we recommend firs
 
 ## Policy Enforcement
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 Policies are rules that Terraform Cloud enforces on Terraform runs. You can use two policy-as-code frameworks to define fine-grained, logic-based policies: Sentinel and Open Policy Agent (OPA). 
 

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -208,7 +208,7 @@ If you prefer to use the CLI in a non-interactive environment, we recommend firs
 
 ## Policy Enforcement
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 Policies are rules that Terraform Cloud enforces on Terraform runs. You can use two policy-as-code frameworks to define fine-grained, logic-based policies: Sentinel and Open Policy Agent (OPA). 
 

--- a/website/docs/cloud-docs/run/states.mdx
+++ b/website/docs/cloud-docs/run/states.mdx
@@ -97,8 +97,6 @@ _Leaving this stage:_
 <!-- BEGIN: TFC:only name:opa-policies -->
 ## The OPA Policy Check Stage
 
--> **Note:** OPA policies are in beta.
-
 This stage only occurs if you enabled [Open Policy Agent (OPA) policies](/cloud-docs/policy-enforcement/opa) and runs after a successful `terraform plan` and before Cost Estimation. In this stage, Terraform Cloud checks whether the plan adheres to the policies in the OPA policy sets for the workspace.
 
 _States in this stage:_

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -157,7 +157,7 @@ Enable and disable the [cost estimation](/cloud-docs/cost-estimation) feature fo
 
 #### Policies
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing). OPA policies are not available in Terraform Enterprise.
 
 Policies let you define and enforce rules for Terraform runs. You can write them using either the [Sentinel](/cloud-docs/policy-enforcement/sentinel) or [Open Policy Agent (OPA)](/cloud-docs/policy-enforcement/opa) policy-as-code frameworks and then group them into policy sets that you can apply to workspaces in your organization. To create policies and policy sets, you must have [permission to manage policies](/cloud-docs/users-teams-organizations/permissions#organization-permissions).
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -157,7 +157,7 @@ Enable and disable the [cost estimation](/cloud-docs/cost-estimation) feature fo
 
 #### Policies
 
--> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing), and OPA policies are in beta. OPA policies are not available in Terraform Enterprise.
+-> **Note:** Policies are available in the [Terraform Cloud Team and Governance tier](https://www.hashicorp.com/products/terraform/pricing).
 
 Policies let you define and enforce rules for Terraform runs. You can write them using either the [Sentinel](/cloud-docs/policy-enforcement/sentinel) or [Open Policy Agent (OPA)](/cloud-docs/policy-enforcement/opa) policy-as-code frameworks and then group them into policy sets that you can apply to workspaces in your organization. To create policies and policy sets, you must have [permission to manage policies](/cloud-docs/users-teams-organizations/permissions#organization-permissions).
 


### PR DESCRIPTION
### What
This commit removes the beta flag for OPA as it is now generally available.


### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
