### PR TITLE
adding a note for the private regsitry not supported

### DIFF
--- a/website/docs/registry/providers/docs.mdx
+++ b/website/docs/registry/providers/docs.mdx
@@ -11,6 +11,8 @@ The [Terraform Registry][terraform-registry] displays documentation for the prov
 
 -> In order to test how documents will render in the Terraform Registry, you can use the [Terraform Registry Doc Preview Tool](https://registry.terraform.io/tools/doc-preview).
 
+-> Please note that this currently isn't supported in the private registry of [Terraform Cloud/Terraform Enterprise](https://developer.hashicorp.com/terraform/cloud-docs/registry/publish-providers#release-files)
+
 ## Publishing
 
 The Terraform Registry publishes providers from their Git repositories, creating a version for each Git tag that matches the [Semver](https://semver.org/) versioning format. Provider documentation is published automatically as part of the provider release process.


### PR DESCRIPTION
### What
added lines to website/docs/registry/providers/docs.mdx 

### Why
Customer created a ticket that they created the entire documentation and later found that it wasn't supported yet on TFC/TFE
https://developer.hashicorp.com/terraform/cloud-docs/registry/publish-providers#release-files