### PR TITLE
Add Version Id to Workspace Variables

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,10 @@ description: >-
 
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
+## 2023-04-25
+
+* Add the `version-id` property to the response for the Create, List, and Update [Workspace Variables endpoints](/terraform/cloud-docs/api-docs/workspaces-variables).
+
 ## 2023-03-30
 
 * Add the `sort` query parameter to the Workspaces API's [list workspaces endpoint](/terraform/cloud-docs/api-docs/workspaces#list-workspaces).

--- a/website/docs/cloud-docs/api-docs/workspace-variables.mdx
+++ b/website/docs/cloud-docs/api-docs/workspace-variables.mdx
@@ -118,7 +118,7 @@ curl \
       "sensitive":false,
       "category":"terraform",
       "hcl":false,
-      "version-id":"1aa07d63ea8ff4df941c94ca9ddfd5d2bd04cefda0e7096d96a94fa9f28f7608"
+      "version-id":"1aa07d63ea8ff4df941c94ca9ddfd5d2bd04"
     },
     "relationships": {
       "configurable": {
@@ -169,7 +169,7 @@ $ curl \
         "sensitive":false,
         "category":"terraform",
         "hcl":false,
-        "version-id":"1aa07d63ea8ff4df941c94ca9ddfd5d2bd04cefda0e7096d96a94fa9f28f7608"
+        "version-id":"1aa07d63ea8ff4df941c94ca9ddfd5d2bd04"
       },
       "relationships": {
         "configurable": {
@@ -255,7 +255,7 @@ $ curl \
       "sensitive":false,
       "category":"terraform",
       "hcl":false,
-      "version-id":"1aa07d63ea8ff4df941c94ca9ddfd5d2bd04cefda0e7096d96a94fa9f28f7608"
+      "version-id":"1aa07d63ea8ff4df941c94ca9ddfd5d2bd04"
     },
     "relationships": {
       "configurable": {

--- a/website/docs/cloud-docs/api-docs/workspace-variables.mdx
+++ b/website/docs/cloud-docs/api-docs/workspace-variables.mdx
@@ -117,7 +117,8 @@ curl \
       "description":"some description",
       "sensitive":false,
       "category":"terraform",
-      "hcl":false
+      "hcl":false,
+      "version-id":"1aa07d63ea8ff4df941c94ca9ddfd5d2bd04cefda0e7096d96a94fa9f28f7608"
     },
     "relationships": {
       "configurable": {
@@ -167,7 +168,8 @@ $ curl \
         "description":"some description",
         "sensitive":false,
         "category":"terraform",
-        "hcl":false
+        "hcl":false,
+        "version-id":"1aa07d63ea8ff4df941c94ca9ddfd5d2bd04cefda0e7096d96a94fa9f28f7608"
       },
       "relationships": {
         "configurable": {
@@ -252,7 +254,8 @@ $ curl \
       "description":"some description",
       "sensitive":false,
       "category":"terraform",
-      "hcl":false
+      "hcl":false,
+      "version-id":"1aa07d63ea8ff4df941c94ca9ddfd5d2bd04cefda0e7096d96a94fa9f28f7608"
     },
     "relationships": {
       "configurable": {


### PR DESCRIPTION
### What
Add the property `version-id` to the response for the Create, List and Update Workspace Variables endpoints. This property can be used to determine if an update was made to a variable.

The new property is being added in Atlas with [PR 15446](https://github.com/hashicorp/atlas/pull/15446).

Endpoints Include
- GET /workspaces/:workspace_id/vars
- POST /workspaces/:workspace_id/vars
- PATCH /workspaces/:workspace_id/vars/:variable_id

### Why
Including this will allow a faster way to determine if a variable was updated over the current way which is to compare each property's value.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
