### PR TITLE
replace aws_rds_cluster with aws_rds_cluster_instance

### DIFF
--- a/website/docs/cloud-docs/cost-estimation/aws.mdx
+++ b/website/docs/cloud-docs/cost-estimation/aws.mdx
@@ -12,7 +12,7 @@ Terraform Cloud can estimate monthly costs for many AWS Terraform resources.
 
 ## Supported Resources
 
-Cost estimation supports the following resources:
+Cost estimation supports the following resources. Not all possible values for attributes of each resource are supported, ex. newer instance types or EBS volume types.
 
 | Resource | Incurs Cost |
 | ----------- | ----------- |
@@ -30,7 +30,7 @@ Cost estimation supports the following resources:
 | `aws_instance` | X |
 | `aws_kms_key` | X |
 | `aws_lb` | X |
-| `aws_rds_cluster` | X |
+| `aws_rds_cluster_instance` | X |
 | `aws_acm_certificate_validation` | |
 | `aws_alb_listener` | |
 | `aws_alb_listener_rule` | |

--- a/website/docs/cloud-docs/cost-estimation/azure.mdx
+++ b/website/docs/cloud-docs/cost-estimation/azure.mdx
@@ -12,7 +12,7 @@ Terraform Cloud can estimate monthly costs for many Azure Terraform resources.
 
 ## Supported Resources
 
-Cost estimation supports the following resources:
+Cost estimation supports the following resources. Not all possible values for attributes of each resource are supported, ex. newer VM sizes or managed disk types.
 
 | Resource | Incurs Cost |
 | ----------- | ----------- |

--- a/website/docs/cloud-docs/cost-estimation/gcp.mdx
+++ b/website/docs/cloud-docs/cost-estimation/gcp.mdx
@@ -12,7 +12,7 @@ Terraform Cloud can estimate monthly costs for many GCP Terraform resources.
 
 ## Supported Resources
 
-Cost estimation supports the following resources:
+Cost estimation supports the following resources. Not all possible values for attributes of each resource are supported, ex. new or custom machine types.
 
 | Resource | Incurs Cost |
 | ----------- | ----------- |


### PR DESCRIPTION
### What
replaced aws_rds_cluster with aws_rds_cluster_instance on the cost estimation support pages: https://developer.hashicorp.com/terraform/cloud-docs/cost-estimation/aws#handled-resources

### Why
the actual priced resource is aws_rds_cluster_instance, not aws_rds_cluster.

i've also updated the help text to mention that we don't support every possible attribute value for every research.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
