### PR TITLE
Add documentation for Vault-backed dynamic credentials

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -161,7 +161,16 @@
           { "title":  "AWS Configuration", "path":  "workspaces/dynamic-provider-credentials/aws-configuration" },
           { "title":  "GCP Configuration", "path":  "workspaces/dynamic-provider-credentials/gcp-configuration" },
           { "title":  "Azure Configuration", "path":  "workspaces/dynamic-provider-credentials/azure-configuration" },
-          { "title":  "Manually Generating Workload Identity Tokens", "path":  "workspaces/dynamic-provider-credentials/manual-generation" }
+          { "title":  "Manually Generating Workload Identity Tokens", "path":  "workspaces/dynamic-provider-credentials/manual-generation" },
+          {
+            "title": "Vault-Backed Dynamic Credentials",
+            "routes": [
+              { "title":  "Overview", "path":  "workspaces/dynamic-provider-credentials/vault-backed" },
+              { "title":  "AWS Configuration", "path": "workspaces/dynamic-provider-credentials/vault-backed/aws-configuration" },
+              { "title":  "GCP Configuration", "path": "workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration" },
+              { "title":  "Azure Configuration", "path": "workspaces/dynamic-provider-credentials/vault-backed/azure-configuration" }
+            ]
+          }
         ]
       },
       {

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -9,7 +9,7 @@ description: >-
 
 ~> **Important:** If using self-managed agents, make sure you’re using **v1.7.0** or later.
 
-You can use Terraform Cloud’s native OpenID Connect integration with AWS to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the AWS provider in your Terraform Cloud runs. Configuring the integration requires the following steps.
+You can use Terraform Cloud’s native OpenID Connect integration with AWS to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the AWS provider in your Terraform Cloud runs. Configuring the integration requires the following steps:
 
 1. **[Configure AWS](#configure-aws):** Set up a trust configuration between AWS and Terraform Cloud. Then, you must create AWS roles and policies for your Terraform Cloud workspaces.
 2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.
@@ -93,10 +93,10 @@ A permissions policy needs to be added to the role which defines what operations
 You’ll need to set some environment variables in your Terraform Cloud workspace in order to configure Terraform Cloud to authenticate with AWS using dynamic credentials. You can set these as workspace variables, or if you’d like to share one AWS role across multiple workspaces, you can use a variable set.
 
 ### Required Environment Variables
-| Variable                | Value                                               | Notes                                                                                                                                                                                                                                     |
-|-------------------------|-----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `TFC_AWS_PROVIDER_AUTH` | `true`                                              | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate to AWS.                                                                                                                                            |
-| `TFC_AWS_RUN_ROLE_ARN`  | The arn of the AWS role arn to authenticate against | Optional if `TFC_AWS_PLAN_ROLE_ARN` and `TFC_AWS_APPLY_ROLE_ARN` are both provided. These variables are described [below](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration#optional-environment-variables) |
+| Variable                | Value                                 | Notes                                                                                                                                                                                                                                     |
+|-------------------------|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `TFC_AWS_PROVIDER_AUTH` | `true`                                | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate to AWS.                                                                                                                                            |
+| `TFC_AWS_RUN_ROLE_ARN`  | The ARN of the role to assume in AWS. | Optional if `TFC_AWS_PLAN_ROLE_ARN` and `TFC_AWS_APPLY_ROLE_ARN` are both provided. These variables are described [below](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration#optional-environment-variables) |
 
 ### Optional Environment Variables
 You may need to set these variables, depending on your use case.
@@ -104,8 +104,8 @@ You may need to set these variables, depending on your use case.
 | Variable                             | Value                                                                                        | Notes                                                                  |
 |--------------------------------------|----------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
 | `TFC_AWS_WORKLOAD_IDENTITY_AUDIENCE` | Will be used as the `aud` claim for the identity token. Defaults to `aws.workload.identity`. |
-| `TFC_AWS_PLAN_ROLE_ARN`              | The AWS role arn to use for the plan phase of a run.                                         | Will fall back to the value of `TFC_AWS_RUN_ROLE_ARN` if not provided. |
-| `TFC_AWS_APPLY_ROLE_ARN`             | The AWS role arn to use for the apply phase of a run.                                        | Will fall back to the value of `TFC_AWS_RUN_ROLE_ARN` if not provided. |
+| `TFC_AWS_PLAN_ROLE_ARN`              | The ARN of the role to use for the plan phase of a run.                                      | Will fall back to the value of `TFC_AWS_RUN_ROLE_ARN` if not provided. |
+| `TFC_AWS_APPLY_ROLE_ARN`             | The ARN of the role to use for the apply phase of a run.                                     | Will fall back to the value of `TFC_AWS_RUN_ROLE_ARN` if not provided. |
 
 
 ## Configure the AWS Provider

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -13,7 +13,7 @@ description: >-
 
 !> **Warning:** Dynamic Credentials with the Azure providers do **_not_** work when your TFE instance is using a custom or self-signed certificate due to restrictions on Azure's end.
 
-You can use Terraform Cloud’s native OpenID Connect integration with Azure to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the AzureRM or AzureAD providers in your Terraform Cloud runs. Configuring the integration requires the following steps.
+You can use Terraform Cloud’s native OpenID Connect integration with Azure to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the AzureRM or AzureAD providers in your Terraform Cloud runs. Configuring the integration requires the following steps:
 
 1. **[Configure Azure](#configure-azure):** Set up a trust configuration between Azure and Terraform Cloud. Then, you must create Azure roles and policies for your Terraform Cloud workspaces.
 2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -11,7 +11,7 @@ description: >-
 
 !> **Warning:** Dynamic Credentials with the GCP provider do **_not_** work when your TFE instance is using a custom or self-signed certificate due to restrictions on GCP's end.
 
-You can use Terraform Cloud’s native OpenID Connect integration with GCP to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the GCP provider in your Terraform Cloud runs. Configuring the integration requires the following steps.
+You can use Terraform Cloud’s native OpenID Connect integration with GCP to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the GCP provider in your Terraform Cloud runs. Configuring the integration requires the following steps:
 
 1. **[Configure GCP](#configure-gcp):** Set up a trust configuration between GCP and Terraform Cloud. Then, you must create GCP roles and policies for your Terraform Cloud workspaces.
 2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/index.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/index.mdx
@@ -36,8 +36,10 @@ Using dynamic credentials in a workspace requires the following steps for each c
 The process for each step is different for each cloud platform. Refer to the cloud platform configuration instructions for full details. You can configure dynamic credentials for the following platforms:
 - [Vault](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration)
 - [Amazon Web Services](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration)
-- [Azure](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration)
 - [Google Cloud Platform](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration)
+- [Azure](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration)
+
+You can also use Vault to generate credentials for AWS, GCP, or Azure by setting up [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed), which take advantage of Vault's [secrets engines](/vault/docs/secrets) to generate temporary credentials.
 
 ## TFE Specific Requirements
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -1,0 +1,78 @@
+---
+page_title: Vault-Backed Dynamic Credentials with the AWS Provider - Workspaces - Terraform Cloud
+description: >-
+  Use OpenID Connect and Vault to get short-term credentials for the AWS Terraform provider in
+  your Terraform Cloud runs.
+---
+
+# Vault-Backed Dynamic Credentials with the AWS Provider
+
+~> **Important:** If using self-managed agents, make sure you’re using **v1.8.0** or later.
+
+You can use Terraform Cloud’s native OpenID Connect integration with Vault to use [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed) with the AWS provider in your Terraform Cloud runs. Configuring the integration requires the following steps:
+
+1. **[Configure Vault Dynamic Provider Credentials](#configure-vault-dynamic-provider-credentials)**: Set up a trust configuration between Vault and Terraform Cloud, create Vault roles and policies for your Terraform Cloud workspaces, and add environment variables to those workspaces.
+2. **[Configure the Vault AWS Secrets Engine](#configure-vault-aws-secrets-engine)**: Set up the AWS secrets engine in your Vault instance.
+3. **[Configure Terraform Cloud](#configure-terraform-cloud)**: Add additional environment variables to the Terraform Cloud workspaces where you want to use Vault-Backed Dynamic Credentials.
+4. **[Configure Terraform Providers](#configure-terraform-providers)**: Configure your Terraform providers to work with Vault-backed dynamic credentials.
+
+Once you complete this setup, Terraform Cloud automatically authenticates with AWS via Vault-generated credentials during the plan and apply phase of each run. The AWS provider's authentication is only valid for the length of the plan or apply phase.
+
+## Configure Vault Dynamic Provider Credentials
+You must first set up Vault dynamic provider credentials before you can use Vault-backed dynamic credentials. This includes setting up the JWT auth backend in Vault, configuring trust between Terraform Cloud and Vault, and populating the required environment variables in your Terraform Cloud workspace.
+
+[See the setup instructions for Vault dynamic provider credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration).
+
+# Configure Vault AWS Secrets Engine
+Follow the instructions in the Vault documentation for [setting up the AWS secrets engine in your Vault instance](/vault/docs/secrets/aws). You can also do this configuration through Terraform. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/vault-backed/aws).
+
+~> **Important**: carefully consider the limitations and differences between each supported credential type in the AWS secrets engine. These limitations carry over to Terraform Cloud’s usage of these credentials for authenticating the AWS provider.
+
+## Configure Terraform Cloud
+Next, you need to set certain environment variables in your Terraform Cloud workspace to authenticate Terraform Cloud with AWS using Vault-backed dynamic credentials. These variables are in addition to those you previously set while configuring [Vault dynamic provider credentials](#configure-vault-dynamic-provider-credentials). You can add these as workspace variables or as a [variable set](/terraform/cloud-docs/workspaces/variables/managing-variables#variable-sets).
+### Common Environment Variables
+The below variables apply to all AWS auth types.
+
+#### Required Common Environment Variables
+| Variable                              | Value                                                                                                                                      | Notes                                                                                                                                                                                            |
+|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_AWS_AUTH`           | `true`                                                                                                                                     | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate with AWS.                                                                                                 |
+| `TFC_VAULT_BACKED_AWS_AUTH_TYPE`      | Specifies the type of authentication to perform with AWS. Must be one of the following: `iam_user`, `assumed_role`, or `federation_token`. |
+| `TFC_VAULT_BACKED_AWS_RUN_VAULT_ROLE` | The role to use in Vault.                                                                                                                  | Optional if `TFC_VAULT_BACKED_AWS_PLAN_VAULT_ROLE` and `TFC_VAULT_BACKED_AWS_APPLY_VAULT_ROLE` are both provided. These variables are described [below](#optional-common-environment-variables). |
+
+#### Optional Common Environment Variables
+You may need to set these variables, depending on your use case.
+
+| Variable                                | Value                                               | Notes                                                                                 |
+|-----------------------------------------|-----------------------------------------------------|---------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_AWS_MOUNT_PATH`       | The mount path of the AWS secrets engine in Vault.  | Defaults to `aws`.                                                                    |
+| `TFC_VAULT_BACKED_AWS_PLAN_VAULT_ROLE`  | The Vault role to use the plan phase of a run.      | Will fall back to the value of `TFC_VAULT_BACKED_AWS_RUN_VAULT_ROLE` if not provided. |
+| `TFC_VAULT_BACKED_AWS_APPLY_VAULT_ROLE` | The Vault role to use for the apply phase of a run. | Will fall back to the value of `TFC_VAULT_BACKED_AWS_RUN_VAULT_ROLE` if not provided. |
+
+### Assumed Role Specific Environment Variables
+These environment variables are only valid if the `TFC_VAULT_BACKED_AWS_AUTH_TYPE` is `assumed_role`.
+
+#### Required Assumed Role Specific Environment Variables
+| Variable                            | Value                                 | Notes                                                                                                                                                                                                      |
+|-------------------------------------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_AWS_RUN_ROLE_ARN` | The ARN of the role to assume in AWS. | Optional if `TFC_VAULT_BACKED_AWS_PLAN_ROLE_ARN` and `TFC_VAULT_BACKED_AWS_APPLY_ROLE_ARN` are both provided. These variables are described [below](#optional-assume-role-specific-environment-variables). |
+
+#### Optional Assumed Role Specific Environment Variables
+You may need to set these variables, depending on your use case.
+
+| Variable                              | Value                                                    | Notes                                                                               |
+|---------------------------------------|----------------------------------------------------------|-------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_AWS_PLAN_ROLE_ARN`  | The ARN of the role to use for the plan phase of a run.  | Will fall back to the value of `TFC_VAULT_BACKED_AWS_RUN_ROLE_ARN` if not provided. |
+| `TFC_VAULT_BACKED_AWS_APPLY_ROLE_ARN` | The ARN of the role to use for the apply phase of a run. | Will fall back to the value of `TFC_VAULT_BACKED_AWS_RUN_ROLE_ARN` if not provided. |
+
+## Configure Terraform Providers
+The final step is to directly configure your AWS and Vault providers.
+
+### Configure the AWS Provider
+Ensure you pass a value for the `region` argument in your AWS provider configuration block or set the `AWS_REGION` variable in your workspace.
+
+Ensure you are not using any of the arguments or methods mentioned in the [authentication and configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration) section of the provider documentation. Otherwise, these settings may interfere with dynamic provider credentials.
+
+### Configure the Vault Provider
+If you were previously using the Vault provider to authenticate the AWS provider, remove any existing usage of the AWS secrets engine from your Terraform Code.
+This includes the [`vault_aws_access_credentials`](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/aws_access_credentials) data source and any instances of [`vault_generic_secret`](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) you previously used to generate AWS credentials.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -1,0 +1,59 @@
+---
+page_title: Vault-Backed Dynamic Credentials with the Azure Providers - Terraform Cloud
+description: >-
+  Use OpenID Connect and Vault to get short-term credentials for the Azure Terraform providers in
+  your Terraform Cloud runs.
+---
+
+# Vault-Backed Dynamic Credentials with the Azure Provider
+
+~> **Important:** If using self-managed agents, make sure you’re using **v1.8.0** or later.
+
+!> **Warning:** Dynamic Credentials with the Azure providers do **_not_** work when your TFE instance is using a custom or self-signed certificate due to restrictions on Azure's end.
+
+You can use Terraform Cloud’s native OpenID Connect integration with Vault to use [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed) with the Azure provider in your Terraform Cloud runs. Configuring the integration requires the following steps:
+
+1. **[Configure Vault Dynamic Provider Credentials](#configure-vault-dynamic-provider-credentials)**: Set up a trust configuration between Vault and Terraform Cloud, create Vault roles and policies for your Terraform Cloud workspaces, and add environment variables to those workspaces.
+2. **[Configure the Vault Azure Secrets Engine](#configure-vault-azure-secrets-engine)**: Set up the Azure secrets engine in your Vault instance.
+3. **[Configure Terraform Cloud](#configure-terraform-cloud)**: Add additional environment variables to the Terraform Cloud workspaces where you want to use Vault-Backed Dynamic Credentials.
+4. **[Configure Terraform Providers](#configure-terraform-providers)**: Configure your Terraform providers to work with Vault-backed Dynamic Credentials.
+
+Once you complete this setup, Terraform Cloud automatically authenticates with Azure via Vault-generated credentials during the plan and apply phase of each run. The Azure provider's authentication is only valid for the length of the plan or apply phase.
+
+## Configure Vault Dynamic Provider Credentials
+You must first set up Vault dynamic provider credentials before you can use Vault-backed dynamic credentials. This includes setting up the JWT auth backend in Vault, configuring trust between Terraform Cloud and Vault, and populating the required environment variables in your Terraform Cloud workspace.
+
+[See the setup instructions for Vault dynamic provider credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration).
+
+# Configure Vault Azure Secrets Engine
+Follow the instructions in the Vault documentation for [setting up the Azure secrets engine in your Vault instance](/vault/docs/secrets/azure). You can also do this configuration through Terraform. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/vault-backed/azure).
+
+## Configure Terraform Cloud
+Next, you need to set certain environment variables in your Terraform Cloud workspace to authenticate Terraform Cloud with Azure using Vault-backed dynamic credentials. These variables are in addition to those you previously set while configuring [Vault dynamic provider credentials](#configure-vault-dynamic-provider-credentials). You can add these as workspace variables or as a [variable set](/terraform/cloud-docs/workspaces/variables/managing-variables#variable-sets).
+
+### Required Environment Variables
+| Variable                                | Value                     | Notes                                                                                                                                                                                         |
+|-----------------------------------------|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_AZURE_AUTH`           | `true`                    | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate with Azure.                                                                                            |
+| `TFC_VAULT_BACKED_AZURE_RUN_VAULT_ROLE` | The role to use in Vault. | Optional if `TFC_VAULT_BACKED_AZURE_PLAN_VAULT_ROLE` and `TFC_VAULT_BACKED_AZURE_APPLY_VAULT_ROLE` are both provided. These variables are described [below](#optional-environment-variables). |
+
+### Optional Environment Variables
+You may need to set these variables, depending on your use case.
+
+| Variable                                  | Value                                                | Notes                                                                                   |
+|-------------------------------------------|------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_AZURE_MOUNT_PATH`       | The mount path of the Azure secrets engine in Vault. | Defaults to `azure`.                                                                    |
+| `TFC_VAULT_BACKED_AZURE_PLAN_VAULT_ROLE`  | The Vault role to use the plan phase of a run.       | Will fall back to the value of `TFC_VAULT_BACKED_AZURE_RUN_VAULT_ROLE` if not provided. |
+| `TFC_VAULT_BACKED_AZURE_APPLY_VAULT_ROLE` | The Vault role to use for the apply phase of a run.  | Will fall back to the value of `TFC_VAULT_BACKED_AZURE_RUN_VAULT_ROLE` if not provided. |
+
+## Configure Terraform Providers
+The final step is to directly configure your Azure and Vault providers.
+
+### Configure the AzureRM or AzureAD Provider
+Ensure you pass a value for the `subscription_id` and `tenant_id` arguments in your provider configuration block or set the `ARM_SUBSCRIPTION_ID` and `ARM_TENANT_ID` variables in your workspace.
+
+Do not set values for `client_id`, `use_oidc`, or `oidc_token` in your provider configuration block. Additionally, do not set variable values for `ARM_CLIENT_ID`, `ARM_USE_OIDC`, or `ARM_OIDC_TOKEN`.
+
+### Configure the Vault Provider
+If you were previously using the Vault provider to authenticate the Azure provider, remove any existing usage of the Azure secrets engine from your Terraform Code.
+This includes the [`vault_azure_access_credentials`](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/azure_access_credentials) data source and any instances of [`vault_generic_secret`](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) you previously used to generate Azure credentials.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -1,0 +1,94 @@
+---
+page_title: Vault-Backed Dynamic Credentials with the GCP Provider - Workspaces - Terraform Cloud
+description: >-
+  Use OpenID Connect and Vault to get short-term credentials for the GCP Terraform provider in
+  your Terraform Cloud runs.
+---
+
+# Vault-Backed Dynamic Credentials with the GCP Provider
+
+~> **Important:** If using self-managed agents, make sure you’re using **v1.8.0** or later.
+
+!> **Warning:** Dynamic Credentials with the GCP provider do **_not_** work when your TFE instance is using a custom or self-signed certificate due to restrictions on GCP's end.
+
+You can use Terraform Cloud’s native OpenID Connect integration with Vault to use [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed) with the GCP provider in your Terraform Cloud runs. Configuring the integration requires the following steps:
+
+1. **[Configure Vault Dynamic Provider Credentials](#configure-vault-dynamic-provider-credentials)**: Set up a trust configuration between Vault and Terraform Cloud, create Vault roles and policies for your Terraform Cloud workspaces, and add environment variables to those workspaces.
+2. **[Configure the Vault GCP Secrets Engine](#configure-vault-gcp-secrets-engine)**: Set up the GCP secrets engine in your Vault instance.
+3. **[Configure Terraform Cloud](#configure-terraform-cloud)**: Add additional environment variables to the Terraform Cloud workspaces where you want to use Vault-Backed Dynamic Credentials.
+4. **[Configure Terraform Providers](#configure-terraform-providers)**: Configure your Terraform providers to work with Vault-backed dynamic credentials.
+
+Once you complete this setup, Terraform Cloud automatically authenticates with GCP via Vault-generated credentials during the plan and apply phase of each run. The GCP provider's authentication is only valid for the length of the plan or apply phase.
+
+## Configure Vault Dynamic Provider Credentials
+You must first set up Vault dynamic provider credentials before you can use Vault-backed dynamic credentials. This includes setting up the JWT auth backend in Vault, configuring trust between Terraform Cloud and Vault, and populating the required environment variables in your Terraform Cloud workspace.
+
+[See the setup instructions for Vault dynamic provider credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration).
+
+# Configure Vault GCP Secrets Engine
+Follow the instructions in the Vault documentation for [setting up the GCP secrets engine in your Vault instance](/vault/docs/secrets/gcp). You can also do this configuration through Terraform. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/vault-backed/gcp).
+
+~> **Important**: carefully consider the limitations and differences between each supported credential type in the GCP secrets engine. These limitations carry over to Terraform Cloud’s usage of these credentials for authenticating the GCP provider.
+
+## Configure Terraform Cloud
+Next, you need to set certain environment variables in your Terraform Cloud workspace to authenticate Terraform Cloud with GCP using Vault-backed dynamic credentials. These variables are in addition to those you previously set while configuring [Vault dynamic provider credentials](#configure-vault-dynamic-provider-credentials). You can add these as workspace variables or as a [variable set](/terraform/cloud-docs/workspaces/variables/managing-variables#variable-sets).
+
+### Common Environment Variables
+The below variables apply to all GCP auth types.
+
+#### Required Common Environment Variables
+| Variable                         | Value                                                                                                                                                                                                                  | Notes                                                                                            |
+|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_GCP_AUTH`      | `true`                                                                                                                                                                                                                 | Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate with GCP. |
+| `TFC_VAULT_BACKED_GCP_AUTH_TYPE` | Specifies the type of authentication to perform with GCP. Must be one of the following: `roleset/access_token`, `roleset/service_account_key`, `static_account/access_token`, or `static_account/service_account_key`. |
+
+#### Optional Common Environment Variables
+You may need to set these variables, depending on your use case.
+
+| Variable                          | Value                                              | Notes              |
+|-----------------------------------|----------------------------------------------------|--------------------|
+| `TFC_VAULT_BACKED_GCP_MOUNT_PATH` | The mount path of the GCP secrets engine in Vault. | Defaults to `gcp`. |
+
+### Roleset Specific Environment Variables
+These environment variables are only valid if the `TFC_VAULT_BACKED_GCP_AUTH_TYPE` is `roleset/access_token` or `roleset/service_account_key`.
+
+#### Required Roleset Specific Environment Variables
+| Variable                                 | Value                        | Notes                                                                                                                                                                                                            |
+|------------------------------------------|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_GCP_RUN_VAULT_ROLESET` | The roleset to use in Vault. | Optional if `TFC_VAULT_BACKED_GCP_PLAN_VAULT_ROLESET` and `TFC_VAULT_BACKED_GCP_APPLY_VAULT_ROLESET` are both provided. These variables are described [below](#optional-roleset-specific-environment-variables). |
+
+#### Optional Roleset Specific Environment Variables
+You may need to set these variables, depending on your use case.
+
+| Variable                                   | Value                                            | Notes                                                                                    |
+|--------------------------------------------|--------------------------------------------------|------------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_GCP_PLAN_VAULT_ROLESET`  | The roleset to use for the plan phase of a run.  | Will fall back to the value of `TFC_VAULT_BACKED_GCP_RUN_VAULT_ROLESET` if not provided. |
+| `TFC_VAULT_BACKED_GCP_APPLY_VAULT_ROLESET` | The roleset to use for the apply phase of a run. | Will fall back to the value of `TFC_VAULT_BACKED_GCP_RUN_VAULT_ROLESET` if not provided. |
+
+### Static Account Specific Environment Variables
+These environment variables are only valid if the `TFC_VAULT_BACKED_GCP_AUTH_TYPE` is `static_account/access_token` or `static_account/service_account_key`.
+
+#### Required Static Account Specific Environment Variables
+| Variable                                        | Value                               | Notes                                                                                                                                                                                                                                 |
+|-------------------------------------------------|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_GCP_RUN_VAULT_STATIC_ACCOUNT` | The static account to use in Vault. | Optional if `TFC_VAULT_BACKED_GCP_PLAN_VAULT_STATIC_ACCOUNT` and `TFC_VAULT_BACKED_GCP_APPLY_VAULT_STATIC_ACCOUNT` are both provided. These variables are described [below](#optional-static-account-specific-environment-variables). |
+
+#### Optional Static Account Specific Environment Variables
+You may need to set these variables, depending on your use case.
+
+| Variable                                          | Value                                                   | Notes                                                                                           |
+|---------------------------------------------------|---------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `TFC_VAULT_BACKED_GCP_PLAN_VAULT_STATIC_ACCOUNT`  | The static account to use for the plan phase of a run.  | Will fall back to the value of `TFC_VAULT_BACKED_GCP_RUN_VAULT_STATIC_ACCOUNT` if not provided. |
+| `TFC_VAULT_BACKED_GCP_APPLY_VAULT_STATIC_ACCOUNT` | The static account to use for the apply phase of a run. | Will fall back to the value of `TFC_VAULT_BACKED_GCP_RUN_VAULT_STATIC_ACCOUNT` if not provided. |
+
+## Configure Terraform Providers
+The final step is to directly configure your GCP and Vault providers.
+
+### Configure the GCP Provider
+Ensure you pass values for the `project` and `region` arguments into the provider configuration block.
+
+Ensure you are not setting values or environment variables for `GOOGLE_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS`. Otherwise, these values may interfere with dynamic provider credentials.
+
+### Configure the Vault Provider
+If you were previously using the Vault provider to authenticate the GCP provider, remove any existing usage of the GCP secrets engine from your Terraform Code.
+This includes instances of [`vault_generic_secret`](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/generic_secret) that you previously used to generate GCP credentials.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -1,0 +1,47 @@
+---
+page_title: Vault-Backed Dynamic Credentials - Dynamic Provider Credentials - Workspaces - Terraform Cloud
+description: >-
+  Vault-Backed dynamic credentials improve security by leveraging Vault to generate
+  temporary credentials for Terraform Cloud runs. Configure Vault-backed dynamic credentials
+  for the AWS, Azure, and GCP providers.
+---
+
+# Vault-Backed Dynamic Credentials
+
+~> **Important:** If using self-managed agents, make sure you’re using **v1.8.0** or later.
+
+For most use cases, separately configuring [dynamic provider credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) with different cloud providers works well. However, Vault-backed dynamic credentials are for those looking for a way to:
+ 1. Use Vault's secrets engines as a centralized way to manage and consolidate cloud credentials management.
+ 2. Generate short-lived credentials without exposing their Terraform Enterprise instance's OIDC metadata endpoints to the broader public internet.
+
+The "Vault-backed" in "Vault-backed dynamic credentials" refers to Vault's [secrets engines](/vault/docs/secrets), which allow you to generate short-lived [dynamic secrets](https://www.vaultproject.io/use-cases/dynamic-secrets) for the AWS, GCP, or Azure providers. If you are using Terraform Enterprise and your Vault instance is configured within the same secure network, you can generate secrets while keeping your environment air-gapped.
+
+Vault-backed dynamic credentials combine the features of dynamic provider credentials and Vault's secrets engines. This means you can authenticate a Vault instance using workload identity tokens and use secrets engines on that instance to generate dynamic credentials for the AWS, GCP, and Azure providers.
+
+## Configure Vault-Backed Dynamic Credentials
+
+Using Vault-backed dynamic credentials in a workspace requires the following steps for each cloud platform:
+
+1. **Set up Dynamic Provider Credentials with the Vault Provider:** You must first [configure dynamic credentials with the Vault provider](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration).
+2. **Configure the desired Secrets Engine**: You must configure the desired secrets engine in your Vault instance (i.e., AWS, GCP, or Azure).
+3. **Configure Terraform Cloud Workspace**: You must add specific environment variables to your workspace to tell Terraform Cloud how to authenticate to other cloud providers during runs. Each cloud platform has its own set of environment variables that are necessary to configure dynamic credentials.
+
+Setting up Vault-backed dynamic credentials differs slightly for each cloud provider. You can configure Vault-backed dynamic credentials on the following platforms:
+- [Amazon Web Services](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration)
+- [Google Cloud Platform](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration)
+- [Azure](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration)
+
+## TFE Specific Requirements
+
+### Access to Metadata Endpoints
+
+In order to verify signed JWTs, Vault must have network access to the following static OIDC metadata endpoints within TFE:
+
+1. `/.well-known/openid-configuration` - standard OIDC metadata.
+2. `/.well-known/jwks` - TFE’s public key(s) that cloud platforms use to verify the authenticity of tokens that claim to come from TFE.
+
+These endpoints **do not** need to be publicly exposed as long as your Vault instance can access them.
+
+### External Vault Policy
+
+If you are using an external Vault instance, you must ensure that your Vault instance has the correct policies setup as detailed in the [External Vault Requirements for Terraform Enterprise](/terraform/enterprise/requirements/data-storage/vault) documentation.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -9,15 +9,17 @@ description: >-
 
 ~> **Important:** If using self-managed agents, make sure you’re using **v1.7.0** or later.
 
-You can use Terraform Cloud’s native OpenID Connect integration with Vault to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the Vault provider in your Terraform Cloud runs. Configuring the integration requires the following steps.
+You can use Terraform Cloud’s native OpenID Connect integration with Vault to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the Vault provider in your Terraform Cloud runs. Configuring the integration requires the following steps:
 
 1. **[Configure Vault](#configure-vault):** Set up a trust configuration between Vault and Terraform Cloud. Then, you must create Vault roles and policies for your Terraform Cloud workspaces.
 2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.
 
 Once you complete the setup, Terraform Cloud automatically authenticates to Vault during each run. The Vault provider authentication is valid for the length of the plan or apply. Vault does not revoke authentication until the run is complete.
 
+If you are using Vault's [secrets engines](/vault/docs/secrets), you must complete the following set up before continuing to configure [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed).
+
 ## Configure Vault
-You must enable and configure the JWT backend in Vault. These instructions use the Vault CLI commands, but you can also use Terraform to configure Vault. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-workload-identity-setup-examples/tree/main/vault).
+You must enable and configure the JWT backend in Vault. These instructions use the Vault CLI commands, but you can also use Terraform to configure Vault. Refer to our [example Terraform configuration](https://github.com/hashicorp/terraform-dynamic-credentials-setup-examples/tree/main/vault).
 ### Enable the JWT Auth Backend
 Run the following command to enable the JWT auth backend in Vault:
 ```shell
@@ -125,6 +127,4 @@ Once you set up dynamic credentials for a workspace, Terraform Cloud automatical
 You can use the Vault provider to read secrets from Vault and use them with other Terraform resources. You can also access the other resources and data sources available in the [Vault provider documentation](https://registry.terraform.io/providers/hashicorp/vault/latest). You must adjust your [Vault policy](#create-a-vault-policy) to give your Terraform Cloud workspace access to all required Vault paths.
 
 ### Vault Dynamic Secrets Engines
-You **cannot** access Vault’s dynamic secrets engines via the Vault provider’s dynamic secrets data sources (such as `[vault_aws_access_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/aws_access_credentials)`) when using this integration.
-
-This is because data sources in Terraform Cloud are read only once, during the plan, and the results are passed to the apply using a [plan output file](/terraform/cli/commands/plan#out-filename). When the plan’s Vault token is revoked, any dynamic secrets issued using that token are revoked as well, so they’ll be invalid when the apply runs.
+You can use Vault's dynamic secrets engines for AWS, GCP, and Azure by adding additional configurations. For more details, see [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed).


### PR DESCRIPTION
### What
Adds documentation for Vault-backed dynamic credentials in Terraform Cloud

### Why
This change describes the new Vault-backed dynamic credentials functionality that is being released for Terraform Cloud and provides guidance on setup for AWS / GCP / Azure.

### Links
- [Landing Page JIRA](https://hashicorp.atlassian.net/browse/TF-4428)
- [AWS Page JIRA](https://hashicorp.atlassian.net/browse/TF-4429)
- [GCP Page JIRA](https://hashicorp.atlassian.net/browse/TF-4430)
- [Azure Page JIRA](https://hashicorp.atlassian.net/browse/TF-4431)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
