### PR TITLE
Update documentation regarding no longer processing duplicate webhooks.

### DIFF
--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -31,7 +31,7 @@ A workspace is linked to one branch of a VCS repository and ignores changes to o
 
 -> **Note:** A workspace with no runs will not accept new runs via VCS webhook. At least one run must be manually queued to confirm that the workspace is ready for further runs.
 
--> **Note:** A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If workspace receives a webhook with a previously processed commit, a new event is added to the [VCS events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
+-> **Note:** A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If a workspace receives a webhook with a previously processed commit, a new event will be added to the [VCS Events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
 
 ## Manually Starting Runs
 

--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -31,6 +31,8 @@ A workspace is linked to one branch of a VCS repository and ignores changes to o
 
 -> **Note:** A workspace with no runs will not accept new runs via VCS webhook. At least one run must be manually queued to confirm that the workspace is ready for further runs.
 
+-> **Note:** A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If workspace receives a webhook with a previously processed commit, a new event is added to the [VCS events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
+
 ## Manually Starting Runs
 
 When you initially set up the workspace and add variables, or when the code in version control hasn't changed but you've modified some variables, you can manually start a run from the UI. Each workspace has an "Actions" menu in its header, which includes a "Start new plan" action for this purpose. When creating a new plan, you can optionally provide a message and can choose between normal and [refresh-only](/cloud-docs/run/modes-and-options#refresh-only-mode) modes.

--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -31,7 +31,7 @@ A workspace is linked to one branch of a VCS repository and ignores changes to o
 
 -> **Note:** A workspace with no runs will not accept new runs via VCS webhook. At least one run must be manually queued to confirm that the workspace is ready for further runs.
 
--> **Note:** A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If a workspace receives a webhook with a previously processed commit, a new event will be added to the [VCS Events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
+A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If a workspace receives a webhook with a previously processed commit, Terraform Cloud will add a new event to the [VCS Events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
 
 ## Manually Starting Runs
 

--- a/website/docs/cloud-docs/vcs/index.mdx
+++ b/website/docs/cloud-docs/vcs/index.mdx
@@ -56,7 +56,7 @@ To use configurations from VCS, Terraform Cloud needs to do several things:
 
 Terraform Cloud uses webhooks to monitor new commits and pull requests.
 
-- When someone adds new commits to a branch, any Terraform Cloud workspaces based on that branch will begin a Terraform run. Usually a user must inspect the plan output and approve an apply, but you can also enable automatic applies on a per-workspace basis. You can prevent automatic runs by locking a workspace.
+- When someone adds new commits to a branch, any Terraform Cloud workspaces based on that branch will begin a Terraform run. Usually a user must inspect the plan output and approve an apply, but you can also enable automatic applies on a per-workspace basis. You can prevent automatic runs by locking a workspace. A run will only occur if the workspace has not previously processed a run for the commit SHA.
 - When someone submits a pull request/merge request to a branch, any Terraform Cloud workspaces based on that branch will perform a [speculative plan](/cloud-docs/run/remote-operations#speculative-plans) with the contents of the request and links to the results on the PR's page. This helps you avoid merging PRs that cause plan failures.
 
 ~> **Important:** In Terraform Enterprise, integration with a SaaS VCS provider (GitHub.com, GitLab.com, Bitbucket Cloud, or Azure DevOps Services) requires ingress from the public internet. This lets the inbound web hooks reach Terraform Enterprise. You should also configure appropriate security controls, such as a Web Application Firewall (WAF).
@@ -108,9 +108,7 @@ For complete details, click the link for your VCS provider:
 
 ## Viewing events
 
--> **Note**: The VCS Event Viewer is still in beta as support is being added for additional VCS providers. Currently only GitLab.com connections established after December 2020 are supported.
-
-VCS events describe changes within your organization for VCS-related actions, such as creating a new VCS provider (also called an OAuth Client), loading repositories while creating a new workspace, or processing incoming webhooks. Displayed events are limited to the past 10 days.
+VCS events describe changes within your organization for VCS-related actions, such as when a webhook is received with a previously processed commit SHA. Displayed events are limited to the past 30 days.
 
 Viewing VCS events requires permission to manage VCS settings for the organization. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions))
 

--- a/website/docs/cloud-docs/vcs/index.mdx
+++ b/website/docs/cloud-docs/vcs/index.mdx
@@ -108,7 +108,7 @@ For complete details, click the link for your VCS provider:
 
 ## Viewing events
 
-VCS events describe changes within your organization for VCS-related actions, such as when a webhook is received with a previously processed commit SHA. Displayed events are limited to the past 30 days.
+VCS events describe changes within your organization for VCS-related actions, such as when Terraform Cloud receives a webhook with a previously processed commit SHA. The VCS events page only displays events from the past 30 days.
 
 Viewing VCS events requires permission to manage VCS settings for the organization. ([More about permissions.](/cloud-docs/users-teams-organizations/permissions))
 

--- a/website/docs/cloud-docs/vcs/troubleshooting.mdx
+++ b/website/docs/cloud-docs/vcs/troubleshooting.mdx
@@ -87,7 +87,7 @@ The fix is to update the OAuth Callback URL in your VCS provider to use app.terr
 
 A workspace with no runs will not accept new runs from a VCS webhook. You must queue at least one run manually.
 
-A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If workspace receives a webhook with a previously processed commit, a new event is added to the [VCS events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
+A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If a workspace receives a webhook with a previously processed commit, a new event will be added to the [VCS Events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
 
 ### Changing the URL for a VCS provider
 

--- a/website/docs/cloud-docs/vcs/troubleshooting.mdx
+++ b/website/docs/cloud-docs/vcs/troubleshooting.mdx
@@ -87,6 +87,8 @@ The fix is to update the OAuth Callback URL in your VCS provider to use app.terr
 
 A workspace with no runs will not accept new runs from a VCS webhook. You must queue at least one run manually.
 
+A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If workspace receives a webhook with a previously processed commit, a new event is added to the [VCS events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
+
 ### Changing the URL for a VCS provider
 
 On rare occasions, you might need Terraform Cloud to change the URL it uses to reach your VCS provider. This usually only happens if you move your VCS server or the VCS vendor changes their supported API versions.

--- a/website/docs/cloud-docs/vcs/troubleshooting.mdx
+++ b/website/docs/cloud-docs/vcs/troubleshooting.mdx
@@ -87,7 +87,7 @@ The fix is to update the OAuth Callback URL in your VCS provider to use app.terr
 
 A workspace with no runs will not accept new runs from a VCS webhook. You must queue at least one run manually.
 
-A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If a workspace receives a webhook with a previously processed commit, a new event will be added to the [VCS Events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
+A workspace will not process a webhook if the workspace previously processed a webhook with the same commit SHA and created a run. To trigger a run, create a new commit. If a workspace receives a webhook with a previously processed commit, a Terraform Cloud will add a new event to the [VCS Events](/cloud-docs/vcs#viewing-events) page documenting the received webhook.
 
 ### Changing the URL for a VCS provider
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Added documentation explaining that we do not process webhooks for duplicate commits

Pages changed:
- /terraform/cloud-docs/vcs
- /terraform/cloud-docs/run/ui
- /terraform/cloud-docs/vcs/troubleshooting

Related Atlas PR: https://github.com/hashicorp/atlas/pull/14529

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
This reflects the change in default behavior for no longer processing webhooks for duplicate commit SHA's. Previously, we would process any webhook received even if we processed it in the past, which resulted in customer data loss as a result of an old webhook being processed that removed infrastructure.

### Screenshots
<img width="708" alt="Screen Shot 2023-02-08 at 2 47 31 PM" src="https://user-images.githubusercontent.com/98980386/217668742-e909da76-40b3-42e7-bcfd-46b6e7bf12c1.png">
<img width="738" alt="Screen Shot 2023-02-08 at 2 45 34 PM" src="https://user-images.githubusercontent.com/98980386/217668747-0dfed607-16ca-4e24-a254-f653504b336c.png">
<img width="700" alt="Screen Shot 2023-02-08 at 2 44 21 PM" src="https://user-images.githubusercontent.com/98980386/217668751-bd353f6c-d9b2-40f2-805f-e1f009a69f0f.png">



----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
