### PR TITLE
Update provisioning.mdx for GA

### DIFF
--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -55,7 +55,8 @@ To launch the no-code workflow:
 No-code workspaces have a limited feature set because you cannot access the resource configuration. However, you can edit workspace variables and settings, including notifications, permissions, and run triggers. You can use run triggers to connect the workspace to one or more source workspaces, start new runs when you change workspace variables, or queue destroy runs.
 
 ### Updating Variables
-To change variable input options after provisioning, go to the **Variables** section in your workspace to see your workspace's variables listed. To edit a variable:
+
+To change a variable's options after provisioning, go to the **Variables** section in your workspace to see your workspace's variables listed. To edit a variable:
 1. Click the ellipses next to the variable you want to edit and select **Edit**.
 2. Enter your desired value and click **Save variable**.
 

--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -57,7 +57,7 @@ No-code workspaces have a limited feature set because you cannot access the reso
 ### Updating Variables
 In order to change variable inputs after provisioning, go to the Variables section in your workspace. There you will see the variables that have been applied. 
 1. Click the ellipses next to the variable you want to edit and select **Edit**.
-2. Enter the desired value
+2. Enter your desired value and click **Save variable**.
 3. **Plan** and **Apply**.
 
 ### Module Upgrades

--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -57,7 +57,7 @@ No-code workspaces have a limited feature set because you cannot access the reso
 ### Updating Variables
 In order to change variable inputs after provisioning, go to the Variables section in your workspace. There you will see the variables that have been applied. 
 1. Select **Edit** for the variables you want to update.
-2. Enter the desired value, or select it if dropdown options are present.
+2. Enter the desired value
 3. **Plan** and **Apply**.
 
 ### Module Upgrades

--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -6,9 +6,9 @@ tfc_only: true
 
 # Provisioning No-Code Infrastructure
 
--> **Note:** No-code provisioning is in beta and available in the [Terraform Cloud Business tier](https://www.hashicorp.com/products/terraform/pricing).
+-> **Note:** No-code provisioning is available in the [Terraform Cloud Business tier](https://www.hashicorp.com/products/terraform/pricing).
 
-No-code provisioning lets you deploy infrastructure resources in a new Terraform Cloud workspace without writing any Terraform configuration. You can create a no-code workspace from any module labeled **No-code Ready** in your organization's [private registry](/terraform/cloud-docs/registry).
+No-code provisioning lets you deploy infrastructure resources in a new Terraform Cloud workspace without writing any Terraform configuration. You can create a no-code workspace from any module version labeled **No-code Ready** in your organization's [private registry](/terraform/cloud-docs/registry).
 
 The no-code provisioning workflow is best for quickly deploying relatively static infrastructure. Beyond changing variable values, you cannot apply configuration changes to existing no-code workspaces. If you need to deploy updates to the no-code ready module's configuration, you must create new no-code workspaces with new resources. We recommend standard modules for use cases that require dynamic configuration and development.
 
@@ -36,7 +36,7 @@ To launch the no-code workflow:
 
      Terraform Cloud scans the module configuration for input variables and prompts for values for any variables without defaults or undefined in an existing global variable set. Terraform requires values for these variables to successfully complete runs in the workspace. Terraform Cloud performs type validation for the variable values if the module configuration specifies a type.
 
-1. (Optional) Set values for the input variables. You can choose to skip this step and configure the variables later. However, Terraform Cloud does not prompt you for these values again and your Terraform runs may fail.
+1. (Optional) Set values for the input variables. If your organization has defined variable input options, you will see them here as dropdown options. You can choose to skip this step and configure the variables later in your workspace. However, Terraform Cloud does not prompt you for these values again and your Terraform runs may fail.
 
 1. Cick **Next: Workspace settings**.
 
@@ -54,4 +54,11 @@ To launch the no-code workflow:
 
 No-code workspaces have a limited feature set because you cannot access the resource configuration. However, you can edit workspace variables and settings, including notifications, permissions, and run triggers. You can use run triggers to connect the workspace to one or more source workspaces, start new runs when you change workspace variables, or queue destroy runs.
 
-If the module’s configuration changes, you must destroy the workspace and create a new one to provision resources with the updated configuration.
+### Updating Variables
+In order to change variable inputs after provisioning, go to the Variables section in your workspace. There you will see the variables that have been applied. 
+1. Select **Edit** for the variables you want to update.
+2. Enter the desired value, or select it if dropdown options are present.
+3. **Plan** and **Apply**.
+
+### Module Upgrades
+Currently, if the module’s configuration changes and you want to upgrade to the new version, you must destroy the workspace and create a new one to provision resources with the updated configuration.

--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -36,7 +36,7 @@ To launch the no-code workflow:
 
      Terraform Cloud scans the module configuration for input variables and prompts for values for any variables without defaults or undefined in an existing global variable set. Terraform requires values for these variables to successfully complete runs in the workspace. Terraform Cloud performs type validation for the variable values if the module configuration specifies a type.
 
-1. (Optional) Set values for the input variables. If your organization has defined variable input options, you will see them here as dropdown options. You can choose to skip this step and configure the variables later in your workspace. However, Terraform Cloud does not prompt you for these values again and your Terraform runs may fail.
+1. (Optional) Set values for the input variables. If your organization has defined options for a variable's values, these options appear in a dropdown menu. You can skip this step and configure the variables later in your workspace. However, Terraform Cloud does not prompt you for these values again, and your Terraform runs may fail.
 
 1. Cick **Next: Workspace settings**.
 

--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -61,4 +61,4 @@ In order to change variable inputs after provisioning, go to the Variables secti
 3. **Plan** and **Apply**.
 
 ### Module Upgrades
-Currently, if the module’s configuration changes and you want to upgrade to the new version, you must destroy the workspace and create a new one to provision resources with the updated configuration.
+If a module’s configuration changes and you want to upgrade to a newer version, you must destroy the workspace and create a new one to provision resources with that updated version.

--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -55,7 +55,7 @@ To launch the no-code workflow:
 No-code workspaces have a limited feature set because you cannot access the resource configuration. However, you can edit workspace variables and settings, including notifications, permissions, and run triggers. You can use run triggers to connect the workspace to one or more source workspaces, start new runs when you change workspace variables, or queue destroy runs.
 
 ### Updating Variables
-In order to change variable inputs after provisioning, go to the Variables section in your workspace. There you will see the variables that have been applied. 
+To change variable input options after provisioning, go to the **Variables** section in your workspace to see your workspace's variables listed. To edit a variable:
 1. Click the ellipses next to the variable you want to edit and select **Edit**.
 2. Enter your desired value and click **Save variable**.
 

--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -58,7 +58,8 @@ No-code workspaces have a limited feature set because you cannot access the reso
 In order to change variable inputs after provisioning, go to the Variables section in your workspace. There you will see the variables that have been applied. 
 1. Click the ellipses next to the variable you want to edit and select **Edit**.
 2. Enter your desired value and click **Save variable**.
-3. **Plan** and **Apply**.
+
+Start a new run in your workspace to update your existing infrastructure with your new variable value.
 
 ### Module Upgrades
 If a module’s configuration changes and you want to upgrade to a newer version, you must destroy the workspace and create a new one to provision resources with that updated version.

--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -56,7 +56,7 @@ No-code workspaces have a limited feature set because you cannot access the reso
 
 ### Updating Variables
 In order to change variable inputs after provisioning, go to the Variables section in your workspace. There you will see the variables that have been applied. 
-1. Select **Edit** for the variables you want to update.
+1. Click the ellipses next to the variable you want to edit and select **Edit**.
 2. Enter the desired value
 3. **Plan** and **Apply**.
 


### PR DESCRIPTION
Related PRs
https://github.com/hashicorp/terraform-docs-common/pull/329
https://github.com/hashicorp/terraform-docs-common/pull/330

### What
<!-- Explain what you changed and provide a list of changed page names. -->
Updated copy to remove beta tags and add in a section about updating variables after provisioning.

website/docs/cloud-docs/no-code-provisioning/provisioning.mdx 

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
No Code Provisioning is going GA

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
