### PR TITLE
Add documentation for authentication token expirations

### DIFF
--- a/website/docs/cloud-docs/api-docs/organization-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/organization-tokens.mdx
@@ -67,7 +67,7 @@ This POST endpoint requires a JSON object with the following properties as a req
 | Key path                      | Type   | Default | Description                                                                                                             |
 | ----------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `data.type`                   | string |         | Must be `"authentication-token"`.                                                                                       |
-| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the Organization Token will expire. If omitted or set to `null` the token will never expire. |
+| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the Organization Token will expire, in ISO 8601 format. If omitted or set to `null` the token will never expire. |
 
 ### Sample Payload
 

--- a/website/docs/cloud-docs/api-docs/organization-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/organization-tokens.mdx
@@ -50,12 +50,37 @@ Generates a new [organization API token](/terraform/cloud-docs/users-teams-organ
 
 Only members of the owners team, the owners [team API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens), and the [organization API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens) can access this endpoint.
 
+This endpoint returns the secret text of the created authentication token. A token value is only shown upon creation, and cannot be recovered later.
+
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 | Status  | Response                                                | Reason              |
 | ------- | ------------------------------------------------------- | ------------------- |
 | [201][] | [JSON API document][] (`type: "authentication-tokens"`) | Success             |
 | [404][] | [JSON API error object][]                               | User not authorized |
+
+### Request Body
+
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+
+| Key path                      | Type   | Default | Description                                                                                                             |
+| ----------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `data.type`                   | string |         | Must be `"authentication-token"`.                                                                                       |
+| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the Organization Token will expire. If omitted or set to `null` the token will never expire. |
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "type": "authentication-token",
+    "attributes": {
+      "expired-at": "2023-04-06T12:00:00.000Z"
+    }
+  }
+}
+```
 
 ### Sample Request
 
@@ -64,6 +89,7 @@ curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
+  --data @payload.json \
   https://app.terraform.io/api/v2/organizations/my-organization/authentication-token
 ```
 
@@ -78,7 +104,8 @@ curl \
       "created-at": "2017-11-29T19:11:28.075Z",
       "last-used-at": null,
       "description": null,
-      "token": "ZgqYdzuvlv8Iyg.atlasv1.6nV7t1OyFls341jo1xdZTP72fN0uu9VL55ozqzekfmToGFbhoFvvygIRy2mwVAXomOE"
+      "token": "ZgqYdzuvlv8Iyg.atlasv1.6nV7t1OyFls341jo1xdZTP72fN0uu9VL55ozqzekfmToGFbhoFvvygIRy2mwVAXomOE",
+      "expired-at": "2023-04-06T12:00:00.000Z"
     },
     "relationships": {
       "created-by": {

--- a/website/docs/cloud-docs/api-docs/organization-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/organization-tokens.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: Organization Tokens - API Docs - Terraform Cloud
 description: >-
-  Use the `authentication-token` endpoint to manage organization-level API tokens. Generate and delete organization tokens using the HTTP API.
+  Use the `/authentication-token` endpoint to manage organization-level API tokens. Generate and delete organization tokens using the HTTP API.
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/organization-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/organization-tokens.mdx
@@ -50,7 +50,7 @@ Generates a new [organization API token](/terraform/cloud-docs/users-teams-organ
 
 Only members of the owners team, the owners [team API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens), and the [organization API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens) can access this endpoint.
 
-This endpoint returns the secret text of the created authentication token. A token value is only shown upon creation, and cannot be recovered later.
+This endpoint returns the secret text of the new authentication token. A token value is only returned upon creation, and cannot be recovered later.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/website/docs/cloud-docs/api-docs/team-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/team-tokens.mdx
@@ -46,9 +46,34 @@ Generates a new team token and overrides existing token if one exists.
 | :----- | :----------------------------------- |
 | POST   | /teams/:team_id/authentication-token |
 
+This endpoint returns the secret text of the created authentication token. A token value is only shown upon creation, and cannot be recovered later.
+
 ### Parameters
 
 - `:team_id` (`string: <required>`) - specifies the team ID for generating the team token
+
+### Request Body
+
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+
+| Key path                      | Type   | Default | Description                                                                                                     |
+| ----------------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `data.type`                   | string |         | Must be `"authentication-token"`.                                                                               |
+| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the Team Token will expire. If omitted or set to `null` the token will never expire. |
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "type": "authentication-token",
+    "attributes": {
+      "expired-at": "2023-04-06T12:00:00.000Z"
+    }
+  }
+}
+```
 
 ### Sample Request
 
@@ -57,6 +82,7 @@ curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
+  --data @payload.json \
   https://app.terraform.io/api/v2/teams/team-BUHBEM97xboT8TVz/authentication-token
 ```
 
@@ -71,7 +97,8 @@ curl \
       "created-at": "2017-11-29T19:18:09.976Z",
       "last-used-at": null,
       "description": null,
-      "token": "QnbSxjjhVMHJgw.atlasv1.gxZnWIjI5j752DGqdwEUVLOFf0mtyaQ00H9bA1j90qWb254lEkQyOdfqqcq9zZL7Sm0"
+      "token": "QnbSxjjhVMHJgw.atlasv1.gxZnWIjI5j752DGqdwEUVLOFf0mtyaQ00H9bA1j90qWb254lEkQyOdfqqcq9zZL7Sm0",
+      "expired-at": "2023-04-06T12:00:00.000Z"
     },
     "relationships": {
       "created-by": {

--- a/website/docs/cloud-docs/api-docs/team-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/team-tokens.mdx
@@ -60,7 +60,7 @@ This POST endpoint requires a JSON object with the following properties as a req
 | Key path                      | Type   | Default | Description                                                                                                     |
 | ----------------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------- |
 | `data.type`                   | string |         | Must be `"authentication-token"`.                                                                               |
-| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the Team Token will expire. If omitted or set to `null` the token will never expire. |
+| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the Team Token will expire, in ISO 8601 format. If omitted or set to `null` the token will never expire. |
 
 ### Sample Payload
 

--- a/website/docs/cloud-docs/api-docs/team-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/team-tokens.mdx
@@ -46,7 +46,7 @@ Generates a new team token and overrides existing token if one exists.
 | :----- | :----------------------------------- |
 | POST   | /teams/:team_id/authentication-token |
 
-This endpoint returns the secret text of the created authentication token. A token value is only shown upon creation, and cannot be recovered later.
+This endpoint returns the secret text of the new authentication token. A token value is only returned upon creation, and cannot be recovered later.
 
 ### Parameters
 

--- a/website/docs/cloud-docs/api-docs/user-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/user-tokens.mdx
@@ -205,7 +205,7 @@ Properties without a default value are required.
 | ----------------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------- |
 | `data.type`                   | string |         | Must be `"authentication-tokens"`.                                                                              |
 | `data.attributes.description` | string |         | The description for the User Token.                                                                             |
-| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the User Token will expire. If omitted or set to `null` the token will never expire. |
+| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the User Token will expire, in ISO 8601 format. If omitted or set to `null` the token will never expire. |
 
 ### Sample Payload
 

--- a/website/docs/cloud-docs/api-docs/user-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/user-tokens.mdx
@@ -89,7 +89,8 @@ curl \
         "created-at": "2018-11-06T22:56:10.203Z",
         "last-used-at": null,
         "description": null,
-        "token": null
+        "token": null,
+        "expired-at": null
       },
       "relationships": {
         "created-by": {
@@ -104,7 +105,8 @@ curl \
         "created-at": "2018-11-25T22:31:30.624Z",
         "last-used-at": "2018-11-26T20:27:54.931Z",
         "description": "api",
-        "token": null
+        "token": null,
+        "expired-at": "2023-04-06T12:00:00.000Z"
       },
       "relationships": {
         "created-by": {
@@ -157,7 +159,8 @@ curl \
       "created-at": "2018-11-25T22:31:30.624Z",
       "last-used-at": "2018-11-26T20:34:59.487Z",
       "description": "api",
-      "token": null
+      "token": null,
+      "expired-at": "2023-04-06T12:00:00.000Z"
     },
     "relationships": {
       "created-by": {
@@ -198,10 +201,11 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-| Key path                      | Type   | Default | Description                         |
-| ----------------------------- | ------ | ------- | ----------------------------------- |
-| `data.type`                   | string |         | Must be `"authentication-tokens"`.  |
-| `data.attributes.description` | string |         | The description for the User Token. |
+| Key path                      | Type   | Default | Description                                                                                                     |
+| ----------------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `data.type`                   | string |         | Must be `"authentication-tokens"`.                                                                              |
+| `data.attributes.description` | string |         | The description for the User Token.                                                                             |
+| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the User Token will expire. If omitted or set to `null` the token will never expire. |
 
 ### Sample Payload
 
@@ -210,7 +214,8 @@ Properties without a default value are required.
   "data": {
     "type": "authentication-tokens",
     "attributes": {
-      "description":"api"
+      "description":"api",
+      "expired-at": "2023-04-06T12:00:00.000Z"
     }
   }
 }
@@ -238,7 +243,8 @@ curl \
       "created-at": "2018-11-26T20:48:35.054Z",
       "last-used-at": null,
       "description": "api",
-      "token": "6tL24nM38M7XWQ.atlasv1.KmWckRfzeNmUVFNvpvwUEChKaLGznCSD6fPf3VPzqMMVzmSxFU0p2Ibzpo2h5eTGwPU"
+      "token": "6tL24nM38M7XWQ.atlasv1.KmWckRfzeNmUVFNvpvwUEChKaLGznCSD6fPf3VPzqMMVzmSxFU0p2Ibzpo2h5eTGwPU",
+      "expired-at": "2023-04-06T12:00:00.000Z"
     },
     "relationships": {
       "created-by": {

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -101,7 +101,7 @@ The following chart illustrates the various access levels for the supported API 
 
 ## Token Expiration
 
-User, team, and organization tokens may be created with an expiration date and time set. Once this time has passed, the token will no longer be treated as valid, and may not be used to authenticate to any API.
+User, team, and organization tokens may be created with an expiration date and time. Once this time has passed, the token will no longer be treated as valid, and may not be used to authenticate to any API. Any API requests made with an expired token will result in failure.
 
 HashiCorp recommends setting an expiration on all new authentication tokens. Creating tokens which will expire once they are no longer needed helps reduce the risk that valid tokens may be leaked, or that token owners will forget to delete tokens meant for delegated use once their intended purpose is complete.
 

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -103,6 +103,6 @@ The following chart illustrates the various access levels for the supported API 
 
 User, team, and organization tokens may be created with an expiration date and time. Once this time has passed, the token will no longer be treated as valid, and may not be used to authenticate to any API. Any API requests made with an expired token will result in failure.
 
-HashiCorp recommends setting an expiration on all new authentication tokens. Creating tokens which will expire once they are no longer needed helps reduce the risk that valid tokens may be leaked, or that token owners will forget to delete tokens meant for delegated use once their intended purpose is complete.
+HashiCorp recommends setting an expiration on all new authentication tokens. Creating tokens with an expiration date helps reduce the risk that valid tokens may be leaked, or that token owners will forget to delete tokens meant for delegated use once their intended purpose is complete.
 
 Once a token has been created its expiration time may not be modified. The Terraform Cloud UI will display tokens relative to the timezone of the current user, but all tokens are expected to be passed and displayed in UTC through the Terraform Cloud API.

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -87,7 +87,7 @@ The following chart illustrates the various access levels for the supported API 
 | Modify organizations               |      🔶     |             |                     |
 | Manage organization tokens         |      🔶     |             |                     |
 | View audit trails                  |             |             |          🔵         |
-| Invite users to organiation        |      🔶     |      🔶     |          🔵         |
+| Invite users to organization       |      🔶     |      🔶     |          🔵         |
 | **Sentinel**                       |             |             |                     |
 | Manage Sentinel policies           |      🔶     |      🔶     |          🔵         |
 | Manage policy sets                 |      🔶     |      🔶     |          🔵         |
@@ -98,3 +98,11 @@ The following chart illustrates the various access levels for the supported API 
 | Manage run tasks                   |      🔶     |      🔶     |          🔵          |
 | **Modules**                        |             |             |                     |
 | Manage Terraform modules           |      🔶     | 🔵 (owners) |                     |
+
+## Token Expiration
+
+User, team, and organization tokens may be created with an expiration date and time set. Once this time has passed, the token will no longer be treated as valid, and may not be used to authenticate to any API.
+
+HashiCorp recommends setting an expiration on all new authentication tokens. Creating tokens which will expire once they are no longer needed helps reduce the risk that valid tokens may be leaked, or that token owners will forget to delete tokens meant for delegated use once their intended purpose is complete.
+
+Once a token has been created its expiration time may not be modified. The Terraform Cloud UI will display tokens relative to the timezone of the current user, but all tokens are expected to be passed and displayed in UTC through the Terraform Cloud API.

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -105,4 +105,4 @@ User, team, and organization tokens may be created with an expiration date and t
 
 HashiCorp recommends setting an expiration on all new authentication tokens. Creating tokens with an expiration date helps reduce the risk that valid tokens may be leaked, or that token owners will forget to delete tokens meant for delegated use once their intended purpose is complete.
 
-Once a token has been created its expiration time may not be modified. The Terraform Cloud UI will display tokens relative to the timezone of the current user, but all tokens are expected to be passed and displayed in UTC through the Terraform Cloud API.
+Once a token has been created its expiration time may not be modified. The Terraform Cloud UI will display tokens relative to the timezone of the current user, but all tokens are expected to be passed and displayed in UTC in ISO 8601 format through the Terraform Cloud API.

--- a/website/docs/cloud-docs/users-teams-organizations/users.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/users.mdx
@@ -128,7 +128,7 @@ Terraform Cloud also recommends protecting your tokens by giving them an expirat
  To create a new token:
   1. Click **Create an API token**. The **Create API token** box appears.
   1. Enter a **Description** that explains what the token is for and click **Create API token**.
-  1. Optionally, enter an expiration date or time for the token, or choose to create a token which will never expire. Token expiration will always be displayed in the UI relative to your current time zone.
+  1. Optionally, enter an expiration date or time for the token, or choose to create a token which will never expire. In the UI, token expirations will always be displayed in your current time zone.
   1. Copy your token from the box and save it in a secure location. Terraform Cloud only displays the token once, right after you create it. If you lose it, you must revoke the old token and create a new one.
 
 

--- a/website/docs/cloud-docs/users-teams-organizations/users.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/users.mdx
@@ -121,11 +121,14 @@ API tokens are required for the following tasks:
 
 Protect your tokens carefully because they contain the same permissions as your user account. For example, if you belong to a team with permission to read and write variables for a workspace, another user could use your API token to authenticate as your user account and also edit variables in that workspace. Refer to [permissions](/terraform/cloud-docs/users-teams-organizations/permissions) for more details.
 
+Terraform Cloud also recommends protecting your tokens by giving them an expiration date and time on token creation. Refer to [API Token Expiration](/terraform/cloud-docs/users-teams-organizations/api-tokens#token-expiration) for details.
+
 #### Creating a Token
 
  To create a new token:
   1. Click **Create an API token**. The **Create API token** box appears.
   1. Enter a **Description** that explains what the token is for and click **Create API token**.
+  1. Optionally, enter an expiration date or time for the token, or choose to create a token which will never expire. Token expiration will always be displayed in the UI relative to your current time zone.
   1. Copy your token from the box and save it in a secure location. Terraform Cloud only displays the token once, right after you create it. If you lose it, you must revoke the old token and create a new one.
 
 


### PR DESCRIPTION
### What
Adds documentation for authentication token expiration, including changes to the API to set/display token expiration.

### Why
An upcoming feature will allow user, team, and organization tokens to be created with an expiration time set. We want to encourage users to set an expiration on new tokens.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
