### PR TITLE
Add new testing path to plugin data json

### DIFF
--- a/website/data/plugin-nav-data.json
+++ b/website/data/plugin-nav-data.json
@@ -35,5 +35,6 @@
   { "title": "SDKv2", "href": "sdkv2" },
   { "title": "Framework", "href": "framework" },
   { "title": "Logging", "href": "log" },
-  { "title": "Combining and Translating", "href": "mux" }
+  { "title": "Combining and Translating", "href": "mux" },
+  { "title": "Testing", "href": "testing" }
 ]


### PR DESCRIPTION
### What
DevEx team requesting a new source content repository for [terraform-plugin-testing](https://github.com/hashicorp/terraform-plugin-testing). The website code was merged with complete nav data, but it wan't reflected in the site. This PR adds the new `testing` path to the nav data.

[Asana](https://app.asana.com/0/1100423001970639/1203790804633686)
[Slack Thread](https://hashicorp.slack.com/archives/C03BX0MJD27/p1669665303717709)
[New Docs](https://developer.hashicorp.com/terraform/plugin/testing)

### Why
To create visibility into new testing plugin docs

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [X] Description links to related pull requests or issues, if any.

#### Content
- [ ] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] (N/A) API documentation and the API Changelog have been updated. 
- [X] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] (N/A) Pages with related content are updated and link to this content when appropriate.
- [X] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [X] New pages have metadata (page name and description) at the top.
- [X] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] (N/A) The Vercel website preview successfully deployed.

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
- [X] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
