### PR TITLE
Remove beta note about dynamic credentials

### DIFF
--- a/website/docs/cloud-docs/workspaces/variables/index.mdx
+++ b/website/docs/cloud-docs/workspaces/variables/index.mdx
@@ -33,8 +33,6 @@ You can use the `TFE_PARALLELISM` environment variable when your infrastructure 
 
 #### Dynamic Credentials
 
--> **Note:** Dynamic Credentials are in beta.
-
 You can configure [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for certain providers using environment variables [at the workspace level](/terraform/cloud-docs/workspaces/variables/managing-variables#workspace-specific-variables) or using [variable sets](/terraform/cloud-docs/workspaces/variables/managing-variables#variable-sets).
 
 Dynamic credentials allows for using temporary per-run credentials and eliminates the need to manually rotate secrets.


### PR DESCRIPTION
### What
Removes note about dynamic credentials being in beta from website/docs/cloud-docs/workspaces/variables/index.mdx

### Why
Looks like one note about dynamic provider credentials being in beta was missed in #288. Feature is GA.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
