### PR TITLE
Fix 'related' URL for oauth client to use URL to list of oauth tokens for current oauth client

### DIFF
--- a/website/docs/cloud-docs/api-docs/oauth-clients.mdx
+++ b/website/docs/cloud-docs/api-docs/oauth-clients.mdx
@@ -107,7 +107,7 @@ curl \
         "oauth-tokens": {
           "data": [],
           "links": {
-            "related": "/api/v2/oauth-tokens/ot-KaeqH4cy72VPXFQT"
+            "related": "/api/v2/oauth-clients/oc-XKFwG6ggfA9n7t1K/oauth-tokens"
           }
         }
       }
@@ -171,7 +171,7 @@ curl \
       "oauth-tokens": {
         "data": [],
         "links": {
-          "related": "/api/v2/oauth-tokens/ot-KaeqH4cy72VPXFQT"
+          "related": "/api/v2/oauth-clients/oc-XKFwG6ggfA9n7t1K/oauth-tokens"
         }
       }
     }
@@ -283,7 +283,7 @@ curl \
       "oauth-tokens": {
         "data": [],
         "links": {
-          "related": "/api/v2/oauth-tokens/ot-KaeqH4cy72VPXFQT"
+          "related": "/api/v2/oauth-clients/oc-XKFwG6ggfA9n7t1K/oauth-tokens"
         }
       }
     }
@@ -377,7 +377,7 @@ curl \
       "oauth-tokens": {
         "data": [],
         "links": {
-          "related": "/api/v2/oauth-tokens/ot-KaeqH4cy72VPXFQT"
+          "related": "/api/v2/oauth-clients/oc-XKFwG6ggfA9n7t1K/oauth-tokens"
         }
       }
     }


### PR DESCRIPTION

### What
Update the 'related' URL in the example responses from oauth client endpoints .

### Why
The original URL was for a particular oauth token, which isn't present in the list and, based on real testing, this URL should the link to the list of oauth tokens for the given oauth client.

### Screenshots
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file. - *No pages added/removed/moved*
- [x] API documentation and the API Changelog have been updated. - *No API changes, purely documentation.*
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate. - *No new pages*
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. - *No page changes*
- [x] New pages have metadata (page name and description) at the top. - *No new pages*
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. - *No new images*
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. - *No new code blocks*
- [ ] UI elements (button names, page names, etc.) are bolded. - *No changes to UI elements*
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
