### PR TITLE
Update state version and workspace API docs

### DIFF
--- a/website/docs/cloud-docs/api-docs/state-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/state-versions.mdx
@@ -48,15 +48,28 @@ Attribute                        | Description
 ---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 `hosted-json-state-download-url` | A URL from which you can download the state data in a [stable format](/terraform/internals/json-format) appropriate for external integrations to consume. Only available if the state was created by Terraform 1.3+.
 `hosted-state-download-url`      | A URL from which you can download the raw state data, in the format used internally by Terraform.
+`hosted-json-state-upload-url`   | A URL to which you can upload state data in a [stable format](/terraform/internals/json-format) appropriate for external integrations to consume. You can upload JSON state content once per state version.
+`hosted-state-upload-url`        | A URL to which you can upload state data in the format used Terraform uses internally. You can upload state data once per state version.
 `modules`                        | Extracted information about the Terraform modules in this state data. Populated asynchronously.
 `providers`                      | Extracted information about the Terraform providers used for resources in this state data. Populated asynchronously.
+`provisional`                    | A boolean flag that indicating that Terraform Cloud created a state version, but that version is not the current versions for a workspace yet.
 `resources`                      | Extracted information about the resources in this state data. Populated asynchronously.
 `resources-processed`            | A Boolean flag indicating whether Terraform Cloud has finished asynchronously extracting outputs, resources, and other information about this state data.
 `serial`                         | The serial number of this state instance, which increases every time Terraform creates new state in the workspace.
 `state-version`                  | The version of the internal state format used for this state. Different Terraform versions read and write different format versions, but it only changes infrequently.
+`status`                         | Indicates a state version's content upload [status](/terraform/cloud-docs/api-docs/state-versions#state-version-status). This status can be `pending`, `finalized` or `discarded`.
 `terraform-version`              | The Terraform version that created this state. Populated asynchronously.
 `vcs-commit-sha`                 | The SHA of the configuration commit used in the Terraform run that produced this state. Only present if the workspace is connected to a VCS repository.
 `vcs-commit-url`                 | A link to the configuration commit used in the Terraform run that produced this state. Only present if the workspace is connected to a VCS repository.
+
+### State Version Status
+The state version status is found in `data.attributes.status`, and you can reference the following list of possible statuses.
+A state version created through the API or CLI will only be listed in the UI if it is has a `finalized` status.
+| State        | Description                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `pending`    | The initial status of a state version after it has been created without encoding the state data within the request. Pending state versions do not contain state data and will not appear in the UI. The workspace cannot be unlocked normally until the latest state version has been finalized.                                     |
+| `finalized`  | The state version has been uploaded successfully to Terraform Cloud or if the state version was created with a valid `state` attribute.                                                                                                                                                                                                              |
+| `discarded` | The state version has been discarded because it was provisional and not promoted to be the current state version of the workspace. |
 
 ## Create a State Version
 
@@ -98,10 +111,10 @@ Properties without a default value are required.
 |--------------------------------------|---------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `data.type`                          | string  |           | Must be `"state-versions"`.                                                                                                                                                                                                                                                                |
 | `data.attributes.serial`             | integer |           | The serial of the state version. Must match the serial value extracted from the raw state file.                                                                                                                                                                                            |
-| `data.attributes.md5`                | string  |           | An MD5 hash of the raw state version                                                                                                                                                                                                                                                       |
-| `data.attributes.state`              | string  |           | Base64 encoded raw state file                                                                                                                                                                                                                                                              |
+| `data.attributes.md5`                | string  |           | An MD5 hash of the raw state version.                                                                                                                                                                                                                                                       |
+| `data.attributes.state`              | string  | (nothing) | **Optional** Base64 encoded raw state file. If omitted, you must use the upload method below to complete the state version creation. The workspace may not be unlocked normally until the state version is uploaded.                                                                                                                                                                                                                                                              |
 | `data.attributes.lineage`            | string  | (nothing) | **Optional** Lineage of the state version. Should match the lineage extracted from the raw state file. Early versions of terraform did not have the concept of lineage, so this is an optional attribute.                                                                                  |
-| `data.attributes.json-state`         | string  | (nothing) | **Optional** Base64 encoded json state, as expressed by `terraform show -json`. See [JSON Output Format](/terraform/internals/json-format) for more details                                                                                                                                          |
+| `data.attributes.json-state`         | string  | (nothing) | **Optional** Base64 encoded json state, as expressed by `terraform show -json`. See [JSON Output Format](/terraform/internals/json-format) for more details.                                                                                                                                          |
 | `data.attributes.json-state-outputs` | string  | (nothing) | **Optional** Base64 encoded output values as represented by `terraform show -json` (the contents of the values/outputs key). If provided, the workspace outputs populate immediately. If omitted, Terraform Cloud populates the workspace outputs from the given state after a short time. |
 | `data.relationships.run.data.id`     | string  | (nothing) | **Optional** The ID of the run to associate with the state version.                                                                                                                                                                                                                        |
 
@@ -155,6 +168,10 @@ curl \
             "created-at": "2018-07-12T20:32:01.490Z",
             "hosted-state-download-url": "https://archivist.terraform.io/v1/object/f55b739b-ff03-4716-b436-726466b96dc4",
             "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/4fde7951-93c0-4414-9a40-f3abc4bac490",
+            "hosted-state-upload-url": null,
+            "hosted-json-state-upload-url": null,
+            "status": "finalized",
+            "provisional": true,
             "serial": 1
         },
         "links": {
@@ -162,6 +179,26 @@ curl \
         }
     }
 }
+```
+
+## Upload State and JSON State
+
+ You can upload state version content in the same request when creating a state version. However, we _strongly_ recommend that you upload content separately.
+
+`PUT https://archivist.terraform.io/v1/object/<UNIQUE OBJECT ID>`
+
+Terraform Cloud returns a `hosted-state-upload-url` or `hosted-json-state-upload-url` returned when you create a `state-version`. Once you upload state content, this URL is hidden on the resource and _no longer available_.
+
+### Sample Request
+
+In the below example, `@filename` is the name of Terraform state file you wish to upload.
+
+```shell
+curl \
+  --header "Content-Type: application/octet-stream" \
+  --request PUT \
+  --data-binary @filename \
+  https://archivist.terraform.io/v1/object/4c44d964-eba7-4dd5-ad29-1ece7b99e8da
 ```
 
 ## List State Versions for a Workspace
@@ -176,12 +213,13 @@ Listing state versions requires permission to read state versions for the worksp
 
 This endpoint supports pagination [with standard URL query parameters](/terraform/cloud-docs/api-docs#query-parameters). Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
 
-| Parameter                    | Description                                                                    |
-|------------------------------|--------------------------------------------------------------------------------|
-| `filter[workspace][name]`    | **Required** The name of one workspace to list versions for.                   |
-| `filter[organization][name]` | **Required** The name of the organization that owns the desired workspace.     |
-| `page[number]`               | **Optional.** If omitted, the endpoint will return the first page.             |
-| `page[size]`                 | **Optional.** If omitted, the endpoint will return 20 state versions per page. |
+| Parameter                    | Description                                                                            |
+|------------------------------|----------------------------------------------------------------------------------------|
+| `filter[workspace][name]`    | **Required** The name of one workspace to list versions for.                           |
+| `filter[organization][name]` | **Required** The name of the organization that owns the desired workspace.             |
+| `filter[status]`             | **Optional.** Filter state versions by status: `pending`, `finalized`, or `discarded`. |
+| `page[number]`               | **Optional.** If omitted, the endpoint will return the first page.                     |
+| `page[size]`                 | **Optional.** If omitted, the endpoint will return 20 state versions per page.         |
 
 ### Sample Request
 
@@ -204,7 +242,11 @@ curl \
                 "created-at": "2021-06-08T01:22:03.794Z",
                 "size": 940,
                 "hosted-state-download-url": "https://archivist.terraform.io/v1/object/...",
+                "hosted-state-upload-url": null,
                 "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
+                "hosted-json-state-upload-url": null,
+                "status": "finalized",
+                "provisional": false,
                 "modules": {
                     "root": {
                         "null-resource": 1,
@@ -235,7 +277,7 @@ curl \
                         "provider": "provider[\"registry.terraform.io/hashicorp/null\"]"
                     }
                 ],
-                "resources-processed": false,
+                "resources-processed": true,
                 "serial": 9,
                 "state-version": 4,
                 "terraform-version": "0.15.4",
@@ -293,7 +335,11 @@ curl \
                 "created-at": "2021-06-01T21:40:25.941Z",
                 "size": 819,
                 "hosted-state-download-url": "https://archivist.terraform.io/v1/object/...",
+                "hosted-state-upload-url": null,
                 "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
+                "hosted-json-state-upload-url": null,
+                "status": "finalized",
+                "provisional": false,
                 "modules": {
                     "root": {
                         "data.terraform-remote-state": 1
@@ -313,7 +359,7 @@ curl \
                         "provider": "provider[\"terraform.io/builtin/terraform\"]"
                     }
                 ],
-                "resources-processed": false,
+                "resources-processed": true,
                 "serial": 8,
                 "state-version": 4,
                 "terraform-version": "0.15.4",
@@ -421,7 +467,11 @@ curl \
             "created-at": "2021-06-08T01:22:03.794Z",
             "size": 940,
             "hosted-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-state-upload-url": null,
             "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-json-state-upload-url": null,
+            "status": "finalized",
+            "provisional": false,
             "modules": {
                 "root": {
                     "null-resource": 1,
@@ -452,7 +502,7 @@ curl \
                     "provider": "provider[\"registry.terraform.io/hashicorp/null\"]"
                 }
             ],
-            "resources-processed": false,
+            "resources-processed": true,
             "serial": 9,
             "state-version": 4,
             "terraform-version": "0.15.4",
@@ -543,7 +593,11 @@ curl \
             "created-at": "2021-06-08T01:22:03.794Z",
             "size": 940,
             "hosted-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-state-upload-url": null,
             "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-json-state-upload-url": null,
+            "status": "finalized",
+            "provisional": false,
             "modules": {
                 "root": {
                     "null-resource": 1,
@@ -574,7 +628,7 @@ curl \
                     "provider": "provider[\"registry.terraform.io/hashicorp/null\"]"
                 }
             ],
-            "resources-processed": false,
+            "resources-processed": true,
             "serial": 9,
             "state-version": 4,
             "terraform-version": "0.15.4",
@@ -704,7 +758,9 @@ curl \
             "created-at": "2022-11-22T01:22:03.794Z",
             "size": 940,
             "hosted-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-state-upload-url": null,
             "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-json-state-upload-url": null,
             "modules": {
                 "root": {
                     "null-resource": 1,
@@ -735,7 +791,7 @@ curl \
                     "provider": "provider[\"registry.terraform.io/hashicorp/null\"]"
                 }
             ],
-            "resources-processed": false,
+            "resources-processed": true,
             "serial": 9,
             "state-version": 4,
             "terraform-version": "1.3.5"

--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -1529,7 +1529,7 @@ $ curl \
 
 ## Unlock a workspace
 
-This endpoint unlocks a workspace.
+This endpoint unlocks a workspace. Unlocking a workspace sets the current state version to the latest finalized provisional state version. If provisional state versions are available, but Terraform Cloud has not yet finalized the latest provisional state version, the unlock will fail.
 
 `POST /workspaces/:workspace_id/actions/unlock`
 
@@ -1692,6 +1692,8 @@ $ curl \
 ## Force Unlock a workspace
 
 This endpoint force unlocks a workspace. Only users with admin access are authorized to force unlock a workspace.
+
+For a force unlock, Terraform Cloud attempts to find the latest finalized provisional state version and sets it as the current state version for a workspace. Terraform Cloud may select an earlier provisional state version as the current version for a workspace. This only occurs if Terraform Cloud has not yet finalized the latest provisional state version. Terraform Cloud will not prevent a force unlock if no finalized provisional state versions are available.
 
 `POST /workspaces/:workspace_id/actions/force-unlock`
 

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -17,6 +17,10 @@ In [remote runs](/terraform/cloud-docs/run/remote-operations), Terraform Cloud a
 
 In local runs (available for workspaces whose execution mode setting is set to "local"), you can use a workspace's state by configuring the [CLI integration](/terraform/cli/cloud) and authenticating with a user token that has permission to read and write state versions for the relevant workspace. When using a Terraform configuration that references outputs from another workspace, the authentication token must also have permission to read state outputs for that workspace. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))
 
+During a Terraform Cloud run, Terraform incrementally creates provisional state versions and marks them as finalized once it uploads the state content.  When a workspace is unlocked, Terraform Cloud selects the latest finalized state version as the current state version for that workspace.
+
+If Terraform Cloud has not finalized the latest state version when a workspace is unlocked, the workspace may need to be force unlocked. In the event of a force unlock, Terraform Cloud selects the latest finalized state version. When Terraform Cloud selects the current state version, it discards all pending provisional state versions.
+
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 ## State Versions


### PR DESCRIPTION
### What
These changes are related to the functionality that was implemented to support Terraform state snapshots. This commit adds the `status` and `provisional` fields to state versions attribute table, the new Upload State and JSON State endpoint, and information about workspace unlocking.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
