### PR TITLE
Change check-legacy-links-format to run on pull_request

### DIFF
--- a/.github/workflows/check-legacy-links-format.yml
+++ b/.github/workflows/check-legacy-links-format.yml
@@ -1,7 +1,7 @@
 name: Legacy Link Format Checker
 
 on:
-  push:
+  pull_request:
     paths:
       - "website/docs/**/*.mdx"
       - "website/data/*-nav-data.json"


### PR DESCRIPTION
### What
Modifies the `check-legacy-links-format` check to run on `pull_request` instead of `push`.

### Why
Before this change, the `check-legacy-links-format` check would fail on pushes that were not part of pull requests as the action it uses relies on a pull request existing for the change. 

This would result in a failing check without useful feedback to the user around their potentially incorrect link format. If a change was a single commit this failure would never be cleared and useful feedback would not be surfaced.

Changing this to run on `pull_request` instead ensures that this workflow is only run when a pull request exists so that the underlying action can run properly.