### PR TITLE
Add new content for policies and run tasks

### DIFF
--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -107,7 +107,7 @@ It is important to note that the policy-as-code integration in Terraform Cloud s
 ### Malicious or Insecure Third-Party Run Tasks
 Terraform [Run Tasks](https://developer.hashicorp.com/terraform/cloud-docs/integrations/run-tasks) are provided with access to all Terraform configuration and plan data. Terraform Cloud does not have the capability to prevent malicious Run Tasks from potentially exfiltrating sensitive data that may be present in either the Terraform configuration or plan.
 
-In order to minimize potential security risks, it is highly recommended to only utilize trusted technology partners for Run Tasks within your Terraform organization and limit the number of users who have been assigned the "manage run tasks" permission.
+In order to minimize potential security risks, it is highly recommended to only utilize trusted technology partners for Run Tasks within your Terraform organization and limit the number of users who have been assigned the [Manage Run Tasks](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/permissions#manage-run-tasks) permission.
 
 ### Access to Sensitive Variables or State from Terraform Operations
 

--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -99,11 +99,15 @@ Commits and pull requests to connected VCS repositories will trigger a plan oper
 
 Terraform providers and modules used in your Terraform configuration will have full access to the variables and Terraform state within a workspace. Terraform Cloud cannot prevent malicious providers and modules from exfiltrating this sensitive data. We recommend only using trusted modules and providers within your Terraform configuration.
 
-### Malicious Bypasses of Sentinel Policies
+### Malicious Bypasses of Terraform Policies
+The policy-as-code frameworks used by the Terraform [Policy Enforcement](https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement) feature are embedded within Terraform Cloud and can be used to ensure the infrastructure provisioned using Terraform complies with defined organizational policies. The goal of this feature is to enforce compliance with organizational policies and best practices when provisioning infrastructure using Terraform.
 
-[Sentinel](https://www.hashicorp.com/sentinel) is an embedded policy-as-code framework integrated with the HashiCorp Enterprise products. You can create Sentinel policies to ensure the infrastructure provisioned by Terraform is compliant with a set of policies defined by your organization.
+It is important to note that the policy-as-code integration in Terraform Cloud should be viewed as a guide or set of guardrails, not a security boundary. It is not designed to prevent malicious actors from executing malicious Terraform configurations or modifying infrastructure.
 
-Sentinel aims to prevent well-intentioned operators from writing configurations that violate organizational policies or best practices. It is not intended to be used as a security boundary that prevents malicious actors from executing malicious Terraform configuration, or modifying Terraform-provisioned infrastructure. Think of Sentinel as guard rails, not a locked door.
+### Malicious or Insecure Third-Party Run Tasks
+Terraform [Run Tasks](https://developer.hashicorp.com/terraform/cloud-docs/integrations/run-tasks) are provided with access to all Terraform configuration and plan data. Terraform Cloud does not have the capability to prevent malicious Run Tasks from potentially exfiltrating sensitive data that may be present in either the Terraform configuration or plan.
+
+In order to minimize potential security risks, it is highly recommended to only utilize trusted technology partners for Run Tasks within your Terraform organization and limit the number of users who have been assigned the "manage run tasks" permission.
 
 ### Access to Sensitive Variables or State from Terraform Operations
 


### PR DESCRIPTION
### What
Updated the docs for the Terraform security model to include a new section for the Run Tasks integration. I've also updated the policies section to call out the risks for policies as a whole and not specifically Sentinel. 

### Why
Run Tasks have been missing from the docs since the initial release date of the Run Tasks feature and need to be included in the security model. The policy as code workflow has changed recently to include support for Native Open Policy Agent and the docs need to reflect this change. 

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] N/A Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] N/A API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] N/A New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
