### PR TITLE
Update the steps for obtaining the Okta metadata URL

### DIFF
--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/okta.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/okta.mdx
@@ -23,7 +23,8 @@ For more information on the listed features, visit the [Okta Glossary](https://h
 1. Choose a label for your application or keep the default, "Terraform Cloud".
 1. Click "Done".
 1. Visit the "Sign On" tab in the application.
-1. Copy the "Identity Provider Metadata" URL.
+1. Click "View SAML setup instructions" under "SAML Setup".
+1. Copy the "Okta Metadata URL" URL under step 4.
 
 For information on configuring automated team mapping using Okta group membership, please see the [Team Mapping Configuration (Okta)](#team-mapping-configuration-okta-) section below.
 


### PR DESCRIPTION
### What
This updates the Terraform Cloud Okta SAML instructions to point out more explicitly where the Okta metadata URL can be obtained.

### Why
It could provide some confusion for users, as the documentation suggests this is in the settings shown directly under the **Sign On** tab.

### Screenshots

<img width="794" alt="Screen Shot 2023-02-03 at 8 36 33 AM" src="https://user-images.githubusercontent.com/54044423/216619582-45adfc59-29e5-4717-a375-5a6e4ce30b76.png">

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
