### PR TITLE
Remove warning about self-signed certs for Vault-backed credentials

### DIFF
--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -9,8 +9,6 @@ description: >-
 
 ~> **Important:** If using self-managed agents, make sure you’re using **v1.8.0** or later.
 
-!> **Warning:** Dynamic Credentials with the Azure providers do **_not_** work when your TFE instance is using a custom or self-signed certificate due to restrictions on Azure's end.
-
 You can use Terraform Cloud’s native OpenID Connect integration with Vault to use [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed) with the Azure provider in your Terraform Cloud runs. Configuring the integration requires the following steps:
 
 1. **[Configure Vault Dynamic Provider Credentials](#configure-vault-dynamic-provider-credentials)**: Set up a trust configuration between Vault and Terraform Cloud, create Vault roles and policies for your Terraform Cloud workspaces, and add environment variables to those workspaces.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -9,8 +9,6 @@ description: >-
 
 ~> **Important:** If using self-managed agents, make sure you’re using **v1.8.0** or later.
 
-!> **Warning:** Dynamic Credentials with the GCP provider do **_not_** work when your TFE instance is using a custom or self-signed certificate due to restrictions on GCP's end.
-
 You can use Terraform Cloud’s native OpenID Connect integration with Vault to use [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed) with the GCP provider in your Terraform Cloud runs. Configuring the integration requires the following steps:
 
 1. **[Configure Vault Dynamic Provider Credentials](#configure-vault-dynamic-provider-credentials)**: Set up a trust configuration between Vault and Terraform Cloud, create Vault roles and policies for your Terraform Cloud workspaces, and add environment variables to those workspaces.


### PR DESCRIPTION
### What
Removes warnings from Vault-backed Azure and GCP pages around Azure and GCP not working properly with self-signed certs.

These warnings were erroneously copied over from the non Vault-backed documentation where these are valid warnings.

### Why
Reduce confusion around whether Vault-backed Azure and GCP dynamic credentials properly work when the TFE instance is using a self-signed certificate.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
-  [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
-  [x] (N/A) API documentation and the API Changelog have been updated. 
-  [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
-  [x] (N/A) Pages with related content are updated and link to this content when appropriate.
-  [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
-  [x] (N/A) New pages have metadata (page name and description) at the top.
-  [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] (N/A) The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
