### PR TITLE
Update provider publishing docs with goreleaser to use `--clean` flag

### DIFF
--- a/website/docs/registry/providers/publishing.mdx
+++ b/website/docs/registry/providers/publishing.mdx
@@ -99,7 +99,7 @@ GoReleaser is a tool for building Go projects for multiple platforms, creating a
 1. Set your `GITHUB_TOKEN` to a [Personal Access Token](https://github.com/settings/tokens/new?scopes=public_repo) that has the **public_repo** scope.
 1. Ensure there is not a branch name with the expected version tag name (e.g. `v1.2.3`).
 1. Tag your version with `git tag v1.2.3` and push your tags to GitHub.
-1. Build, sign, and upload your release with `goreleaser release --rm-dist`.
+1. Build, sign, and upload your release with `goreleaser release --clean`.
 
 -> GoReleaser does not support signing binaries with a GPG key that requires a passphrase. Some systems may cache your GPG passphrase for a few minutes. If you are unable to cache the passphrase for GoReleaser, please use the manual release preparation process below, or remove the signature step from GoReleaser and sign it prior to moving the GitHub release from draft to published.
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
- Updated `Terraform Registry - Publishing Providers` page's goreleaser instructions with new flag

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
- Goreleaser version [1.15.0](https://github.com/goreleaser/goreleaser/releases/tag/v1.15.0) deprecates the `--rm-dist` flag and replaces it with the `--clean` flag
- Similar issue: https://github.com/hashicorp/ghaction-terraform-provider-release/issues/36

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
