### PR TITLE
chore: update docs to reflect new health settings location

### DIFF
--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -40,7 +40,7 @@ You can enforce health assessments across all eligible workspaces in an organiza
 To enable health assessments within a workspace:
 
 1. Verify that your workspace satisfies the [requirements](#workspace-requirements).
-1. Go to the workspace and click **Health > Settings**.
+1. Go to the workspace and click **Settings > Health**.
 1. Select **Enable** under **Health Assessments**.
 1. Click **Save settings**.
 

--- a/website/docs/cloud-docs/workspaces/settings/index.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/index.mdx
@@ -9,6 +9,7 @@ description: >-
 
 You can change a workspace’s settings after creation. Workspace settings are separated into several pages.
 - [General](#general): Settings that determine how the workspace functions, including its name, description, associated project, Terraform version, and execution mode.
+- [Health](/terraform/cloud-docs/workspaces/health): Settings that let you configure health assessments, including drift detection and continuous validation.
 - [Locking](#locking): Locking a workspace temporarily prevents new plans and applies.
 - [Notifications](#notifications): Settings that let you configure run notifications.
 - [Run Triggers](#run-triggers): Settings that let you configure run triggers. Run triggers allow runs to queue automatically in your workspace when runs in other workspaces are successful.


### PR DESCRIPTION
### What

Updated the docs to reflect the new location of the Health Settings page in atlas ([PR](https://github.com/hashicorp/atlas/pull/15189)).

Pages changed:
- `/terraform/cloud-docs/workspaces/health`
  - Updated the breadcrumb path in the "Enable Health Assessments" section.
- `/terraform/cloud-docs/workspaces/settings/index`
  - Added a new setting, "Health", to describe the new section that has been introduced.

### Why
The Health Settings page are being moved and the docs need to be updated to reflect the new location.

### External Links
- [JIRA](https://hashicorp.atlassian.net/browse/TF-4902?atlOrigin=eyJpIjoiZGE1Yzc3ZGQ3MTY4NGQ4YTg5YWViNzRhMDAwZGJiYzYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
