### PR TITLE
feat: add redirects.js from terraform-website

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ _If items do not apply to your changes, add (N/A) and mark them as complete._
 - [ ] Description links to related pull requests or issues, if any.
 
 #### Content
-- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
+- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
 - [ ] API documentation and the API Changelog have been updated. 
 - [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
 - [ ] Pages with related content are updated and link to this content when appropriate.

--- a/README.md
+++ b/README.md
@@ -327,4 +327,4 @@ In markdown, images should be referenced by their absolute path, starting with `
 
 ## Redirects
 
-Handle all redirects in this file in the `terraform-website` repository: [redirects.js](https://github.com/hashicorp/terraform-website/blob/master/redirects.js)
+Handle all redirects in this file: [redirects.js](/website/redirects.js).

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1,0 +1,86 @@
+/**
+ * Redirects in this file are intended to be for documentation content only. The redirects will be applied to developer.hashicorp.com.
+ */
+module.exports = [
+  // Redirects for restructured Terraform Plugin Framework docs for GA release of the Framework
+  // - https://github.com/hashicorp/terraform-plugin-framework/pull/554
+  // - https://github.com/hashicorp/terraform-docs-common/pull/252
+  {
+    source: "/terraform/plugin/which-sdk",
+    destination: "/terraform/plugin/framework-benefits",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/framework/schemas",
+    destination: "/terraform/plugin/framework/handling-data/schemas",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/framework/types",
+    destination: "/terraform/plugin/framework/handling-data/attributes",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/framework/paths",
+    destination: "/terraform/plugin/framework/handling-data/paths",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/framework/path-expressions",
+    destination: "/terraform/plugin/framework/handling-data/path-expressions",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/framework/accessing-values",
+    destination: "/terraform/plugin/framework/handling-data/accessing-values",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/framework/writing-state",
+    destination: "/terraform/plugin/framework/handling-data/writing-state",
+    permanent: true,
+  },
+  {
+    source: "/terraform/cloud-docs/workspaces/naming",
+    destination: "/terraform/cloud-docs/workspaces/creating",
+    permanent: true,
+  },
+  // Moving TF Plugin Development best practice info
+  // - https://github.com/hashicorp/terraform-plugin-sdk/issues/1151
+  {
+    source: "/terraform/plugin/sdkv2/best-practices/other-languages",
+    destination: "/terraform/plugin/best-practices/provider-code",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/sdkv2/best-practices/testing",
+    destination: "/terraform/plugin/testing/testing-patterns",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/sdkv2/best-practices/versioning",
+    destination: "/terraform/plugin/best-practices/versioning",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/sdkv2/best-practices/sensitive-state",
+    destination: "/terraform/plugin/best-practices/sensitive-state",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/sdkv2/best-practices/depending-on-providers",
+    destination: "/terraform/plugin/best-practices/interacting-with-providers",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/sdkv2/best-practices/naming",
+    destination: "/terraform/plugin/best-practices/naming",
+    permanent: true,
+  },
+  {
+    source: "/terraform/plugin/hashicorp-provider-design-principles",
+    destination:
+      "/terraform/plugin/best-practices/hashicorp-provider-design-principles",
+    permanent: true,
+  },
+];


### PR DESCRIPTION
### What

This PR moves the `redirects.js` file from `terraform-website` to this repo in preparation for Terraform's migration to the web monorepo. This PR is up-to-date as of commit f1bfe651ad4f28e1a87cad0801f70cb8f19cffaa made on March 23 2023.

It also updates the pull request template to remove the note that redirects need to be defined in `terraform-website`.

### Why

`terraform-website` is being deprecated in favor of `web`. To ensure that docs authors can continue to add redirects, the redirects file is being moved to this repo.

