### PR TITLE
docs: use configuration drift when describing drift detection

### DIFF
--- a/website/docs/cloud-docs/index.mdx
+++ b/website/docs/cloud-docs/index.mdx
@@ -14,7 +14,7 @@ tfc_only: true
 
 Terraform Cloud is available as a hosted service at <https://app.terraform.io>. Small teams can sign up for free to connect Terraform to version control, share variables, run Terraform in a stable remote environment, and securely store remote state. Paid editions allow you to add more than five users, create teams with different levels of permissions, and collaborate more effectively.
 
-Terraform Cloud **Plus** Edition allows organizations to enable audit logging, continuous validation, and automated state drift detection.
+Terraform Cloud **Plus** Edition allows organizations to enable audit logging, continuous validation, and automated configuration drift detection.
 
 ## What is Terraform Enterprise?
 

--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -23,7 +23,7 @@ Terraform Cloud runs support many of the same modes and options available in the
 
 -> **Version note:** Refresh-only support requires a workspace using at least Terraform CLI v0.15.4.
 
-[Refresh-only mode](/terraform/cli/commands/plan#planning-modes) instructs Terraform to create a plan which updates the Terraform state to match changes made to remote objects outside of Terraform.
+[Refresh-only mode](/terraform/cli/commands/plan#planning-modes) instructs Terraform to create a plan that updates the Terraform state to match changes made to remote objects outside of Terraform. This can be useful if state drift has occurred and you would like to reconcile your state file to match the drifted remote objects. Applying a refresh-only runs will not result in further changes to remote objects.
 
 - **CLI:** Use `terraform plan -refresh-only` or `terraform apply -refresh-only`.
 - **API:** Use the `refresh-only` option.

--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -23,7 +23,7 @@ Terraform Cloud runs support many of the same modes and options available in the
 
 -> **Version note:** Refresh-only support requires a workspace using at least Terraform CLI v0.15.4.
 
-[Refresh-only mode](/terraform/cli/commands/plan#planning-modes) instructs Terraform to create a plan that updates the Terraform state to match changes made to remote objects outside of Terraform. This can be useful if state drift has occurred and you would like to reconcile your state file to match the drifted remote objects. Applying a refresh-only runs will not result in further changes to remote objects.
+[Refresh-only mode](/terraform/cli/commands/plan#planning-modes) instructs Terraform to create a plan that updates the Terraform state to match changes made to remote objects outside of Terraform. This is useful if state drift has occurred and you want to reconcile your state file to match the drifted remote objects. Applying a refresh-only run does not result in further changes to remote objects.
 
 - **CLI:** Use `terraform plan -refresh-only` or `terraform apply -refresh-only`.
 - **API:** Use the `refresh-only` option.

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -142,7 +142,7 @@ Refer to the [variables overview](/terraform/cloud-docs/workspaces/variables) do
 <!-- END: TFC:only name:pnp-callout -->
 
 Terraform Cloud can perform automatic health assessments in a workspace to assess whether its real infrastructure matches the requirements defined in its Terraform configuration. Health assessments include the following types of evaluations:
-- Drift detection determines whether your real-world infrastructure matches the configuration in your Terraform state file. Drift detection requires Terraform version 0.15.4+.
+- Drift detection determines whether your real-world infrastructure matches your Terraform configuration. Drift detection requires Terraform version 0.15.4+.
 - Continuous validation determines whether custom conditions in the workspace’s configuration continue to pass after Terraform provisions the infrastructure. Continuous validation requires Terraform version 1.3.0+.
 
 You can enforce health assessments for all eligible workspaces or let each workspace opt in to health assessments through workspace settings. Refer to [Health](/terraform/cloud-docs/workspaces/health) in the workspaces documentation for more details.

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -95,17 +95,17 @@ On the right of a workspace’s overview page, Terraform Cloud displays a **Heal
 
 ## Drift Detection
 
-Infrastructure drift means that your real-world infrastructure no longer matches your Terraform state file. Drift occurs when a user modifies resources outside of the Terraform workflow. For example, a colleague may update resource configuration directly in the cloud provider console to resolve a production incident. This action changes the real resource attributes from those tracked in the state file.
+Infrastructure drift means that your real-world infrastructure no longer matches your Terraform configuration. Drift typically occurs when actions outside of the Terraform workflow result in changes to your infrastructure. For example, a colleague may update resource configuration directly in the cloud provider console to resolve a production incident. This action changes the real resource attributes from those specified in your configuration.
 
 ### View Workspace Drift
 
-To view the continuous validation results from the latest health assessment, go to the workspace and click **Health > Drift**. If there is drift, Terraform Cloud shows how the real infrastructure differs from the latest version of the workspace’s state file.
+To view the drift detection results from the latest health assessment, go to the workspace and click **Health > Drift**. If there is drift, Terraform Cloud shows how the real infrastructure differs from the latest version of the workspace’s configuration.
 
 ### Resolve Drift
 
 You can use one of the following approaches to correct workspace drift:
-- **Overwrite drift**: Queue a new plan to realign your real-world infrastructure with your Terraform configuration.
-- **Update Terraform state and configuration:** Queue a refresh-only plan to update your Terraform state to match your real-world infrastructure. We recommend also modifying your Terraform configuration to include any new or changed resources. Otherwise, Terraform will overwrite the updated state file during the next apply. Refer to our [Manage Resource Drift](/terraform/tutorials/state/resource-drift) tutorial for a detailed example.
+- **Overwrite drift**: If the drift is unwanted, queue a new plan and apply the changes to revert your real-world infrastructure to match your Terraform configuration.
+- **Update Terraform configuration:** If the drift contains changes that are desired, modify your Terraform configuration to include the changes. This will prevent Terraform from reverting the changes during the next apply. Refer to our [Manage Resource Drift](/terraform/tutorials/state/resource-drift) tutorial for a detailed example.
 
 ## Continuous Validation
 

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -8,7 +8,7 @@ description: |-
 
 Terraform Cloud can perform automatic health assessments in a workspace to assess whether its real infrastructure matches the requirements defined in its Terraform configuration. Health assessments include the following types of evaluations:
 
-- [Drift detection](#drift-detection) determines whether your real-world infrastructure matches your Terraform state file.
+- [Drift detection](#drift-detection) determines whether your real-world infrastructure matches your Terraform configuration.
 - [Continuous validation](#continuous-validation) determines whether custom conditions in the workspace’s configuration continue to pass after Terraform provisions the infrastructure.
 
 When enabled, Terraform Cloud automatically runs a health assessment for your workspace about every 24 hours. Refer to [Health Assessment Scheduling](#health-assessment-scheduling) for details.

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -110,7 +110,7 @@ To view the drift detection results from the latest health assessment, go to the
 ### Resolve Drift
 
 You can use one of the following approaches to correct configuration drift:
-- **Overwrite drift**: If the drift is unwanted, queue a new plan and apply the changes to revert your real-world infrastructure to match your Terraform configuration.
+- **Overwrite drift**: If you do not want the drift's changes, queue a new plan and apply the changes to revert your real-world infrastructure to match your Terraform configuration.
 - **Update Terraform configuration:** If the drift contains changes that are desired, modify your Terraform configuration to include the changes and push a new configuration version. This will prevent Terraform from reverting the drift during the next apply. Refer to our [Manage Resource Drift](/terraform/tutorials/state/resource-drift) tutorial for a detailed example.
 
 ## Continuous Validation

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -95,7 +95,7 @@ On the right of a workspace’s overview page, Terraform Cloud displays a **Heal
 
 ## Drift Detection
 
-Drift detection helps you identify situations where your actual infrastructure no longer matches the configuration you've defined in Terraform. This deviation is known as configuration drift. Configuration drift occurs when changes are made outside of Terraform's regular process, leading to inconsistencies between the remote objects and your configured infrastructure.
+Drift detection helps you identify situations where your actual infrastructure no longer matches the configuration defined in Terraform. This deviation is known as _configuration drift_. Configuration drift occurs when changes are made outside Terraform's regular process, leading to inconsistencies between the remote objects and your configured infrastructure.
 
 For instance, if a colleague makes direct updates to remote objects using your cloud provider's console to address a production issue, the changes they make might conflict with the intended configuration. In such cases, Drift Detection detects these differences and recommends steps to address and rectify the discrepancies.
 

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -95,11 +95,15 @@ On the right of a workspace’s overview page, Terraform Cloud displays a **Heal
 
 ## Drift Detection
 
-Infrastructure drift means that your real-world infrastructure no longer matches your Terraform configuration. Drift typically occurs when actions outside of the Terraform workflow result in changes to your infrastructure. For example, a colleague may update resource configuration directly in the cloud provider console to resolve a production incident. This action changes the real resource attributes from those specified in your configuration.
+Drift detection helps you identify situations where your actual infrastructure no longer matches the configuration you've defined in Terraform. This deviation is known as configuration drift. Configuration drift occurs when changes are made outside of Terraform's regular process, leading to inconsistencies between the remote objects and your configured infrastructure.
+
+For instance, if a colleague makes direct updates to remote objects using your cloud provider's console to address a production issue, the changes they make might conflict with the intended configuration. In such cases, Drift Detection detects these differences and recommends steps to address and rectify the discrepancies.
+
+~> **NOTE:** Configuration drift is distinct from state drift, which is no longer detected by Drift Detection. Configuration drift arises when changes made externally affect remote objects in a manner that renders your infrastructure configuration invalid. State drift, on the other hand, emerges when modifications are applied to remote objects without invalidating your infrastructure configuration. See [Refresh-Only Mode](/terraform/cloud-docs/run/modes-and-options#refresh-only-mode) for more information about the steps required to remediate state drift.
 
 ### View Workspace Drift
 
-To view the drift detection results from the latest health assessment, go to the workspace and click **Health > Drift**. If there is drift, Terraform Cloud shows how the real infrastructure differs from the latest version of the workspace’s configuration.
+To view the drift detection results from the latest health assessment, go to the workspace and click **Health > Drift**. If configuration drift occurs, Terraform Cloud shows how the real infrastructure differs from the latest version of the workspace’s configuration.
 
 ### Resolve Drift
 

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -97,7 +97,7 @@ On the right of a workspace’s overview page, Terraform Cloud displays a **Heal
 
 Drift detection helps you identify situations where your actual infrastructure no longer matches the configuration defined in Terraform. This deviation is known as _configuration drift_. Configuration drift occurs when changes are made outside Terraform's regular process, leading to inconsistencies between the remote objects and your configured infrastructure.
 
-For instance, if a colleague makes direct updates to remote objects using your cloud provider's console to address a production issue, the changes they make might conflict with the intended configuration. In such cases, Drift Detection detects these differences and recommends steps to address and rectify the discrepancies.
+For example, a teammate could create configuration drift by directly updating a storage bucket's settings with conflicting configuration settings using the cloud provider's console. Drift detection could detect these differences and recommend steps to address and rectify the discrepancies.
 
 Configuration drift differs from state drift.  Drift detection _does not detect_ state drift.
 

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -99,7 +99,9 @@ Drift detection helps you identify situations where your actual infrastructure n
 
 For instance, if a colleague makes direct updates to remote objects using your cloud provider's console to address a production issue, the changes they make might conflict with the intended configuration. In such cases, Drift Detection detects these differences and recommends steps to address and rectify the discrepancies.
 
-~> **NOTE:** Configuration drift is distinct from state drift, which is no longer detected by Drift Detection. Configuration drift arises when changes made externally affect remote objects in a manner that renders your infrastructure configuration invalid. State drift, on the other hand, emerges when modifications are applied to remote objects without invalidating your infrastructure configuration. See [Refresh-Only Mode](/terraform/cloud-docs/run/modes-and-options#refresh-only-mode) for more information about the steps required to remediate state drift.
+Configuration drift differs from state drift.  Drift detection _does not detect_ state drift.
+
+Configuration drift happens when external changes affecting remote objects invalidate your infrastructure configuration. State drift occurs when external changes affecting remote objects _do not_ invalidate your infrastructure configuration. Refer to [Refresh-Only Mode](/terraform/cloud-docs/run/modes-and-options#refresh-only-mode)  to learn more about remediating state drift.
 
 ### View Workspace Drift
 

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -103,13 +103,13 @@ For instance, if a colleague makes direct updates to remote objects using your c
 
 ### View Workspace Drift
 
-To view the drift detection results from the latest health assessment, go to the workspace and click **Health > Drift**. If configuration drift occurs, Terraform Cloud shows how the real infrastructure differs from the latest version of the workspace’s configuration.
+To view the drift detection results from the latest health assessment, go to the workspace and click **Health > Drift**. If configuration drift has occurred, Terraform Cloud shows the proposed changes required to bring the infrastructure back in sync with its configuration.
 
 ### Resolve Drift
 
-You can use one of the following approaches to correct workspace drift:
+You can use one of the following approaches to correct configuration drift:
 - **Overwrite drift**: If the drift is unwanted, queue a new plan and apply the changes to revert your real-world infrastructure to match your Terraform configuration.
-- **Update Terraform configuration:** If the drift contains changes that are desired, modify your Terraform configuration to include the changes. This will prevent Terraform from reverting the changes during the next apply. Refer to our [Manage Resource Drift](/terraform/tutorials/state/resource-drift) tutorial for a detailed example.
+- **Update Terraform configuration:** If the drift contains changes that are desired, modify your Terraform configuration to include the changes and push a new configuration version. This will prevent Terraform from reverting the drift during the next apply. Refer to our [Manage Resource Drift](/terraform/tutorials/state/resource-drift) tutorial for a detailed example.
 
 ## Continuous Validation
 

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -105,7 +105,7 @@ Configuration drift happens when external changes affecting remote objects inval
 
 ### View Workspace Drift
 
-To view the drift detection results from the latest health assessment, go to the workspace and click **Health > Drift**. If configuration drift has occurred, Terraform Cloud shows the proposed changes required to bring the infrastructure back in sync with its configuration.
+To view the drift detection results from the latest health assessment, go to the workspace and click **Health > Drift**. If there is configuration drift, Terraform Cloud proposes the necessary changes to bring the infrastructure back in sync with its configuration.
 
 ### Resolve Drift
 

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -111,7 +111,7 @@ To view the drift detection results from the latest health assessment, go to the
 
 You can use one of the following approaches to correct configuration drift:
 - **Overwrite drift**: If you do not want the drift's changes, queue a new plan and apply the changes to revert your real-world infrastructure to match your Terraform configuration.
-- **Update Terraform configuration:** If the drift contains changes that are desired, modify your Terraform configuration to include the changes and push a new configuration version. This will prevent Terraform from reverting the drift during the next apply. Refer to our [Manage Resource Drift](/terraform/tutorials/state/resource-drift) tutorial for a detailed example.
+- **Update Terraform configuration:** If you want the drift's changes, modify your Terraform configuration to include the changes and push a new configuration version. This prevents Terraform from reverting the drift during the next apply. Refer to the [Manage Resource Drift](/terraform/tutorials/state/resource-drift) tutorial for a detailed example.
 
 ## Continuous Validation
 

--- a/website/docs/cloud-docs/workspaces/index.mdx
+++ b/website/docs/cloud-docs/workspaces/index.mdx
@@ -110,7 +110,7 @@ You can create workspaces through the [Terraform Cloud UI](/terraform/cloud-docs
 
 Terraform Cloud can perform automatic health assessments in a workspace to assess whether its real infrastructure matches the requirements defined in its Terraform configuration. Health assessments include the following types of evaluations:
 
-- Drift detection determines whether your real-world infrastructure matches the configuration in your Terraform state file.
+- Drift detection determines whether your real-world infrastructure matches your Terraform configuration.
 - Continuous validation determines whether custom conditions in the workspace’s configuration continue to pass after Terraform provisions the infrastructure.
 
 You can enforce health assessments for all eligible workspaces or let each workspace opt in to health assessments through workspace settings. Refer to [Health](/terraform/cloud-docs/workspaces/health) in the workspaces documentation for more details.


### PR DESCRIPTION
### What
This PR updates the Drift Detection docs to prepare for the release of reduced noise Drift Detection.

#### Pages affected
- Developer -> Terraform -> Terraform Cloud -> Terraform Runs -> Run Modes and Options
- Developer -> Terraform -> Terraform Cloud -> Workspaces -> Health

### Why
There is a need to differentiate between configuration drift and state drift once the changes are released.

### LInks
[JIRA](https://hashicorp.atlassian.net/browse/TF-7538)

cc @ritsok 



----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] (N/A) The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
