### PR TITLE
Update links to cross-org registry sharing

### DIFF
--- a/website/docs/cloud-docs/registry/index.mdx
+++ b/website/docs/cloud-docs/registry/index.mdx
@@ -19,7 +19,7 @@ Terraform Cloud's private registry works similarly to the [public Terraform Regi
 
 ## Private Providers and Modules
 
-[Private providers](/cloud-docs/registry/publish-providers) and [private modules](/cloud-docs/registry/publish-modules) are hosted on an organization's private registry and are only available to members of that organization. In Terraform Enterprise, private modules are also available to other organizations that are configured to [share modules](/enterprise/admin/application/module-sharing) with that organization.
+[Private providers](/cloud-docs/registry/publish-providers) and [private modules](/cloud-docs/registry/publish-modules) are hosted on an organization's private registry and are only available to members of that organization. In Terraform Enterprise, private providers and modules are also available to other organizations that are [configured to share](/enterprise/admin/application/module-provider-sharing) with that organization.
 
 
 ## Managing Usage

--- a/website/docs/cloud-docs/registry/index.mdx
+++ b/website/docs/cloud-docs/registry/index.mdx
@@ -19,7 +19,7 @@ Terraform Cloud's private registry works similarly to the [public Terraform Regi
 
 ## Private Providers and Modules
 
-[Private providers](/cloud-docs/registry/publish-providers) and [private modules](/cloud-docs/registry/publish-modules) are hosted on an organization's private registry and are only available to members of that organization. In Terraform Enterprise, private providers and modules are also available to other organizations that are [configured to share](/enterprise/admin/application/module-provider-sharing) with that organization.
+[Private providers](/cloud-docs/registry/publish-providers) and [private modules](/cloud-docs/registry/publish-modules) are hosted on an organization's private registry and are only available to members of that organization. In Terraform Enterprise, private providers and modules are also available to other organizations that are [configured to share](/enterprise/admin/application/registry-sharing) with that organization.
 
 
 ## Managing Usage

--- a/website/docs/cloud-docs/registry/publish-modules.mdx
+++ b/website/docs/cloud-docs/registry/publish-modules.mdx
@@ -19,7 +19,7 @@ The private registry uses your configured [Version Control System (VCS) integrat
 
 ## Permissions
 
-Private modules are only available to members of the organization where you add them. In Terraform Enterprise, they are also available to organizations that you configure to [share modules](/enterprise/admin/application/module-provider-sharing) with that organization.
+Private modules are only available to members of the organization where you add them. In Terraform Enterprise, they are also available to organizations that you configure to [share modules](/enterprise/admin/application/registry-sharing) with that organization.
 
 Members of the [owners team](/cloud-docs/users-teams-organizations/permissions#organization-owners) and teams with [Manage Private Registry permissions](/cloud-docs/users-teams-organizations/permissions#manage-private-registry) can publish and delete modules from the private registry.
 
@@ -117,4 +117,4 @@ Terraform Cloud does not typically allow one organization's workspaces to use pr
 
 Instead, you can share modules across organizations by sharing the underlying VCS repository. Grant each organization access to the module's repository, and then add the module to each organization's registry. When you push tags to publish new module versions, both organizations update accordingly.
 
-Terraform Enterprise administrators can configure [module sharing](/enterprise/admin/application/module-provider-sharing) to allow organizations to use private modules from other organizations.
+Terraform Enterprise administrators can configure [module sharing](/enterprise/admin/application/registry-sharing) to allow organizations to use private modules from other organizations.

--- a/website/docs/cloud-docs/registry/publish-modules.mdx
+++ b/website/docs/cloud-docs/registry/publish-modules.mdx
@@ -19,7 +19,7 @@ The private registry uses your configured [Version Control System (VCS) integrat
 
 ## Permissions
 
-Private modules are only available to members of the organization where you add them. In Terraform Enterprise, they are also available to organizations that you configure to [share modules](/enterprise/admin/application/module-sharing) with that organization.
+Private modules are only available to members of the organization where you add them. In Terraform Enterprise, they are also available to organizations that you configure to [share modules](/enterprise/admin/application/module-provider-sharing) with that organization.
 
 Members of the [owners team](/cloud-docs/users-teams-organizations/permissions#organization-owners) and teams with [Manage Private Registry permissions](/cloud-docs/users-teams-organizations/permissions#manage-private-registry) can publish and delete modules from the private registry.
 
@@ -117,4 +117,4 @@ Terraform Cloud does not typically allow one organization's workspaces to use pr
 
 Instead, you can share modules across organizations by sharing the underlying VCS repository. Grant each organization access to the module's repository, and then add the module to each organization's registry. When you push tags to publish new module versions, both organizations update accordingly.
 
-Terraform Enterprise administrators can configure [module sharing](/enterprise/admin/application/module-sharing) to allow organizations to use private modules from other organizations.
+Terraform Enterprise administrators can configure [module sharing](/enterprise/admin/application/module-provider-sharing) to allow organizations to use private modules from other organizations.

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -16,7 +16,7 @@ Review the following before publishing a new provider or provider version.
 
 ### Permissions
 
-Private providers are only available to members of the organization where you add them. In Terraform Enterprise, they are also available to organizations that you configure to [share providers](/enterprise/admin/application/registry-sharing) with that organization.
+Users must be members of an organization to access its registry and private providers. In Terraform Enterprise, providers are also available to organizations that you configure to [share registry access](/enterprise/admin/application/registry-sharing).
 
 You must be a member of the [owners team](/cloud-docs/users-teams-organizations/permissions#organization-owners) or a team with [Manage Private Registry permissions](/cloud-docs/users-teams-organizations/permissions#manage-private-registry) to publish and delete private providers from the private registry.
 

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -16,7 +16,7 @@ Review the following before publishing a new provider or provider version.
 
 ### Permissions
 
-Private providers are only available to members of the organization where you add them. In Terraform Enterprise, they are also available to organizations that you configure to [share providers](/enterprise/admin/application/module-provider-sharing) with that organization.
+Private providers are only available to members of the organization where you add them. In Terraform Enterprise, they are also available to organizations that you configure to [share providers](/enterprise/admin/application/registry-sharing) with that organization.
 
 You must be a member of the [owners team](/cloud-docs/users-teams-organizations/permissions#organization-owners) or a team with [Manage Private Registry permissions](/cloud-docs/users-teams-organizations/permissions#manage-private-registry) to publish and delete private providers from the private registry.
 

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -16,6 +16,8 @@ Review the following before publishing a new provider or provider version.
 
 ### Permissions
 
+Private providers are only available to members of the organization where you add them. In Terraform Enterprise, they are also available to organizations that you configure to [share providers](/enterprise/admin/application/module-provider-sharing) with that organization.
+
 You must be a member of the [owners team](/cloud-docs/users-teams-organizations/permissions#organization-owners) or a team with [Manage Private Registry permissions](/cloud-docs/users-teams-organizations/permissions#manage-private-registry) to publish and delete private providers from the private registry.
 
 ### Release Files

--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -24,7 +24,7 @@ Click **Providers** and **Modules** to toggle back and forth between lists of av
 
 ### Shared Providers and Modules - Terraform Enterprise
 
-On Terraform Enterprise, your [registry sharing](/enterprise/admin/application/module-provider-sharing) configuration may grant you access to providers and modules outside your organization. Providers and modules that are shared with your current organization have a **Shared** badge in the private registry (below). Providers and modules in your current organization that are shared with other organizations have a badge that says **Sharing**.
+On Terraform Enterprise, your [registry sharing](/enterprise/admin/application/registry-sharing) configuration may grant you access to providers and modules outside your organization. Providers and modules that are shared with your current organization have a **Shared** badge in the private registry (below). Providers and modules in your current organization that are shared with other organizations have a badge that says **Sharing**.
 
 ### Viewing Provider and Module Details and Versions
 
@@ -114,7 +114,7 @@ A workspace can only use private providers and modules from its own organization
 
 - **Terraform Cloud:** [Add providers and modules to the registry](/cloud-docs/registry/publish-modules#sharing-modules-across-organizations) for each organization that requires access.
 
-- **Terraform Enterprise:** Check your site's [registry sharing](/enterprise/admin/application/module-provider-sharing) configuration. Workspaces can also use private providers and modules from organizations that are sharing with the workspace's organization.
+- **Terraform Enterprise:** Check your site's [registry sharing](/enterprise/admin/application/registry-sharing) configuration. Workspaces can also use private providers and modules from organizations that are sharing with the workspace's organization.
 
 ## Running Configurations with Private Providers and Modules
 

--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -24,7 +24,7 @@ Click **Providers** and **Modules** to toggle back and forth between lists of av
 
 ### Shared Providers and Modules - Terraform Enterprise
 
-On Terraform Enterprise, your [registry sharing](/enterprise/admin/application/registry-sharing) configuration may grant you access to providers and modules outside your organization. Providers and modules that are shared with your current organization have a **Shared** badge in the private registry (below). Providers and modules in your current organization that are shared with other organizations have a badge that says **Sharing**.
+On Terraform Enterprise, your [registry sharing](/enterprise/admin/application/registry-sharing) configuration may grant you access to another organization's providers and modules. Providers and modules that are shared with your current organization have a **Shared** badge in the private registry (below). Providers and modules in your current organization that are shared with other organizations have a badge that says **Sharing**.
 
 ### Viewing Provider and Module Details and Versions
 

--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -22,9 +22,9 @@ To find available providers and modules, click the **Registry** button. The **Re
 
 Click **Providers** and **Modules** to toggle back and forth between lists of available providers and modules in the private registry. You can also use the search field to filter for titles that contain a specific keyword. The search does not include READMEs or resource details.
 
-### Shared Modules - Terraform Enterprise
+### Shared Providers and Modules - Terraform Enterprise
 
-On Terraform Enterprise, your [module sharing](/enterprise/admin/application/module-sharing) configuration may grant you access to modules outside your organization. Modules that are shared with your current organization have a **Shared** badge in the private registry (below). Modules in your current organization that are shared with other organizations have a badge that says **Sharing**.
+On Terraform Enterprise, your [registry sharing](/enterprise/admin/application/module-provider-sharing) configuration may grant you access to providers and modules outside your organization. Providers and modules that are shared with your current organization have a **Shared** badge in the private registry (below). Providers and modules in your current organization that are shared with other organizations have a badge that says **Sharing**.
 
 ### Viewing Provider and Module Details and Versions
 
@@ -114,7 +114,7 @@ A workspace can only use private providers and modules from its own organization
 
 - **Terraform Cloud:** [Add providers and modules to the registry](/cloud-docs/registry/publish-modules#sharing-modules-across-organizations) for each organization that requires access.
 
-- **Terraform Enterprise:** Check your site's [module sharing](/enterprise/admin/application/module-sharing) configuration. Workspaces can also use private modules from organizations that are sharing modules with the workspace's organization.
+- **Terraform Enterprise:** Check your site's [registry sharing](/enterprise/admin/application/module-provider-sharing) configuration. Workspaces can also use private providers and modules from organizations that are sharing with the workspace's organization.
 
 ## Running Configurations with Private Providers and Modules
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

Updating links and wording to be more generic to include provider sharing when discussing registry sharing

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

TFE 202301-1 added the ability to share providers across orgs in addition to modules, and required documentation update. This points to the new documentation pages, as well as updates the wording around it.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x](N/A) API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
