### PR TITLE
Clarify localterraform.com docs, add CLI-workflow version requirement

### DIFF
--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -93,9 +93,9 @@ module "vpc" {
 ```
 
 
-### Generic Hostname - Terraform Enterprise
+### Generic Hostname - Terraform Cloud and Terraform Enterprise
 
-You can use the generic hostname `localterraform.com` in module sources to reference modules without modifying the Terraform Enterprise instance. When you run Terraform, it automatically requests any `localterraform.com` modules from the Terraform Enterprise instance.
+You can use the generic hostname `localterraform.com` in module sources to reference modules without modifying the Terraform Cloud or Terraform Enterprise instance. When you run Terraform, it automatically requests any `localterraform.com` modules from the instance it is running on.
 
 ```hcl
 module "vpc" {
@@ -104,7 +104,7 @@ module "vpc" {
 }
 ```
 
-~> **Important:** The generic hostname only works within a Terraform Enterprise instance.
+~> **Important:** Terraform CLI v1.4.0+ is required for CLI-driven workflows.
 
 To test configurations on a developer workstation without the remote backend configured, you must replace the generic hostname with a literal hostname in all module sources and then change them back before committing to VCS. We are working on making this workflow smoother, but we only recommend `localterraform.com` for large organizations that use multiple Terraform Enterprise instances.
 

--- a/website/docs/cloud-docs/registry/using.mdx
+++ b/website/docs/cloud-docs/registry/using.mdx
@@ -95,7 +95,7 @@ module "vpc" {
 
 ### Generic Hostname - Terraform Cloud and Terraform Enterprise
 
-You can use the generic hostname `localterraform.com` in module sources to reference modules without modifying the Terraform Cloud or Terraform Enterprise instance. When you run Terraform, it automatically requests any `localterraform.com` modules from the instance it is running on.
+You can use the generic hostname `localterraform.com` in module sources to reference modules without modifying the Terraform Cloud or Terraform Enterprise instance. When you run Terraform, it automatically requests any `localterraform.com` modules from the instance it runs on.
 
 ```hcl
 module "vpc" {
@@ -104,7 +104,7 @@ module "vpc" {
 }
 ```
 
-~> **Important:** Terraform CLI v1.4.0+ is required for CLI-driven workflows.
+~> **Important**: CLI-driven workflows require Terraform CLI v1.4.0 or above.
 
 To test configurations on a developer workstation without the remote backend configured, you must replace the generic hostname with a literal hostname in all module sources and then change them back before committing to VCS. We are working on making this workflow smoother, but we only recommend `localterraform.com` for large organizations that use multiple Terraform Enterprise instances.
 


### PR DESCRIPTION
🎟️ [Asana Ticket](https://app.asana.com/0/1128567758154570/1204097183067299/f)
🔍 [Deploy Preview](https://terraform-docs-common-git-bmm-localtf-cli-hashicorp.vercel.app/terraform/cloud-docs/registry/using#generic-hostname-terraform-cloud-and-terraform-enterprise)

### What

This addresses two issues:

1. The current docs read that only TFE supports `localterraform.com`, but TFC also supports this feature.
2. Added a callout that CLI v1.4.0+ is required for CLI-driven workflows

### Why

Better clarifies the availability and use of this feature

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] N/A Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
