### PR TITLE
Call out 500 tag limit in tag filter

### DIFF
--- a/website/docs/cloud-docs/workspaces/index.mdx
+++ b/website/docs/cloud-docs/workspaces/index.mdx
@@ -65,7 +65,7 @@ The following filters are available:
 
 - **Run Status filter buttons:** These filters display workspaces with the selected run status. There are five quick filter buttons that collect the most commonly used groups of statuses: Needs Attention, Errored, Running, On Hold, and Applied.
 
-- **Tag filter:** The tag filter shows a list of tags added to all workspaces. Choosing one or more will show only workspaces tagged with all of the chosen tags.
+- **Tag filter:** The tag filter shows a list of tags added to all workspaces, limited to the first 500 tags alphabetically. Choosing one or more will show only workspaces tagged with all of the chosen tags.
 - **Status filter** - The status filter shows a list of all possible statuses that apply to workspaces. When you choose a status filter, the list will only include workspaces whose current runs match the selected statuses. 
 - **Health filter** - The health filter lists workspaces based on the results of the last health assessment: Drifted, Health error, or Check failed.
 - **Column sorting:** For any columns marked with two arrows, you can click the arrows to change the sort order for the column. You can sort the list by workspace name by alphabetical order, or by the latest change time for the workspace. 


### PR DESCRIPTION
### What
Added a note to the workspace column/filter section mentioning that only 500 tags will be visible in the tags filter.

### Why
This will make it clearer to users with >500 tags why not all tags may be visible in the tags filter.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] (N/A) The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
