### PR TITLE
Documentation for configuration-driven import and generated configuration in Terraform Cloud

### DIFF
--- a/website/docs/cloud-docs/api-docs/applies.mdx
+++ b/website/docs/cloud-docs/api-docs/applies.mdx
@@ -101,7 +101,8 @@ curl \
       "log-read-url": "https://archivist.terraform.io/v1/object/dmF1bHQ6djE6OFA1eEdlSFVHRSs4YUcwaW83a1dRRDA0U2E3T3FiWk1HM2NyQlNtcS9JS1hHN3dmTXJmaFhEYTlHdTF1ZlgxZ2wzVC9kVTlNcjRPOEJkK050VFI3U3dvS2ZuaUhFSGpVenJVUFYzSFVZQ1VZYno3T3UyYjdDRVRPRE5pbWJDVTIrNllQTENyTndYd1Y0ak1DL1dPVlN1VlNxKzYzbWlIcnJPa2dRRkJZZGtFeTNiaU84YlZ4QWs2QzlLY3VJb3lmWlIrajF4a1hYZTlsWnFYemRkL2pNOG9Zc0ZDakdVMCtURUE3dDNMODRsRnY4cWl1dUN5dUVuUzdnZzFwL3BNeHlwbXNXZWRrUDhXdzhGNnF4c3dqaXlZS29oL3FKakI5dm9uYU5ZKzAybnloREdnQ3J2Rk5WMlBJemZQTg",
       "resource-additions": 1,
       "resource-changes": 0,
-      "resource-destructions": 0
+      "resource-destructions": 0,
+      "resource-imports": 0
     },
     "relationships": {
       "state-versions": {
@@ -150,7 +151,8 @@ _Using Terraform Cloud Agents_
       "log-read-url": "https://archivist.terraform.io/v1/object/dmF1bHQ6djE6OFA1eEdlSFVHRSs4YUcwaW83a1dRRDA0U2E3T3FiWk1HM2NyQlNtcS9JS1hHN3dmTXJmaFhEYTlHdTF1ZlgxZ2wzVC9kVTlNcjRPOEJkK050VFI3U3dvS2ZuaUhFSGpVenJVUFYzSFVZQ1VZYno3T3UyYjdDRVRPRE5pbWJDVTIrNllQTENyTndYd1Y0ak1DL1dPVlN1VlNxKzYzbWlIcnJPa2dRRkJZZGtFeTNiaU84YlZ4QWs2QzlLY3VJb3lmWlIrajF4a1hYZTlsWnFYemRkL2pNOG9Zc0ZDakdVMCtURUE3dDNMODRsRnY4cWl1dUN5dUVuUzdnZzFwL3BNeHlwbXNXZWRrUDhXdzhGNnF4c3dqaXlZS29oL3FKakI5dm9uYU5ZKzAybnloREdnQ3J2Rk5WMlBJemZQTg",
       "resource-additions": 1,
       "resource-changes": 0,
-      "resource-destructions": 0
+      "resource-destructions": 0,
+      "resource-imports": 0
     },
     "relationships": {
       "state-versions": {

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -11,6 +11,10 @@ Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 ## 2023-06-09
 
+* Introduce support for [`import` blocks](/terraform/language/import/generating-configuration).
+  * [Runs](/terraform/cloud-docs/api-docs/run#create-a-run) have a new `allow-config-generation` option.
+  * [Plans](/terraform/cloud-docs/api-docs/plans#show-a-plan) have new `resource-imports` and `generated-configuration` properties.
+  * [Applies](/terraform/cloud-docs/api-docs/applies#show-an-apply) have a new `resource-imports` property.
 * The workspaces associated with a policy set can now be updated using the [Policy Sets PATCH endpoint](/terraform/cloud-docs/api-docs/policy-sets#update-a-policy-set)
 * Update the [Workspaces](/terraform/cloud-docs/api-docs/workspaces) API endpoints to include the associated [project](/terraform/cloud-docs/api-docs/projects).
 

--- a/website/docs/cloud-docs/api-docs/plans.mdx
+++ b/website/docs/cloud-docs/api-docs/plans.mdx
@@ -94,10 +94,12 @@ curl \
       "execution-details": {
         "mode": "remote",
       },
+      "generated-configuration": false,
       "has-changes": true,
       "resource-additions": 0,
       "resource-changes": 1,
       "resource-destructions": 0,
+      "resource-imports": 0,
       "status": "finished",
       "status-timestamps": {
         "queued-at": "2018-07-02T22:29:53+00:00",
@@ -137,10 +139,12 @@ _Using Terraform Cloud Agents_
         "agent-pool-name": "first-pool",
         "mode": "agent",
       },
+      "generated-configuration": false,
       "has-changes": true,
       "resource-additions": 0,
       "resource-changes": 1,
       "resource-destructions": 0,
+      "resource-imports": 0,
       "status": "finished",
       "status-timestamps": {
         "queued-at": "2018-07-02T22:29:53+00:00",

--- a/website/docs/cloud-docs/api-docs/run.mdx
+++ b/website/docs/cloud-docs/api-docs/run.mdx
@@ -139,6 +139,8 @@ Properties without a default value are required.
 
 | Key path                                           | Type                 | Default                                            | Description                                                                                                                                                                                                                                   |
 |----------------------------------------------------|----------------------|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `data.attributes.allow-empty-apply`                | bool                 |                                                    | Specifies whether Terraform can apply the run even when the plan [contains no changes](/terraform/cloud-docs/run/modes-and-options#allow-empty-apply). Often used to [upgrade state](/terraform/cloud-docs/workspaces/state#upgrading-state) after upgrading a workspace to a new terraform version.                                                                     |
+| `data.attributes.allow-config-generation`                | bool                 | false                                              | Specifies whether Terraform can [generate resource configuration](/terraform/language/import/generating-configuration) when planning to import new resources. If false, `import` blocks without a corresponding `resource` block will error.                                                               |
 | `data.attributes.auto-apply`                       | bool                 | The current Auto Apply setting in the workspace    | Whether to automatically apply changes when a Terraform plan is successful. Defaults to the [Auto Apply](/terraform/cloud-docs/workspaces/settings#auto-apply-and-manual-apply) workspace setting.                                                      |
 | `data.attributes.is-destroy`                       | bool                 | false                                              | Specifies whether this plan is a destroy plan that will destroy all provisioned resources. Mutually exclusive with `refresh-only`.                                                                                                            |
 | `data.attributes.message`                          | string               | "Queued manually via the Terraform Enterprise API" | Specifies the message associated with this run.                                                                                                                                                                                         |
@@ -149,7 +151,6 @@ Properties without a default value are required.
 | `data.attributes.variables`                        | array\[{key, value}] | (empty array)                                      | Specifies an optional list of run-specific variable values. Refer to [Run-Specific Variables](/terraform/cloud-docs/workspaces/variables/managing-variables#run-specific-variables) for details.    |
 | `data.attributes.plan-only`                        | bool                 | (from configuration version)                       | Specifies if this is a [speculative, plan-only](/terraform/cloud-docs/run/modes-and-options#plan-only-speculative-plan) run that Terraform cannot apply. Often used in conjunction with terraform-version in order to test whether an upgrade would succeed. |
 | `data.attributes.terraform-version`                | string               |                                                    | Specifies the Terraform version to use in this run. Only valid for plan-only runs; must be a valid Terraform version available to the organization.                                                                                           |
-| `data.attributes.allow-empty-apply`                | bool                 |                                                    | Specifies whether Terraform can apply the run even when the plan [contains no changes](/terraform/cloud-docs/run/modes-and-options#allow-empty-apply). Often used to [upgrade state](/terraform/cloud-docs/workspaces/state#upgrading-state) after upgrading a workspace to a new terraform version.                                                                     |
 | `data.relationships.workspace.data.id`             | string               |                                                    | Specifies the workspace ID where the run will be executed.                                                                                                                                                                                    |
 | `data.relationships.configuration-version.data.id` | string               |                                                    | Specifies the configuration version to use for this run. If the `configuration-version` object is omitted, the run will be created using the workspace's latest configuration version.                                                        |
 
@@ -216,6 +217,7 @@ curl \
       "has-changes": false,
       "auto-apply": false,
       "allow-empty-apply": false,
+      "allow-config-generation": false,
       "is-destroy": false,
       "message": "Custom message",
       "plan-only": false,
@@ -372,6 +374,7 @@ curl \
         "has-changes": false,
         "auto-apply": false,
         "allow-empty-apply": false,
+        "allow-config-generation": false,
         "is-destroy": false,
         "message": "Custom message",
         "plan-only": false,
@@ -460,6 +463,7 @@ curl \
       "has-changes": false,
       "auto-apply": false,
       "allow-empty-apply": false,
+      "allow-config-generation": false,
       "is-destroy": false,
       "message": "Custom message",
       "plan-only": false,

--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -85,6 +85,6 @@ When using [`import` blocks](/terraform/language/import) to import existing reso
 - **CLI:** Use `terraform plan -generate-config-out=generated.tf`.
 - **API:** Use the `allow-config-generation` option.
 
-You can find generated configuration displayed in the plan UI. If you're using the CLI workflow, generated configuration will be written to the file you specify when running `terraform plan`.
+You can find generated configuration displayed in the plan UI. If you're using the CLI workflow, Terraform will write generated configuration to the file you specify when running `terraform plan`.
 
 Once Terraform has generated configuration for you, you'll need to review it, incorporate it in your Terraform configuration (including committing it to version control), then run another plan. If you try to directly apply a plan with generated configuration, the run will error.

--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -75,3 +75,16 @@ The usual caveats for targeting in local operations imply some additional limita
 - [Cost Estimation](/terraform/cloud-docs/cost-estimation) is disabled for any run created with `-target` set, to prevent producing a misleading underestimate of cost due to resource instances being excluded from the plan.
 
 You can disable or constrain use of targeting in a particular workspace using a Sentinel policy based on [the `tfrun.target_addrs` value](/terraform/cloud-docs/policy-enforcement/sentinel/import/tfrun#value-target_addrs).
+
+## Generating Configuration
+
+-> **Version note:** Support for `import` blocks and generating configuration requires a workspace using at least Terraform CLI v1.5.0.
+
+When using [`import` blocks](/terraform/language/import) to import existing resources, Terraform can [automatically generate configuration](/terraform/language/import/generating-configuration) during the plan for any imported resources that don't have an existing `resource` block. This option is enabled by default for runs started from the UI or from a VCS webhook.
+
+- **CLI:** Use `terraform plan -generate-config-out=generated.tf`.
+- **API:** Use the `allow-config-generation` option.
+
+You can find generated configuration displayed in the plan UI. If you're using the CLI workflow, generated configuration will be written to the file you specify when running `terraform plan`.
+
+Once Terraform has generated configuration for you, you'll need to review it, incorporate it in your Terraform configuration (including committing it to version control), then run another plan. If you try to directly apply a plan with generated configuration, the run will error.

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -115,6 +115,8 @@ For full details about the stages of a run, see [Run States and Stages][].
 
 ## Import
 
-Terraform Cloud does not support remote execution for `terraform import`. For this command the workspace acts only as a remote backend for Terraform state, with all execution occurring on your own workstations or continuous integration workers.
+Terraform Cloud does not support remote execution for the `terraform import` command. For this command the workspace acts only as a remote backend for Terraform state, with all execution occurring on your own workstations or continuous integration workers.
 
 Since `terraform import` runs locally, environment variables defined in the workspace are not available. Any environment variables required by the provider you're importing from must be defined within your local execution scope.
+
+We recommend using [`import` blocks](/terraform/language/import), introduced in Terraform 1.5, to import resources in Terraform Cloud.

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -115,8 +115,8 @@ For full details about the stages of a run, see [Run States and Stages][].
 
 ## Import
 
+We recommend using [`import` blocks](/terraform/language/import), introduced in Terraform 1.5, to import resources in Terraform Cloud.
+
 Terraform Cloud does not support remote execution for the `terraform import` command. For this command the workspace acts only as a remote backend for Terraform state, with all execution occurring on your own workstations or continuous integration workers.
 
 Since `terraform import` runs locally, environment variables defined in the workspace are not available. Any environment variables required by the provider you're importing from must be defined within your local execution scope.
-
-We recommend using [`import` blocks](/terraform/language/import), introduced in Terraform 1.5, to import resources in Terraform Cloud.

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -32,7 +32,7 @@ You can view a workspace's state versions from its **States** tab. Each state in
 
 Your organization’s managed resource count helps you understand the number of infrastructure resources that Terraform Cloud manages across all your workspaces.
 
-Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource instance created with the `count` or `for_each` meta-arguments. For example, `"aws_instance" "servers" { count = 10 }` creates ten separate managed resources in state. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count. 
+Terraform Cloud reads all the workspaces’ state files to determine the total number of managed resources. Each [resource](/terraform/language/resources/syntax) in the state equals one managed resource. Terraform Cloud includes resources in modules and each resource instance created with the `count` or `for_each` meta-arguments. For example, `"aws_instance" "servers" { count = 10 }` creates ten separate managed resources in state. Terraform Cloud does not include [data sources](/terraform/language/data-sources) in the count.
 
 ### Examples - Managed Resources
 
@@ -175,7 +175,9 @@ The following Terraform state excerpt describes a `aws_availability_zones` data 
 
 ## State Manipulation
 
-Certain tasks (including importing resources, tainting resources, moving or renaming existing resources to match a changed configuration, and more) require modifying Terraform state outside the context of a run.
+Certain tasks (including importing resources, tainting resources, moving or renaming existing resources to match a changed configuration, and more) may require modifying Terraform state outside the context of a run, depending on which version of Terraform your Terraform Cloud workspace is configured to use.
+
+Newer Terraform features like [`moved` blocks](/terraform/language/modules/develop/refactoring), [`import` blocks](/terraform/language/import), and the [`replace` option](/terraform/cloud-docs/run/modes-and-options#replacing-selected-resources) allow you to accomplish these tasks using the usual plan and apply workflow. However, if the Terraform version you're using doesn't support these features, you may need to fall back to manual state manipulation.
 
 Manual state manipulation in Terraform Cloud workspaces, with the exception of [rolling back to a previous state version](#rolling-back-to-a-previous-state), requires the use of Terraform CLI, using the same commands as would be used in a local workflow (`terraform import`, `terraform taint`, etc.). To manipulate state, you must configure the [CLI integration](/terraform/cli/cloud) and authenticate with a user token that has permission to read and write state versions for the relevant workspace. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))
 


### PR DESCRIPTION
### What

Terraform 1.5 brings [`import` blocks](https://developer.hashicorp.com/terraform/language/import) and [generated configuration](https://developer.hashicorp.com/terraform/language/import/generating-configuration), both of which come with first-class support in Terraform Cloud and Terraform Enterprise. That support is the subject of this PR.

Changed pages:

- API documentation for runs, plans, and applies
- Run Modes and Options includes information about working with generated configuration in Terraform Cloud
- Existing information about import on the Remote Operations and State pages has been updated to point users towards `import` blocks instead of the `terraform import` command

### Why

`import` blocks offer a vastly improved experience for importing new resources in Terraform Cloud, but first people need to know how to use them!

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any. N/A

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file. N/A
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. N/A
- [x] New pages have metadata (page name and description) at the top. N/A
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. N/A
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. N/A
- [x] UI elements (button names, page names, etc.) are bolded. N/A
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
