### PR TITLE
Adds `provisional` field to `configuration-versions` API docs

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -10,7 +10,7 @@ description: >-
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 ## 2023-08-10
-* Add `provisional` to `configuration-versions` endpoint
+* Add `provisional` to `configuration-versions` endpoint.
 
 ## 2023-08-08
 * Update Policy Sets API endpoints to create, update, and return projects associated with a policy set.

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,9 @@ description: >-
 
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
+## 2023-08-10
+* Add `provisional` to `configuration-versions` endpoint
+
 ## 2023-08-08
 * Update Policy Sets API endpoints to create, update, and return projects associated with a policy set.
 * Add API endpoints to [Attach a Policy Set](/terraform/cloud-docs/api-docs/policy-sets#attach-a-policy-set-to-projects) and [Detach a Policy Set](/terraform/cloud-docs/api-docs/policy-sets#detach-a-policy-set-to-projects) from a project.

--- a/website/docs/cloud-docs/api-docs/configuration-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/configuration-versions.mdx
@@ -105,7 +105,8 @@ curl \
         "source": "gitlab",
         "speculative":false,
         "status": "uploaded",
-        "status-timestamps": {}
+        "status-timestamps": {},
+        "provisional": false
       },
       "relationships": {
         "ingress-attributes": {
@@ -159,7 +160,8 @@ curl \
       "source": "gitlab",
       "speculative":false,
       "status": "uploaded",
-      "status-timestamps": {}
+      "status-timestamps": {},
+      "provisional": false
     },
     "relationships": {
       "ingress-attributes": {
@@ -273,10 +275,11 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-| Key path                          | Type    | Default | Description                                                                                                                                 |
-| --------------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data.attributes.auto-queue-runs` | boolean | true    | When true, runs are queued automatically when the configuration version is uploaded.                                                        |
-| `data.attributes.speculative`     | boolean | false   | When true, this configuration version may only be used to create runs which are speculative, that is, can neither be confirmed nor applied. |
+| Key path                          | Type    | Default | Description                                                                                                                                                                                                                   |
+| --------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data.attributes.auto-queue-runs` | boolean | true    | When true, runs are queued automatically when the configuration version is uploaded.                                                                                                                                          |
+| `data.attributes.speculative`     | boolean | false   | When true, this configuration version may only be used to create runs which are speculative, that is, can neither be confirmed nor applied.                                                                                   |
+| `data.attributes.provisional`     | boolean | false   | When true, this configuration version does not immediately become the workspace current configuration version. If the associated run is applied, it then becomes the current configuration version unless a newer one exists. |
 
 ### Sample Payload
 
@@ -318,7 +321,8 @@ curl \
       "status": "pending",
       "status-timestamps": {},
       "upload-url":
-        "https://archivist.terraform.io/v1/object/9224c6b3-2e14-4cd7-adff-ed484d7294c2"
+        "https://archivist.terraform.io/v1/object/9224c6b3-2e14-4cd7-adff-ed484d7294c2",
+      "provisional": false
     },
     "relationships": {
       "ingress-attributes": {


### PR DESCRIPTION
### What
Add `provisional` field to `configuration-versions` endpoint

### Why
New types of runs are not speculative because they may be applied later. `provisional` is a special type of configuration version that becomes the workspace current configuration version if the associated run is ever applied.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
