### PR TITLE
Add documentation for dynamic provider credentials

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -152,6 +152,18 @@
         "path": "workspaces/configurations"
       },
       {
+        "title": "Dynamic Provider Credentials",
+        "routes": [
+          { "title":  "Overview", "path":  "workspaces/dynamic-provider-credentials" },
+          { "title":  "Workload Identity Tokens", "path":  "workspaces/dynamic-provider-credentials/workload-identity-tokens" },
+          { "title":  "Vault Configuration", "path":  "workspaces/dynamic-provider-credentials/vault-configuration" },
+          { "title":  "AWS Configuration", "path":  "workspaces/dynamic-provider-credentials/aws-configuration" },
+          { "title":  "GCP Configuration", "path":  "workspaces/dynamic-provider-credentials/gcp-configuration" },
+          { "title":  "Azure Configuration", "path":  "workspaces/dynamic-provider-credentials/azure-configuration" },
+          { "title":  "Manually Generating Workload Identity Tokens", "path":  "workspaces/dynamic-provider-credentials/manual-generation" }
+        ]
+      },
+      {
         "title": "Variables",
         "routes": [
           { "title": "Overview", "path": "workspaces/variables" },

--- a/website/docs/cloud-docs/run/run-environment.mdx
+++ b/website/docs/cloud-docs/run/run-environment.mdx
@@ -69,6 +69,39 @@ Terraform Cloud uses the user token to access a workspace's state when you:
 
 Refer to [Permissions](/cloud-docs/users-teams-organizations/permissions#workspace-permissions) for more details about workspace permissions.
 
+### Provider Authentication
+
+Runs in Terraform Cloud typically require some form of credentials to authenticate with infrastructure providers. Credentials can be provided statically through Environment or Terraform [variables](/cloud-docs/workspaces/variables), or can be generated on a per-run basis through [dynamic credentials](/cloud-docs/workspaces/dynamic-provider-credentials) for certain providers. Below are pros and cons to each approach.
+
+#### Static Credentials
+
+##### Pros
+
+- Simple to setup
+- Broad support across providers
+
+##### Cons
+
+- Requires regular manual rotation for enhanced security posture
+- Large blast radius if a credential is exposed and needs to be revoked
+
+#### Dynamic Credentials
+
+-> **Note:** Dynamic Credentials are in beta.
+
+##### Pros
+
+- Eliminates the need for manual rotation of credentials on Terraform Cloud
+- Terraform Cloud metadata - including the run's project, workspace, and run-phase - is encoded into every token to allow for granular permission scoping on the target cloud platform
+- Credentials are short-lived, which reduces blast radius of potential credential exposure
+
+##### Cons
+
+- More complicated initial setup compared to using static credentials
+- Not supported for all providers
+
+The full list of supported providers and setup instructions can be found in the [dynamic credentials](/cloud-docs/workspaces/dynamic-provider-credentials) documentation.
+
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 ### Environment Variables

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -1,0 +1,116 @@
+---
+page_title: Dynamic Credentials with the AWS Provider - Workspaces - Terraform Cloud
+description: >-
+  Use OpenID Connect to get short-term credentials for the AWS Terraform provider in
+  your Terraform Cloud runs.
+---
+
+# Dynamic Credentials with the AWS Provider
+
+-> **Note:** Dynamic Credentials are in beta.
+
+~> **Important:** If using self-managed agents, make sure you’re using **v1.5.0-rc.2** or later.
+
+You can use Terraform Cloud’s native OpenID Connect integration with AWS to get [dynamic credentials](/cloud-docs/workspaces/dynamic-provider-credentials) for the AWS provider in your Terraform Cloud runs. Configuring the integration requires the following steps.
+
+1. **[Configure AWS](#configure-aws):** Set up a trust configuration between AWS and Terraform Cloud. Then, you must create AWS roles and policies for your Terraform Cloud workspaces.
+2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.
+
+Once you complete the setup, Terraform Cloud automatically authenticates to AWS during each run. The AWS provider authentication is valid for the length of the plan or apply.
+
+## Configure AWS
+You must enable and configure an OIDC identity provider and accompanying role and trust policy on AWS. These instructions use the AWS console, but you can also use Terraform to configure AWS. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/tree/main/aws).
+### Create an OIDC Identity Provider
+AWS documentation for setting this up through the AWS console or API can be found here: [Creating OpenID Connect (OIDC) identity providers - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html).
+
+The `provider URL` should be set to the address of Terraform Cloud (e.g., https://app.terraform.io **without** a trailing slash), and the `audience` should be set to `aws.workload.identity` or the value of `TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE`, if configured."
+### Configure a Role and Trust Policy
+You must configure a role and corresponding trust policy. Amazon documentation on setting this up can be found here: [Creating a role for web identity or OpenID Connect Federation (console) - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html).
+The trust policy will be of the form:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "OIDC_PROVIDER_ARN"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "SITE_ADDRESS:aud": "AUDIENCE_VALUE",
+                    "SITE_ADDRESS:sub": "organization:ORG_NAME:project:PROJECT_NAME:workspace:WORKSPACE_NAME:run_phase:RUN_PHASE"
+                }
+            }
+        }
+    ]
+}
+```
+with the capitalized values replaced with the following:
+* **OIDC_PROVIDER_ARN**: The ARN from the OIDC provider resource created in the previous step
+* **SITE_ADDRESS**: The address of Terraform Cloud with `https://` stripped, (e.g., `app.terraform.io`)
+* **AUDIENCE_VALUE**: This should be set to `aws.workload.identity` unless a non-default audience has been specified in TFC
+* **ORG_NAME**: The organization name this policy will apply to, such as `my-org-name`
+* **PROJECT_NAME**: The project name that this policy will apply to, such as `my-project-name`
+* **WORKSPACE_NAME**: The workspace name this policy will apply to, such as `my-workspace-name`
+* **RUN_PHASE**: The run phase this policy will apply to, currently one of `plan` or `apply`.
+
+**Note**: if different permissions are desired for plan and apply, then two separate roles and trust policies must be created for each of these run phases to properly match them to the correct access level.
+If the same permissions will be used regardless of run phase, then the condition can be modified like the below to use `StringLike` instead of `StringEquals` for the sub and include a `*` after `run_phase:` to perform a wildcard match:
+
+```json
+{
+    "Condition": {
+        "StringEquals": {
+            "SITE_ADDRESS:aud": "AUDIENCE_VALUE"
+        },
+        "StringLike": {
+            "SITE_ADDRESS:sub": "organization:ORG_NAME:project:PROJECT_NAME:workspace:WORKSPACE_NAME:run_phase:*"
+        }
+    }
+}
+```
+
+!> **Warning**: you should always check, at minimum, the audience and the name of the organization in order to prevent unauthorized access from other Terraform Cloud organizations!
+
+A permissions policy needs to be added to the role which defines what operations within AWS the role is allowed to perform. As an example, the below policy allows for fetching a list of S3 buckets:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+## Configure Terraform Cloud
+You’ll need to set some environment variables in your Terraform Cloud workspace in order to configure Terraform Cloud to authenticate with AWS using dynamic credentials. You can set these as workspace variables, or if you’d like to share one AWS role across multiple workspaces, you can use a variable set.
+
+### Required Environment Variables
+| Variable                | Value                                               | Notes                                                                                          |
+|-------------------------|-----------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `TFC_AWS_PROVIDER_AUTH` | `true`                                              | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate to AWS. |
+| `TFC_AWS_RUN_ROLE_ARN`  | The arn of the AWS role arn to authenticate against ||
+
+### Optional Environment Variables
+You may need to set these variables, depending on your use case.
+
+| Variable                             | Value                                                                                        | Notes                                                                  |
+|--------------------------------------|----------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| `TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE` | Will be used as the `aud` claim for the identity token. Defaults to `aws.workload.identity`. |
+| `TFC_AWS_PLAN_ROLE_ARN`              | The AWS role arn to use for the plan phase of a run.                                         | Will fall back to the value of `TFC_AWS_RUN_ROLE_ARN` if not provided. |
+| `TFC_AWS_APPLY_ROLE_ARN`             | The AWS role arn to use for the apply phase of a run.                                        | Will fall back to the value of `TFC_AWS_RUN_ROLE_ARN` if not provided. |
+
+
+## Configure the AWS Provider
+Make sure that you’re passing a value for the `region` argument into the provider configuration block or setting the `AWS_REGION` variable in your workspace.
+
+Make sure that you’re not using any of the other arguments or methods mentioned in the [authentication and configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration) section of the provider documentation as these settings may interfere with dynamic provider credentials.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -23,7 +23,7 @@ You must enable and configure an OIDC identity provider and accompanying role an
 ### Create an OIDC Identity Provider
 AWS documentation for setting this up through the AWS console or API can be found here: [Creating OpenID Connect (OIDC) identity providers - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html).
 
-The `provider URL` should be set to the address of Terraform Cloud (e.g., https://app.terraform.io **without** a trailing slash), and the `audience` should be set to `aws.workload.identity` or the value of `TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE`, if configured."
+The `provider URL` should be set to the address of Terraform Cloud (e.g., https://app.terraform.io **without** a trailing slash), and the `audience` should be set to `aws.workload.identity` or the value of `TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE`, if configured.
 ### Configure a Role and Trust Policy
 You must configure a role and corresponding trust policy. Amazon documentation on setting this up can be found here: [Creating a role for web identity or OpenID Connect Federation (console) - AWS Identity and Access Management](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html).
 The trust policy will be of the form:

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -56,7 +56,7 @@ with the capitalized values replaced with the following:
 * **WORKSPACE_NAME**: The workspace name this policy will apply to, such as `my-workspace-name`
 * **RUN_PHASE**: The run phase this policy will apply to, currently one of `plan` or `apply`.
 
-**Note**: if different permissions are desired for plan and apply, then two separate roles and trust policies must be created for each of these run phases to properly match them to the correct access level.
+-> **Note:** if different permissions are desired for plan and apply, then two separate roles and trust policies must be created for each of these run phases to properly match them to the correct access level.
 If the same permissions will be used regardless of run phase, then the condition can be modified like the below to use `StringLike` instead of `StringEquals` for the sub and include a `*` after `run_phase:` to perform a wildcard match:
 
 ```json

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -1,0 +1,73 @@
+---
+page_title: Dynamic Credentials with the Azure Providers - Terraform Cloud
+description: >-
+  Use OpenID Connect to get short-term credentials for the Azure Terraform providers in
+  your Terraform Cloud runs.
+---
+
+# Dynamic Credentials with the Azure Provider
+
+-> **Note:** Dynamic Credentials are in beta.
+
+~> **Important**: Ensure you are using version **3.25.0** or later of the **AzureRM provider** and version **2.29.0** or later of the **AzureAD provider** as required OIDC functionality was introduced in these provider versions.
+
+~> **Important:** If using self-managed agents, make sure you’re using **v1.5.0-rc.2** or later.
+
+You can use Terraform Cloud’s native OpenID Connect integration with Azure to get [dynamic credentials](/cloud-docs/workspaces/dynamic-provider-credentials) for the AzureRM or AzureAD providers in your Terraform Cloud runs. Configuring the integration requires the following steps.
+
+1. **[Configure Azure](#configure-azure):** Set up a trust configuration between Azure and Terraform Cloud. Then, you must create Azure roles and policies for your Terraform Cloud workspaces.
+2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.
+
+Once you complete the setup, Terraform Cloud automatically authenticates to Azure during each run. The Azure provider authentication is valid for the length of the plan or apply.
+
+## Configure Azure
+You must enable and configure an application and service principal with accompanying federated credentials and permissions on Azure. These instructions use the Azure portal, but you can also use Terraform to configure Azure. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/tree/main/azure).
+### Create an Application and Service Principal
+Follow the steps mentioned in the AzureRM provider docs here: [Creating the Application and Service Principal](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_oidc#creating-the-application-and-service-principal).
+
+As mentioned in the documentation it will be important to make note of the `client_id` for the application as you will use this later for authentication.
+
+**Note**: you will want to skip the `“Configure Azure Active Directory Application to Trust a GitHub Repository”` section as this does not apply here.
+### Grant the Application Access to Manage Resources in Your Azure Subscription
+You must now give the created Application permission to modify resources within your Subscription.
+
+Follow the steps mentioned in the AzureRM provider docs here: [Granting the Application access to manage resources in your Azure Subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_oidc#granting-the-application-access-to-manage-resources-in-your-azure-subscription).
+### Configure Azure Active Directory Application to Trust a Generic Issuer
+Finally, you must create federated identity credentials which validate the contents of the token sent to Azure from Terraform Cloud.
+
+Follow the steps mentioned in the AzureRM provider docs here: [Configure Azure Active Directory Application to Trust a Generic Issuer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_oidc#configure-azure-active-directory-application-to-trust-a-generic-issuer).
+
+The following information should be specified:
+* **Federated credential scenario**: Must be set to `Other issuer`.
+* **Issuer**: The address of Terraform Cloud (e.g., https://app.terraform.io).
+    * **Important**: make sure this value starts with **https://** and does _not_ have a trailing slash.
+* **Subject identifier**: The subject identifier from Terraform Cloud that this credential will match. This will be in the form `organization:my-org-name:project:my-project-name:workspace:my-workspace-name:run_phase:plan` where the `run_phase` can be one of `plan` or `apply`.
+* **Name**: A name for the federated credential, such as `tfc-plan-credential`. Note that this cannot be changed later.
+
+The following is optional, but may be desired:
+* **Audience**: Enter the audience value that will be set when requesting the identity token. This will be `api://AzureADTokenExchange` by default. This should be set to the value of `TFC_AZURE_WORKLOAD_IDENTITY_AUDIENCE` if this has been configured.
+
+**Note**: because the `Subject identifier` for federated credentials is a direct string match, two federated identity credentials need to be created for each workspace using dynamic credentials: one that matches `run_phase:plan` and one that matches `run_phase:apply`.
+
+## Configure Terraform Cloud
+You’ll need to set some environment variables in your Terraform Cloud workspace in order to configure Terraform Cloud to authenticate with Azure using dynamic credentials. You can set these as workspace variables.
+### Required Environment Variables
+
+| Variable                  | Value                                                                                    | Notes                                                                                            |
+|---------------------------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| `TFC_AZURE_PROVIDER_AUTH` | `true`                                                                                   | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate to Azure. |
+| `TFC_AZURE_RUN_CLIENT_ID` | The client ID for the Service Principal / Application used when authenticating to Azure. ||
+
+### Optional Environment Variables
+You may need to set these variables, depending on your use case.
+
+| Variable                               | Value                                                                                             | Notes                                                                     |
+|----------------------------------------|---------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| `TFC_AZURE_WORKLOAD_IDENTITY_AUDIENCE` | Will be used as the `aud` claim for the identity token. Defaults to `api://AzureADTokenExchange`. ||
+| `TFC_AZURE_PLAN_CLIENT_ID`             | The client ID for the Service Principal / Application to use for the plan phase of a run.         | Will fall back to the value of `TFC_AZURE_RUN_CLIENT_ID` if not provided. |
+| `TFC_AZURE_APPLY_CLIENT_ID`            | The client ID for the Service Principal / Application to use for the apply phase of a run.        | Will fall back to the value of `TFC_AZURE_RUN_CLIENT_ID` if not provided. |
+
+## Configure the AzureRM or AzureAD Provider
+Make sure that you’re passing values for the `subscription_id` and `tenant_id` arguments into the provider configuration block or setting the `ARM_SUBSCRIPTION_ID` and `ARM_TENANT_ID` variables in your workspace.
+
+Make sure that you’re _not_ setting values for `client_id`, `use_oidc`, or `oidc_token` in the provider or setting any of `ARM_CLIENT_ID`, `ARM_USE_OIDC`, `ARM_OIDC_TOKEN`.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -9,7 +9,7 @@ description: >-
 
 -> **Note:** Dynamic Credentials are in beta.
 
-~> **Important**: Ensure you are using version **3.25.0** or later of the **AzureRM provider** and version **2.29.0** or later of the **AzureAD provider** as required OIDC functionality was introduced in these provider versions.
+~> **Important:** Ensure you are using version **3.25.0** or later of the **AzureRM provider** and version **2.29.0** or later of the **AzureAD provider** as required OIDC functionality was introduced in these provider versions.
 
 ~> **Important:** If using self-managed agents, make sure you’re using **v1.5.0-rc.2** or later.
 
@@ -27,7 +27,7 @@ Follow the steps mentioned in the AzureRM provider docs here: [Creating the Appl
 
 As mentioned in the documentation it will be important to make note of the `client_id` for the application as you will use this later for authentication.
 
-**Note**: you will want to skip the `“Configure Azure Active Directory Application to Trust a GitHub Repository”` section as this does not apply here.
+-> **Note:** you will want to skip the `“Configure Azure Active Directory Application to Trust a GitHub Repository”` section as this does not apply here.
 ### Grant the Application Access to Manage Resources in Your Azure Subscription
 You must now give the created Application permission to modify resources within your Subscription.
 
@@ -47,7 +47,7 @@ The following information should be specified:
 The following is optional, but may be desired:
 * **Audience**: Enter the audience value that will be set when requesting the identity token. This will be `api://AzureADTokenExchange` by default. This should be set to the value of `TFC_AZURE_WORKLOAD_IDENTITY_AUDIENCE` if this has been configured.
 
-**Note**: because the `Subject identifier` for federated credentials is a direct string match, two federated identity credentials need to be created for each workspace using dynamic credentials: one that matches `run_phase:plan` and one that matches `run_phase:apply`.
+-> **Note:** because the `Subject identifier` for federated credentials is a direct string match, two federated identity credentials need to be created for each workspace using dynamic credentials: one that matches `run_phase:plan` and one that matches `run_phase:apply`.
 
 ## Configure Terraform Cloud
 You’ll need to set some environment variables in your Terraform Cloud workspace in order to configure Terraform Cloud to authenticate with Azure using dynamic credentials. You can set these as workspace variables.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -1,0 +1,90 @@
+---
+page_title: Dynamic Credentials with the GCP Provider - Workspaces - Terraform Cloud
+description: >-
+  Use OpenID Connect to get short-term credentials for the GCP Terraform provider in
+  your Terraform Cloud runs.
+---
+
+# Dynamic Credentials with the GCP Provider
+
+-> **Note:** Dynamic Credentials are in beta.
+
+~> **Important:** If using self-managed agents, make sure you’re using **v1.5.0-rc.2** or later.
+
+You can use Terraform Cloud’s native OpenID Connect integration with GCP to get [dynamic credentials](/cloud-docs/workspaces/dynamic-provider-credentials) for the GCP provider in your Terraform Cloud runs. Configuring the integration requires the following steps.
+
+1. **[Configure GCP](#configure-gcp):** Set up a trust configuration between GCP and Terraform Cloud. Then, you must create GCP roles and policies for your Terraform Cloud workspaces.
+2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.
+
+Once you complete the setup, Terraform Cloud automatically authenticates to GCP during each run. The GCP provider authentication is valid for the length of the plan or apply.
+
+## Configure GCP
+You must enable and configure a workload identity pool and provider on GCP. These instructions use the GCP console, but you can also use Terraform to configure GCP. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/tree/main/gcp).
+### Add a Workload Identity Pool and Provider
+Google documentation for setting this up can be found here: [Configuring workload identity federation with other identity providers](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers).
+
+Before starting to create the resources, you must enable the APIs mentioned at the start of the [Configure workload Identity federation](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#configure).
+#### Add a Workload Identity Pool
+The following information should be specified:
+* **Name**: Name for the pool, such as `my-tfc-pool`. The name is also used as the pool ID. You can't change the pool ID later.
+
+The following is optional, but may be desired:
+* **Pool ID**: The ID for the pool. This defaults to the name as mentioned above, but can be set to another value.
+* **Description**: Text that describes the purpose of the pool.
+
+You will also want to ensure that the `Enabled Pool` option is set to be enabled before clicking next.
+
+#### Add a Workload Identity Provider
+You must add a workload identity provider to the pool. The following information should be specified:
+* **Provider type**: Must be `OpenID Connect (OIDC)`.
+* **Provider name**: Name for the identity provider, such as `my-tfc-provider`. The name is also used as the provider ID. You can’t change the provider ID later.
+* **Issuer (URL)**: The address of the TFC/E instance, such as https://app.terraform.io
+    * **Important**: make sure this value starts with **https://** and does _not_ have a trailing slash.
+* **Audiences**: This can be left as `Default audience` if you are planning on using the default audience TFC provides.
+    * **Important**: you must select the `Allowed audiences` toggle and set this to the value of `TFC_GCP_WORKLOAD_IDENTITY_AUDIENCE`, if configured.
+* **Provider attributes mapping**: At the minimum this must include `assertion.sub` for the `google.subject` entry. Other mappings can be added for other claims in the identity token to attributes by adding `attribute.[claim name]` on the Google side and `assertion.[claim name]` on the OIDC side of a new mapping.
+* **Attribute Conditions**: Conditions to restrict which identity tokens can authenticate using the workload identity pool, such as `assertion.sub.startsWith(\”organization:my-org:project:my-project:workspace:my-workspace”\)` to restrict access to identity tokens from a specific workspace. See this page in Google documentation for more information on the expression language: [Attribute conditions](https://cloud.google.com/iam/docs/workload-identity-federation#conditions).
+
+!> **Warning**: you should always check, at minimum, the audience and the name of the organization in order to prevent unauthorized access from other Terraform Cloud organizations!
+
+The following is optional, but may be desired:
+* **Provider ID**: The ID for the provider. This defaults to the name as mentioned above, but can be set to another value.
+### Add a Service Account and Permissions
+You must next add a service account and properly configure the permissions.
+#### Create a Service Account
+Google documentation for setting this up can be found here: [Creating a service account for the external workload](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#create_a_service_account_for_the_external_workload).
+
+The following information should be specified:
+* **Service account name**: Name for the service account, such as `tfc-service-account`. The name is also used as the pool ID. You can't change the pool ID later.
+
+The following is optional, but may be desired:
+* **Service account ID**: The ID for the service account. This defaults to the name as mentioned above, but can be set to another value.
+* **Description**: Text that describes the purpose of the service account.
+#### Grant IAM Permissions
+The next step in the setup wizard will allow for granting IAM permissions for the service account. The role that is given to the service account will vary depending on your specific needs and project setup. This should in general be the most minimal set of permissions needed for the service account to properly function.
+#### Grant External Permissions
+Once the service account has been created and granted IAM permissions, you will need to grant access to the service account for the identity pool created above. Google documentation for setting this up can be found here: [Allow the external workload to impersonate the service account](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#allow_the_external_workload_to_impersonate_the_service_account).
+## Configure Terraform Cloud
+You’ll need to set some environment variables in your Terraform Cloud workspace in order to configure Terraform Cloud to authenticate with GCP using dynamic credentials. You can set these as workspace variables, or if you’d like to share one GCP service account across multiple workspaces, you can use a variable set.
+### Required Environment Variables
+| Variable                            | Value                                                       | Notes                                                                                          |
+|-------------------------------------|-------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `TFC_GCP_PROVIDER_AUTH`             | `true`                                                      | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate to GCP. |
+| `TFC_GCP_RUN_SERVICE_ACCOUNT_EMAIL` | The service account email used when authenticating to GCP.  ||
+| `TFC_GCP_PROJECT_NUMBER`            | The project number where the pool and other resources live. | This is _not_ the project ID and is a separate number.                                         |
+| `TFC_GCP_WORKLOAD_POOL_ID`          | The workload pool ID.                                       ||
+| `TFC_GCP_WORKLOAD_PROVIDER_ID`      | The workload identity provider ID.                          ||
+
+### Optional Environment Variables
+You may need to set these variables, depending on your use case.
+
+| Variable                              | Value                                                                                                                                                                                                                                                       | Notes                                                                               |
+|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| `TFC_GCP_WORKLOAD_IDENTITY_AUDIENCE`  | Will be used as the `aud` claim for the identity token. Defaults to a string of the form mentioned [here](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#oidc_1) in the GCP docs with the leading **https:** stripped. | This is one of the default `aud` formats that GCP accepts.                          |
+| `TFC_GCP_PLAN_SERVICE_ACCOUNT_EMAIL`  | The service account email to use for the plan phase of a run.                                                                                                                                                                                               | Will fall back to the value of `TFC_GCP_RUN_SERVICE_ACCOUNT_EMAIL` if not provided. |
+| `TFC_GCP_APPLY_SERVICE_ACCOUNT_EMAIL` | The service account email to use for the apply phase of a run.                                                                                                                                                                                              | Will fall back to the value of `TFC_GCP_RUN_SERVICE_ACCOUNT_EMAIL` if not provided. |
+
+## Configure the GCP Provider
+Make sure that you’re passing values for the `project` and `region` arguments into the provider configuration block.
+
+Make sure that you’re not setting values for the `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS` environment variables as these will conflict with the dynamic credentials authentication process.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/index.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/index.mdx
@@ -1,0 +1,42 @@
+---
+page_title: Dynamic Provider Credentials - Workspaces - Terraform Cloud
+description: >-
+  Dynamic provider credentials improve security by generating temporary credentials
+  for Terraform Cloud runs. Configure dynamic credentials for the Vault, AWS, Azure,
+  and GCP providers.
+---
+
+# Dynamic Provider Credentials
+
+-> **Note:** Dynamic Credentials are in beta.
+
+~> **Important:** If using self-managed agents, make sure you’re using **v1.5.0-rc.2** or later.
+
+Using static credentials in your workspaces to authenticate providers presents a security risk, even if you rotate your credentials regularly. Dynamic provider credentials improve your security posture by letting you provision new, temporary credentials for each run.
+
+You can configure dynamic credentials for each Terraform Cloud workspace. This workflow eliminates the need to manually manage and rotate credentials across your organization. It also lets you use the cloud platform’s authentication and authorization tools to scope permissions based on metadata, such as a run’s phase, its workspace, or its organization.
+
+## How Dynamic Credentials Work
+
+You configure a trust relationship between your cloud platform and Terraform Cloud. As part of that process, you can define rules that let Terraform Cloud workspaces and runs access specific resources. Then, the following process occurs for each Terraform plan and apply:
+1. Terraform Cloud generates a [workload identity token](/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens). The token is compliant with OpenID Connect protocol (OIDC) standards and includes information about the organization, workspace, and run stage.
+2. When a plan or apply begins, Terraform Cloud sends the workload identity token to the cloud platform, along with any other information needed to authenticate.
+3. The cloud platform uses Terraform Cloud’s public signing key to verify the workload identity token.
+4. If verification succeeds, the cloud platform returns a set of fresh temporary credentials for Terraform Cloud to use.
+5. Terraform Cloud sets up these credentials within the run environment for the Terraform provider to use.
+6. The Terraform plan or apply proceeds.
+7. When the plan or apply completes, the run environment is torn down and the temporary credentials are discarded.
+
+## Configure Dynamic Credentials
+
+Using dynamic credentials in a workspace requires the following steps for each cloud platform:
+
+1. **Set up a Trust Relationship:** You must configure a relationship between Terraform Cloud and the other cloud platform. The exact details of this process will be different depending on the cloud platform.
+2. **Configure Cloud Platform Access:** You must configure roles and policies for the cloud platform to define the workspace’s access to infrastructure resources.
+3. **Configure Terraform Cloud Workspace**: You must add specific environment variables to your workspace to tell Terraform Cloud how to authenticate to the other cloud platform during plans and applies. Each cloud platform has its own set of environment variables to configure dynamic credentials.
+
+The process for each step is different for each cloud platform. Refer to the cloud platform configuration instructions for full details. You can configure dynamic credentials for the following platforms:
+- [Vault](/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration)
+- [Amazon Web Services](/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration)
+- [Azure](/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration)
+- [Google Cloud Platform](/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration)

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -1,0 +1,25 @@
+---
+page_title: Manually Generating Workload Identity Tokens - Workspaces - Terraform Cloud
+description: >-
+  Manually generating workload identity tokens for use in your Terraform Cloud runs.
+---
+
+# Manually Generating Workload Identity Tokens
+
+-> **Note:** Dynamic Credentials are in beta.
+
+~> **Important:** Make sure your agents are running version **v1.5.0-rc.2** or later.
+
+If required for custom auth workflows or to perform auth with providers that are not natively supported by dynamic credentials, you can request that Terraform Cloud inject a [workload identity token](/workspaces/dynamic-provider-credentials/workload-identity) into the run environment for usage in agent hooks.
+## Configure Terraform Cloud
+### Required Environment Variables
+You’ll need to set the following environment variable in your Terraform Cloud workspace in order to have Terraform Cloud inject a workload identity token into the run environment. You can set this as a workspace variable, or if you’d like to inject tokens with the same audience value across multiple workspaces, you can use a variable set.
+
+| Variable                         | Value                                       | Notes                                                                                                          |
+|----------------------------------|---------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| `TFC_WORKLOAD_IDENTITY_AUDIENCE` | The desired value for the token’s audience. | Must be present and set or Terraform Cloud will not inject a workload identity token into the run environment. |
+
+## Configure Agent Hooks
+After you've set the `TFC_WORKLOAD_IDENTITY_AUDIENCE` variable, each plan and apply will have a `TFC_WORKLOAD_IDENTITY_TOKEN` variable available in the run environment, which contains a [workload identity token](/workspaces/dynamic-provider-credentials/workload-identity).
+
+You can use this environment variable in custom agent hooks to enable custom auth workflows or to perform auth with providers which are not natively supported by dynamic credentials.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -1,0 +1,132 @@
+---
+page_title: Dynamic Credentials with the Vault Provider - Workspaces - Terraform Cloud
+description: >-
+  Use OpenID Connect to get short-term credentials for the Vault Terraform provider in
+  your Terraform Cloud runs.
+---
+
+# Dynamic Credentials with the Vault Provider
+
+-> **Note:** Dynamic Credentials are in beta.
+
+~> **Important:** If using self-managed agents, make sure you’re using **v1.5.0-rc.2** or later.
+
+You can use Terraform Cloud’s native OpenID Connect integration with Vault to get [dynamic credentials](/cloud-docs/workspaces/dynamic-provider-credentials) for the Vault provider in your Terraform Cloud runs. Configuring the integration requires the following steps.
+
+1. **[Configure Vault](#configure-vault):** Set up a trust configuration between Vault and Terraform Cloud. Then, you must create Vault roles and policies for your Terraform Cloud workspaces.
+2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.
+
+Once you complete the setup, Terraform Cloud automatically authenticates to Vault during each run. The Vault provider authentication is valid for the length of the plan or apply. Vault does not revoke authentication until the run is complete.
+
+## Configure Vault
+You must enable and configure the JWT backend in Vault. These instructions use the Vault CLI commands, but you can also use Terraform to configure Vault. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-workload-identity-setup-examples/tree/main/vault).
+### Enable the JWT Auth Backend
+Run the following command to enable the JWT auth backend in Vault:
+```shell
+vault auth enable jwt
+```
+### Configure Trust with Terraform Cloud
+You must configure Vault to trust Terraform Cloud’s identity tokens and verify them using Terraform Cloud’s public key. The following command configures the `jwt` auth backend in Vault to trust Terraform Cloud as an OIDC identity provider:
+```shell
+vault write auth/jwt/config \
+    oidc_discovery_url="https://app.terraform.io" \
+    bound_issuer="https://app.terraform.io"
+```
+The `oidc_discovery_url` and `bound_issuer` should both be the root address of Terraform Cloud, including the scheme and without a trailing slash.
+
+### Create a Vault Policy
+
+You must create a Vault policy that controls what paths and secrets your Terraform Cloud workspace can access in Vault.
+Create a file called tfc-policy.hcl with the following content:
+```hcl
+# Allow tokens to query themselves
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}
+
+# Allow tokens to renew themselves
+path "auth/token/renew-self" {
+    capabilities = ["update"]
+}
+
+# Allow tokens to revoke themselves
+path "auth/token/revoke-self" {
+    capabilities = ["update"]
+}
+
+# Configure the actual secrets the token should have access to
+path "secret/*" {
+  capabilities = ["read"]
+}
+```
+
+Then create the policy in Vault:
+
+```shell
+vault policy write tfc-policy tfc-policy.hcl
+```
+
+### Create a JWT Auth Role
+Create a Vault role that Terraform Cloud can use when authenticating to Vault.
+
+Vault offers a lot of flexibility in determining how to map roles and permissions in Vault to workspaces in Terraform Cloud. You can have one role for each workspace, one role for a group of workspaces, or one role for all workspaces in an organization. You can also configure different roles for the plan and apply phases of a run.
+
+The following example creates a role called `tfc-role`. The role is mapped to a single workspace and Terraform Cloud can use it for both plan and apply runs.
+
+Create a file called `vault-jwt-auth-role.json` with the following content:
+```json
+{
+  "policies": ["tfc-policy"],
+  "bound_audiences": ["vault.workload.identity"],
+  "bound_claims_type": "glob",
+  "bound_claims": {
+    "sub":
+"organization:my-org-name:project:my-project-name:workspace:my-workspace-name:run_phase:*"
+  },
+  "user_claim": "terraform_full_workspace",
+  "role_type": "jwt",
+  "token_ttl": "20m"
+}
+```
+
+Then run the following command to create a role named `tfc-role` with this configuration in Vault:
+```shell
+vault write auth/jwt/role/tfc-role @vault-jwt-auth-role.json
+```
+To understand all the available options for matching bound claims, refer to the [Terraform workload identity claim specification](/cloud-docs/workspaces/dynamic-provider-credentials) and the [Vault documentation on configuring bound claims](https://developer.hashicorp.com/vault/docs/auth/jwt#bound-claims). To understand all the options available when configuring Vault JWT auth roles, refer to the [Vault API documentation](https://developer.hashicorp.com/vault/api-docs/auth/jwt#create-role).
+
+!> **Warning:** you should always check, at minimum, the audience and the name of the organization in order to prevent unauthorized access from other Terraform Cloud organizations!
+
+#### Token TTLs
+We recommend setting token_ttl to a relatively short value. Terraform Cloud can renew the token periodically until the plan or apply is complete, then revoke it to prevent it from being used further.
+
+## Configure Terraform Cloud
+You’ll need to set some environment variables in your Terraform Cloud workspace in order to configure Terraform Cloud to authenticate with Vault using dynamic credentials. You can set these as workspace variables, or if you’d like to share one Vault role across multiple workspaces, you can use a variable set.
+
+### Required Environment Variables
+| Variable                  | Value                                                                           | Notes                                                                                            |
+|---------------------------|---------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| `TFC_VAULT_PROVIDER_AUTH` | `true`                                                                          | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate to Vault. |
+| `TFC_VAULT_ADDR`          | The address of the Vault instance to authenticate against.                      | Will also be used to set `VAULT_ADDR` in the run environment.                                    |
+| `TFC_VAULT_RUN_ROLE`      | The name of the Vault role to authenticate against (`tfc-role`, in our example) ||
+
+### Optional Environment Variables
+You may need to set these variables, depending on your Vault configuration and use case.
+
+| Variable                               | Value                                                                                          | Notes                                                                |
+|----------------------------------------|------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `TFC_VAULT_NAMESPACE`                  | The namespace to use when authenticating to Vault.                                             | Will also be used to set `VAULT_NAMESPACE` in the run environment.   |
+| `TFC_VAULT_AUTH_PATH`                  | The path where the JWT auth backend is mounted in Vault. Defaults to jwt.                      ||
+| `TFC_VAULT_WORKLOAD_IDENTITY_AUDIENCE` | Will be used as the `aud` claim for the identity token. Defaults to `vault.workload.identity`. | Must match the `bound_audiences` configured for the role in Vault.   |
+| `TFC_VAULT_PLAN_ROLE`                  | The Vault role to use for the plan phase of a run.                                             | Will fall back to the value of `TFC_VAULT_RUN_ROLE` if not provided. |
+| `TFC_VAULT_APPLY_ROLE`                 | The Vault role to use for the apply phase of a run.                                            | Will fall back to the value of `TFC_VAULT_RUN_ROLE` if not provided. |
+
+## Vault Provider Configuration
+Once you set up dynamic credentials for a workspace, Terraform Cloud automatically authenticates to Vault for each run. Do not pass the `address`, `token`, or `namespace` arguments into the provider configuration block. Terraform Cloud sets these values as environment variables in the run environment.
+
+You can use the Vault provider to read secrets from Vault and use them with other Terraform resources. You can also access the other resources and data sources available in the [Vault provider documentation](https://registry.terraform.io/providers/hashicorp/vault/latest). You must adjust your [Vault policy](#create-a-vault-policy) to give your Terraform Cloud workspace access to all required Vault paths.
+
+### Vault Dynamic Secrets Engines
+You **cannot** access Vault’s dynamic secrets engines via the Vault provider’s dynamic secrets data sources (such as `[vault_aws_access_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/aws_access_credentials)`) when using this integration.
+
+This is because data sources in Terraform Cloud are read only once, during the plan, and the results are passed to the apply using a [plan output file](https://developer.hashicorp.com/terraform/cli/commands/plan#out-filename). When the plan’s Vault token is revoked, any dynamic secrets issued using that token are revoked as well, so they’ll be invalid when the apply runs.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens.mdx
@@ -1,0 +1,84 @@
+---
+page_title: Workload Identity - Workspaces - Terraform Cloud
+description: >-
+  Workload Identity uses OpenID Connect (OIDC) to allow Terraform plans and applies
+  to safely authenticate to external systems.
+---
+
+# Workload Identity
+Dynamic Provider Credentials are powered by Terraform Workload Identity, which allows Terraform Cloud to present information about a Terraform workload to an external system – like its workspace, organization, or whether it’s a plan or apply – and allows other external systems to verify that the information is accurate.
+
+You can think of it like an identity card for your Terraform runs: one that comes with a way for another system to easily verify whether the card is genuine. If the other system can confirm that the ID card is legitimate, it can trust the information the card contains and use it to decide whether to let that Terraform workload in the door.
+
+The “identity card” in this analogy is a workload identity token: a JSON Web Token (JWT) that contains information about a plan or apply, is signed by Terraform Cloud’s private key, and expires at the end of the plan or apply timeout. Other systems can use Terraform Cloud’s [public key](https://app.terraform.io/.well-known/jwks) to verify that a token that claims to be from Terraform Cloud is genuine and has not been tampered with.
+
+This workflow is built on the [OpenID Connect protocol](https://openid.net/connect/), a trusted standard for verifying identity across different systems.
+## Token Specification
+Workload identity tokens contain useful metadata in their payloads, known as _claims_. This is the equivalent of the name and date of birth on an identity card. Once a cloud platform verifies a token using Terraform Cloud’s public key, it can look at the claims in the identity token to either match it to the correct permissions or reject it.
+
+You don’t need to understand the full token specification and what every claim means in order to use dynamic credentials, but it’s useful for debugging.
+### Token Structure
+The following example shows a decoded Terraform Cloud workload identity token:
+#### Header
+```json
+{
+  "typ": "JWT",
+  "alg": "RS256",
+  "kid": "j-fFp9evPJAzV5I2_58HY5UvdCK6Q4LLB1rnPOUfQAk"
+}
+```
+#### Payload
+```json
+{
+  "jti": "1192426d-b525-4fde-9d42-f238be437bbd",
+  "iss": "https://app.terraform.io",
+  "aud": "my-example-audience",
+  "iat": 1650486122,
+  "nbf": 1650486117,
+  "exp": 1650486422,
+  "sub": "organization:my-org:project:Default Project:workspace:my-workspace:run_phase:apply",
+  "terraform_organization_id": "org-GRNbCjYNpBB6NEH9",
+  "terraform_organization_name": "my-org",
+  "terraform_project_id": "prj-vegSA59s1XPwMr2t",
+  "terraform_project_name": "Default Project",
+  "terraform_workspace_id": "ws-mbsd5E3Ktt5Rg2Xm",
+  "terraform_workspace_name": "my-workspace",
+  "terraform_full_workspace": "organization:my-org:project:Default Project:workspace:my-workspace",
+  "terraform_run_id": "run-X3n1AUXNGWbfECsJ",
+  "terraform_run_phase": "apply"
+}
+```
+This payload includes a number of standard claims defined in the OIDC spec as well as a number of custom claims for further customization.
+### Standard Claims
+| Claim              | Value                                                                                                                                                                                |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `jti` (JWT ID)     | A unique identifier for each JWT.                                                                                                                                                    |
+| `iss` (issuer)     | Full URL of Terraform Cloud or the TFE instance which signed the JWT.                                                                                                                |
+| `iat` (issued at)  | Unix Timestamp when the JWT was issued. May be required by certain relying parties.                                                                                                  |
+| `nbf` (not before) | Unix Timestamp when the JWT can start being used. This will be the same as iat for tokens issued by Terraform Cloud, but may be required by certain relying parties.                 |
+| `aud` (audience)   | Intended audience for the JWT. For example, `aws.workload.identity` for AWS. This can be customized.                                                                                 |
+| `exp` (expiration) | Unix Timestamp based on the timeout of the run phase that it was issued for. This will follow the `plan` and `apply` timeouts set at the organization and site admin level.          |
+| `sub` (subject)    | Fully qualified path to a workspace, followed by the run phase. For example: `organization:my-organization-name:project:Default Project:workspace:my-workspace-name:run_phase:apply` |
+
+### Custom Claims
+
+| Claim                                                  | Value                                                                                                                                                         |
+|--------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `terraform_organization_id` (organization ID)          | ID of the Terraform Cloud organization performing the run.                                                                                                    |
+| `terraform_organization_name` (organization name)      | Human-readable name of the Terraform Cloud organization performing the run. Note that organization names can be changed.                                      |
+| `terraform_project_id` (project ID)                    | ID of the Terraform Cloud project performing the run.                                                                                                         |
+| `terraform_project_name` (project name)                | Human-readable name of the Terraform Cloud project performing the run. Note that project names can be changed. The default project name is `Default Project`. |
+| `terraform_workspace_id` (workspace ID)                | ID of the Terraform Cloud workspace performing the run.                                                                                                       |
+| `terraform_workspace_name` (workspace name)            | Human-readable name of the Terraform Cloud workspace performing the run. Note that workspace names can be changed.                                            |
+| `terraform_full_workspace` (fully qualified workspace) | Fully qualified path to a workspace. For example: `organization:my-organization-name:project:my-project-name:workspace:my-workspace-name`                     |
+| `terraform_run_id` (run ID)                            | ID of the run that the token was generated for. This is intended to aid in traceability and logging.                                                          |
+| `terraform_run_phase` (run phase)                      | The phase of the run this token was issued for. For example, `plan` or `apply`                                                                                |
+
+### Configuring Trust with your Cloud Platform
+When configuring the trust relationship between Terraform Cloud and your cloud platform, you’ll set up conditions to validate the contents of the identity token provided by Terraform Cloud against your roles and policies.
+
+At the minimum, you should match against the following claims:
+* `aud` - the audience value of the token. This ensures that, for example, a workload identity token intended for AWS can’t be used to authenticate to Vault.
+* `sub` - the subject value, which includes the organization and workspace performing the run. If you don’t match against at least the organization name, any organization or workspace on Terraform Cloud will be able to access your cloud resources!
+
+You can match on as many claims as you want, depending on your cloud platform.

--- a/website/docs/cloud-docs/workspaces/variables/index.mdx
+++ b/website/docs/cloud-docs/workspaces/variables/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Variables
 
-Terraform Cloud workspace variables let you customize configurations, modify Terraform's behavior, and store information like provider credentials.
+Terraform Cloud workspace variables let you customize configurations, modify Terraform's behavior, setup [dynamic provider credentials](/cloud-docs/workspaces/dynamic-provider-credentials), and store information like static provider credentials.
 
 You can set variables specifically for each workspace or you can create variable sets to reuse the same variables across multiple workspaces. For example, you could define a variable set of provider credentials and automatically apply it to all of the workspaces using that provider. You can use the command line to specify variable values for each plan or apply. Otherwise, Terraform Cloud applies workspace variables to all runs within that workspace.
 
@@ -30,6 +30,14 @@ Environment variables can store provider credentials and other data. Refer to yo
 You can use the `TFE_PARALLELISM` environment variable when your infrastructure providers produce errors on concurrent operations or use non-standard rate limiting. The `TFE_PARALLELISM` variable sets the  `-parallelism=<N>` flag for  `terraform plan` and `terraform apply`  ([more about `parallelism`](/internals/graph#walking-the-graph)). Valid values are between 1 and 256, inclusive, and the default is `10`. Terraform Cloud Agents do not support `TFE_PARALLELISM`, but you can specify flags as environment variables directly via [`TF_CLI_ARGS_name`](/cli/config/environment-variables#tf-cli-args). In these cases, use `TF_CLI_ARGS_plan="-parallelism=<N>"` or `TF_CLI_ARGS_apply="-parallelism=<N>"` instead.
 
 !> **Warning:** We recommend talking to HashiCorp support before setting `TFE_PARALLELISM`.
+
+#### Dynamic Credentials
+
+-> **Note:** Dynamic Credentials are in beta.
+
+You can configure [dynamic credentials](/cloud-docs/workspaces/dynamic-provider-credentials) for certain providers using environment variables [at the workspace level](/cloud-docs/workspaces/variables/managing-variables#workspace-specific-variables) or using [variable sets](/cloud-docs/workspaces/variables/managing-variables#variable-sets).
+
+Dynamic credentials allows for using temporary per-run credentials and eliminates the need to manually rotate secrets.
 
 ### Terraform Variables
 

--- a/website/docs/cloud-docs/workspaces/variables/managing-variables.mdx
+++ b/website/docs/cloud-docs/workspaces/variables/managing-variables.mdx
@@ -160,6 +160,12 @@ We also recommend passing credentials to Terraform as environment variables inst
 
 Although Terraform cloud does not store environment variables in state, it can include them in log files if `TF_LOG` is set to `TRACE`.
 
+#### Dynamic Credentials
+
+An alternative to passing static credentials for some providers is to use [dynamic credentials](/cloud-docs/workspaces/dynamic-provider-credentials).
+
+Dynamic credentials allows for using temporary per-run credentials and eliminates the need to manually rotate secrets.
+
 ### Character Limits
 
 The following limits apply to variables:


### PR DESCRIPTION
### What
Adds documentation for dynamic provider credentials in Terraform Cloud

### Why
This change describes the new dynamic provider credentials functionality that is being released in public beta for Terraform Cloud and provides guidance on setup for Vault / AWS / GCP / Azure.

### Links
- [JIRA](https://hashicorp.atlassian.net/browse/TF-3679)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
