### PR TITLE
GA update for module-design.mdx

### DIFF
--- a/website/docs/cloud-docs/no-code-provisioning/module-design.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/module-design.mdx
@@ -6,7 +6,7 @@ tfc_only: true
 
 # Designing No-Code Ready Modules
 
--> **Note:** No-code provisioning is in beta and available in the [Terraform Cloud Business tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** No-code provisioning is available in the [Terraform Cloud Business tier](https://www.hashicorp.com/products/terraform/pricing).
 
 Terraform [modules](/terraform/language/modules) let you define standardized collections of infrastructure resources that downstream users can more easily deploy. No-code ready modules build on these advantages by letting users deploy a module's resources without writing any Terraform configuration. This practice is called no-code provisioning.
 
@@ -30,6 +30,7 @@ When module consumers follow the no-code workflow, Terraform Cloud automatically
 
 You can grant new no-code workspace provider credentials using one of the following methods:
 
+- Recommended: Create a [project variable set]() that Terraform Cloud applies to existing and future workspaces within the project. You can easily assign teams to the project, meaning you can delineate certain teams as "no-code" upfront and house them in their own guardrailed projects.
 - Create a [global variable set](/terraform/cloud-docs/workspaces/variables/managing-variables#variable-sets) that Terraform Cloud applies to all existing and future workspaces in the organization. This action automatically grants newly-created workspaces access to the required provider credentials.
 - Expose provider credentials as sensitive outputs in another workspace. You must add additional configuration to the module to access these values through [remote state data sources](/terraform/language/state/remote-state-data) and then reference them in provider configuration. This approach provides more control over access to these credentials than placing them in a global variable set.
 - Elect to let the first run in new no-code workspaces fail and have module users add credentials directly to the workspace after creation. This approach provides the most control over access to provider credentials, but requires manual intervention. Module users must manually start a new run to provision infrastructure after they configure the credentials.
@@ -49,3 +50,7 @@ For example, you could build modules that satisfy the following well-scoped use 
 ### Provide Variable Defaults When Possible
 
 The no-code provisioning workflow prompts users to set values for the module's input variables before creating the new workspace and deploying resources. We recommend setting reasonable defaults when possible to reduce the effort and expertise needed to deploy the module. Remember that the workspace can also access variable values set through global variable sets in your organization.
+
+### Define Dropdown Options for Variables without Defaults
+
+For variables without defaults, you may still want to limit what the no-code user can input. Define these input options at the time of enabling the module for no-code provisioning. You can do this either from the Terraform Cloud UI or via the [TFE provider](). The latter method is recommended for those that want to track these variable input options through a code approval process, keeping the configuration as code.


### PR DESCRIPTION
Starting new branch in fork opslivia/terraform-docs-common for GA changes to "Designing No-Code Ready Modules."

### What
<!-- Explain what you changed and provide a list of changed page names. -->

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
