### PR TITLE
website/docs/registry: Fix terraform-provider-scaffolding references

### DIFF
--- a/website/docs/registry/providers/docs.mdx
+++ b/website/docs/registry/providers/docs.mdx
@@ -27,7 +27,7 @@ Each document can contain no more than 500KB of data. Documents which exceed thi
 
 The [tfplugindocs](https://github.com/hashicorp/terraform-plugin-docs) command can be used to automatically generate documentation for your provider in the format necessary for the Terraform Registry. It will read descriptions and schema from each resource and data source in your provider and generate the relevant markdown files for you.
 
-The [terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding) template repository includes example usage of the `tfplugindocs` command via `go generate`:
+The [terraform-provider-scaffolding-framework](https://github.com/hashicorp/terraform-provider-scaffolding-framework) template repository includes example usage of the `tfplugindocs` command via `go generate`:
 
 ```go
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs

--- a/website/docs/registry/providers/publishing.mdx
+++ b/website/docs/registry/providers/publishing.mdx
@@ -75,10 +75,10 @@ We have a list of [recommend OS / architecture combinations](/terraform/registry
 
 To use GitHub Actions to publish new provider releases to the Terraform Registry:
 
-1. Ensure the [GitHub Organization settings for GitHub Actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization) and [GitHub Repository settings for GitHub Actions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository) allows running workflows and allows the actions specified in the [GitHub Actions workflow from the terraform-provider-scaffolding repository](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.github/workflows/release.yml).
+1. Ensure the [GitHub Organization settings for GitHub Actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization) and [GitHub Repository settings for GitHub Actions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository) allows running workflows and allows the actions specified in the [GitHub Actions workflow from the terraform-provider-scaffolding-framework repository](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.github/workflows/release.yml).
 1. Create and export a signing key that you plan on using to sign your provider releases. See [Preparing and Adding a Signing Key](#preparing-and-adding-a-signing-key) for more information.
-1. Copy the [GoReleaser configuration from the terraform-provider-scaffolding repository](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.goreleaser.yml) to the root of your repository.
-1. Copy the [GitHub Actions workflow from the terraform-provider-scaffolding repository](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.github/workflows/release.yml) to `.github/workflows/release.yml` in your repository.
+1. Copy the [GoReleaser configuration from the terraform-provider-scaffolding-framework repository](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml) to the root of your repository.
+1. Copy the [GitHub Actions workflow from the terraform-provider-scaffolding-framework repository](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.github/workflows/release.yml) to `.github/workflows/release.yml` in your repository.
 1. Go to _Settings > Secrets_ in your repository, and add the following secrets:
 
 - `GPG_PRIVATE_KEY` - Your ASCII-armored GPG private key. You can export this with `gpg --armor --export-secret-keys [key ID or email]`.
@@ -94,7 +94,7 @@ Once a release is created, you can move on to [Publishing to the Registry](#publ
 GoReleaser is a tool for building Go projects for multiple platforms, creating a checksums file, and signing the release. It can also upload your release to GitHub Releases.
 
 1. Install [GoReleaser](https://goreleaser.com) using the [installation instructions](https://goreleaser.com/install/).
-1. Copy the [.goreleaser.yml file](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/.goreleaser.yml) from the [hashicorp/terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding) repository.
+1. Copy the [.goreleaser.yml file](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/main/.goreleaser.yml) from the [hashicorp/terraform-provider-scaffolding-framework](https://github.com/hashicorp/terraform-provider-scaffolding-framework) repository.
 1. Cache the password for your GPG private key with `gpg --armor --detach-sign` (see note below).
 1. Set your `GITHUB_TOKEN` to a [Personal Access Token](https://github.com/settings/tokens/new?scopes=public_repo) that has the **public_repo** scope.
 1. Ensure there is not a branch name with the expected version tag name (e.g. `v1.2.3`).


### PR DESCRIPTION
### What

Replace links to terraform-provider-scaffolding with terraform-provider-scaffolding-framework.

### Why

Reference: https://github.com/hashicorp/terraform-provider-scaffolding
Reference: https://github.com/hashicorp/terraform-provider-scaffolding-framework

terraform-provider-scaffolding was archived and is superseded by terraform-provider-scaffolding-framework.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
