### PR TITLE
[TF-1899] Adding on-demand-assessment docs

### DIFF
--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -22,6 +22,9 @@ Working with health assessments requires the following permissions:
 - To view health status for a workspace, you need read access to that workspace.
 - To change organization health settings, you must be an [organization owner](/terraform/cloud-docs/users-teams-organizations/permissions#organization-owners).
 - To change a workspace’s health settings, you must be an [administrator for that workspace](/terraform/cloud-docs/users-teams-organizations/permissions#workspace-admins).
+<!-- BEGIN: TFC:only name:health-assessments -->
+- To trigger [on demand assessments](/terraform/cloud-docs/workspaces/health#on-demand-assessments) for a workspace, you must be an [administrator for that workspace](/terraform/cloud-docs/users-teams-organizations/permissions#workspace-admins).
+<!-- END: TFC:only name:health-assessments -->
 
 ## Workspace Requirements
 
@@ -59,6 +62,18 @@ A health assessment never interrupts or interferes with runs. If you start a new
 Terraform Cloud pauses health assessments if the latest run ended in an errored state. This behavior occurs for all run types, including plan-only runs and speculative plans. Once the workspace completes a successful run, Terraform Cloud restarts health assessments after 24 hours.
 
 Health assessments may take longer to complete when you enable health assessments in many workspaces at once or your workspace contains a complex configuration with many resources.
+
+<!-- BEGIN: TFC:only name:health-assessments -->
+### On Demand Assessments
+
+-> **Note:** On demand assessments are only available in the Terraform Cloud web UI.
+
+If you are an administrator for a workspace and it satisfies all [assessment requirements](/terraform/cloud-docs/workspaces/health#workspace-requirements), you can trigger a new assessment by clicking **Start health assessment** on the workspace's **Health** page.
+
+When you click the **Start health assessment** button, the workspace displays a message in the bottom lefthand corner of the page to indicate if it successfully triggered a new assessment. The time it takes to complete an assessment can vary based on network latency and the number of resources managed by the workspace. 
+
+While an assessment is in progress, you cannot trigger another assessment. And on demand assessment resets the scheduling for automated assessments, so the next automated assessment will run in 24 hours. 
+<!-- END: TFC:only name:health-assessments -->
 
 ### Concurrency
 


### PR DESCRIPTION
### What
 
New feature called On-demand-assessments was introduced for Health pages. 

### Why

This will help users to run Health assessments on demand from the UI. This is only available to workspace administrators.

### Screenshots

![on-demand-assessments](https://user-images.githubusercontent.com/18754820/223837589-b1b66ce6-2951-436d-81b9-8f883f3166f6.png)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
