### PR TITLE
fix link to Provisioning No-Code Infrastructure

### DIFF
--- a/website/docs/cloud-docs/registry/publish-modules.mdx
+++ b/website/docs/cloud-docs/registry/publish-modules.mdx
@@ -68,7 +68,7 @@ To publish a new module:
 
   <!-- BEGIN: TFC:only name:no-code -->
   
-  1.  (Optional) If this module is a [no-code ready module](/terraform/enterprise/no-code-provisioning/module-design), select the **Add Module to no-code provision allowlist** checkbox.
+  1.  (Optional) If this module is a [no-code ready module](/terraform/cloud-docs/no-code-provisioning/module-design), select the **Add Module to no-code provision allowlist** checkbox.
 
   -> **Note:** No-code provisioning is in beta and available in the [Terraform Cloud Business tier](https://www.hashicorp.com/products/terraform/pricing).
 

--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -13,7 +13,7 @@ All users in an organization can view the Terraform Cloud private registry and u
 - **Authentication:** If you run Terraform on the command line, you must [authenticate](/terraform/cloud-docs/registry/using#authentication) to Terraform Cloud or your instance to use providers and modules in your organization’s private registry.
 
 <!-- BEGIN: TFC:only name:no-code -->
-Terraform Cloud supports using modules in written configuration or through the [no-code provisioning workflow](/terraform/enterprise/no-code-provisioning/provisioning).
+Terraform Cloud supports using modules in written configuration or through the [no-code provisioning workflow](/terraform/cloud-docs/no-code-provisioning/provisioning).
 <!-- END: TFC:only name:no-code -->
 
 ## Finding Providers and Modules

--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -38,7 +38,7 @@ Use the **Submodules** menu to navigate to the detail pages for any nested modul
 
 ## Provisioning Infrastructure from No-Code Ready Modules
 
-You can use modules marked **No-Code Ready** to create a new workspace and automatically provision the module's resources without writing any Terraform configuration. Refer to [Provisioning No-Code Infrastructure](/terraform/enterprise/no-code-provisioning/provisioning) for details.
+You can use modules marked **No-Code Ready** to create a new workspace and automatically provision the module's resources without writing any Terraform configuration. Refer to [Provisioning No-Code Infrastructure](/terraform/cloud-docs/no-code-provisioning/provisioning) for details.
 <!-- END: TFC:only name:no-code -->
 
 ## Using Public Providers and Modules in Configurations

--- a/website/docs/cloud-docs/workspaces/creating.mdx
+++ b/website/docs/cloud-docs/workspaces/creating.mdx
@@ -15,7 +15,7 @@ Workspaces organize infrastructure into meaningful groups. Create new workspaces
 - **Workspaces API:** [Create a Workspace endpoint](/terraform/cloud-docs/api-docs/workspaces#create-a-workspace)
 - **Terraform Enterprise Provider:** [`tfe_workspace` resource](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace)
 <!-- BEGIN: TFC:only name:no-code -->
--   **No-Code Provisioning:** The no-code provisioning workflow creates a new workspace and deploys a [no-code ready module's](/terraform/enterprise/no-code-provisioning/provisioning) resources in it.
+-   **No-Code Provisioning:** The no-code provisioning workflow creates a new workspace and deploys a [no-code ready module's](/terraform/cloud-docs/no-code-provisioning/provisioning) resources in it.
 
 <!-- END: TFC:only name:no-code -->
 


### PR DESCRIPTION
### What

This section has broken link: https://developer.hashicorp.com/terraform/cloud-docs/registry/using#provisioning-infrastructure-from-no-code-ready-modules

This PR fixes link to Provisioning No-Code Infra page. It currently points to doc under TFE path which seems wrong.

### Why

So users can find the information they need without hunting through left nav.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
