### PR TITLE
Update link to goreleaser file, from new scaffolding repo

### DIFF
--- a/website/docs/registry/providers/os-arch.mdx
+++ b/website/docs/registry/providers/os-arch.mdx
@@ -9,7 +9,7 @@ description: >-
 
 # Recommended Provider Binary Operating Systems and Architectures
 
-We recommend the following operating system / architecture combinations for compiled binaries available in the registry (this list is already satisfied by our [recommended **.goreleaser.yml** configuration file](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.goreleaser.yml)):
+We recommend the following operating system / architecture combinations for compiled binaries available in the registry (this list is already satisfied by our [recommended **.goreleaser.yml** configuration file](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml)):
 
 * Darwin / AMD64
 * Darwin / ARMv8


### PR DESCRIPTION
The previous link on https://developer.hashicorp.com/terraform/registry/providers/os-arch goes to an archived repo. This looks like the new repo.