### PR TITLE
Fix document outline for Workspaces API

### DIFF
--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -2716,7 +2716,7 @@ curl \
   https://app.terraform.io/api/v2/workspaces/workspace-2/relationships/tags
 ```
 
-## Sample Response
+### Sample Response
 
 No response body.
 
@@ -2776,7 +2776,7 @@ curl \
   https://app.terraform.io/api/v2/workspaces/workspace-2/relationships/tags
 ```
 
-## Sample Response
+### Sample Response
 
 No response body.
 


### PR DESCRIPTION
### Why
"Sample Response" was showing up on the endpoint level in the docs site

### Screenshots (Before)

![Screen Shot 2023-01-20 at 9 44 16 AM](https://user-images.githubusercontent.com/174332/213755094-8c233506-fc80-4844-8db6-76e776816f20.png)
