### PR TITLE
Clarify TFC_AWS_RUN_ROLE_ARN, which is only conditionally mandatory

### DIFF
--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -98,7 +98,7 @@ You’ll need to set some environment variables in your Terraform Cloud workspac
 | Variable                | Value                                               | Notes                                                                                          |
 |-------------------------|-----------------------------------------------------|------------------------------------------------------------------------------------------------|
 | `TFC_AWS_PROVIDER_AUTH` | `true`                                              | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate to AWS. |
-| `TFC_AWS_RUN_ROLE_ARN`  | The arn of the AWS role arn to authenticate against | Optional if using `TFC_AWS_PLAN_ROLE_ARN` and `TFC_AWS_APPLY_ROLE_ARN` is being used; see below” |
+| `TFC_AWS_RUN_ROLE_ARN`  | The arn of the AWS role arn to authenticate against | Optional if using `TFC_AWS_PLAN_ROLE_ARN` and `TFC_AWS_APPLY_ROLE_ARN` is being used; see below |
 
 ### Optional Environment Variables
 You may need to set these variables, depending on your use case.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -98,7 +98,7 @@ You’ll need to set some environment variables in your Terraform Cloud workspac
 | Variable                | Value                                               | Notes                                                                                          |
 |-------------------------|-----------------------------------------------------|------------------------------------------------------------------------------------------------|
 | `TFC_AWS_PROVIDER_AUTH` | `true`                                              | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate to AWS. |
-| `TFC_AWS_RUN_ROLE_ARN`  | The arn of the AWS role arn to authenticate against ||
+| `TFC_AWS_RUN_ROLE_ARN`  | The arn of the AWS role arn to authenticate against | Optional if using `TFC_AWS_PLAN_ROLE_ARN` and `TFC_AWS_APPLY_ROLE_ARN` is being used; see below” |
 
 ### Optional Environment Variables
 You may need to set these variables, depending on your use case.


### PR DESCRIPTION
From a discussion in Slack. https://hashicorp.slack.com/archives/C04ATDWCF5F/p1678305342796909?thread_ts=1678290878.384989&channel=C04ATDWCF5F&message_ts=1678305342.796909

Existing documentation makes it seem like `TFC_AWS_RUN_ROLE_ARN` is always mandatory, when it’s not quite that simple. The explanatory note feels sufficient to make that clearer.

This problem might exist for other providers too (Vault, GCP, Azure), but I’ve not checked those.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
