### PR TITLE
ServiceNow Service Catalog documentation - updating prerequisites.

### DIFF
--- a/website/docs/cloud-docs/integrations/service-now/index.mdx
+++ b/website/docs/cloud-docs/integrations/service-now/index.mdx
@@ -79,12 +79,15 @@ You can use this integration on the following ServiceNow server versions:
 - Rome
 - San Diego
 - Tokyo
+- Utah
 
 It requires the following ServiceNow Plugins as dependencies:
 
-- Flow Designer support for the Service Catalog
-- ServiceNow IntegrationHub Action Step
-- ServiceNow IntegrationHub Starter Pack
+- Flow Designer support for the Service Catalog (`com.glideapp.servicecatalog.flow_designer`)
+- ServiceNow IntegrationHub Action Step - Script (`com.glide.hub.action_step.script`)
+- ServiceNow IntegrationHub Action Step - REST (`com.glide.hub.action_step.rest`)
+
+-> **Note:** Dependent plugins are installed on your ServiceNow instance automatically when the app is downloaded from the ServiceNow Store.
 
 ## Configure Terraform Cloud
 


### PR DESCRIPTION
### What
Updated Terraform ServiceNow Service Catalog documentation with the list of relevant ServiceNow versions and dependent plugins:

- added Utah as the Catalog app has recently been certified to run on it
- updated the list of dependent plugins (requested by the community)
- added a note saying that dependent plugins will be installed automatically in prod (requested by the community) 

Previous similar PR for reference: https://github.com/hashicorp/terraform-docs-common/pull/220

### Why
To deliver the most relevant and up-to-date list of ServiceNow versions and app dependencies to the users.

### Screenshots
N/A
----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] N/A Description links to related pull requests or issues, if any.

#### Content
- [x] N/A Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] N/A API documentation and the API Changelog have been updated. 
- [x] N/A Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] N/A Pages with related content are updated and link to this content when appropriate.
- [x] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] N/A New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
