### PR TITLE
Add oidc_discovery_ca_pem guidance

### DIFF
--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -32,6 +32,18 @@ vault write auth/jwt/config \
 ```
 The `oidc_discovery_url` and `bound_issuer` should both be the root address of Terraform Cloud, including the scheme and without a trailing slash.
 
+#### TFE Specific Requirements
+
+If you are using a custom or self-signed CA certificate you may need to specify the CA certificate or chain of certificates, in PEM format, via the [`oidc_discovery_ca_pem`](/vault/api-docs/auth/jwt#oidc_discovery_ca_pem) argument like in the following example command:
+```shell
+vault write auth/jwt/config \
+    oidc_discovery_url="https://app.terraform.io" \
+    bound_issuer="https://app.terraform.io" \
+    oidc_discovery_ca_pem=@my-cert.pem
+```
+
+Where `my-cert.pem` is a PEM formatted file containing the certificate.
+
 ### Create a Vault Policy
 
 You must create a Vault policy that controls what paths and secrets your Terraform Cloud workspace can access in Vault.


### PR DESCRIPTION
### What / Why
Adds guidance around `oidc_discovery_ca_pem` for users who wish to use Vault dynamic credentials with a TFE instance that has custom or self-signed CA certs.

### Links
- [JIRA](https://hashicorp.atlassian.net/browse/TF-5378)
----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] (N/A) API documentation and the API Changelog have been updated. 
- [ ] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] (N/A) Pages with related content are updated and link to this content when appropriate.
- [ ] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] (N/A) New pages have metadata (page name and description) at the top.
- [ ] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
