### PR TITLE
Change docs to say that OPA policy evaluations run in GAP

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/opa/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/opa/index.mdx
@@ -7,7 +7,7 @@ description: Use the Rego policy language to define Open Policy Agent (OPA) poli
 # Defining OPA Policies
 
 Policies are rules that Terraform Cloud enforces on runs. You use the [Rego policy language](https://www.openpolicyagent.org/docs/latest/policy-language/) to write policies for the Open Policy Agent (OPA) framework. After you define policies, you must add them to [policy sets](/terraform/cloud-docs/policy-enforcement/manage-policy-sets) that Terraform Cloud can enforce globally or on specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces.
-OPA Policies are evaluated in [Terraform Cloud Agents](/terraform/cloud-docs/api-docs/agents) and requires Terraform Cloud Agent version 1.4.0 and higher.
+OPA Policies are evaluated in Terraform Cloud's infrastructure.
 
 <!-- BEGIN: TFC:only name:pnp-callout -->
 -> **Note:** Terraform Cloud **Free** Edition includes one policy set of up to five policies. In Terraform Cloud **Plus** Edition, you can connect a policy set to a version control repository or create policy set versions via the API. Refer to [Terraform Cloud pricing](https://www.hashicorp.com/products/terraform/pricing) for details.


### PR DESCRIPTION
### What
Change copy to say that OPA policy evaluations are run in the terraform cloud infrastructure.

### Why
PMM will introduce a new Premium SKU next year which will be included in the pricing and packaging tiers in Terraform Cloud. As part of the change we will introduce a new capability called Enhanced Agents which is primarily focused on provisioning operations within a customer private network, and policy evaluation is one such operation. In preparation for the new Premium SKU we need to put controls in place that restrict all policy evaluation to occur in the Global Agent Pool.

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any. NA

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages. NA
- [ ] API documentation and the API Changelog have been updated. NA
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.). NA
- [ ] Pages with related content are updated and link to this content when appropriate. NA
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. NA
- [ ] New pages have metadata (page name and description) at the top. NA
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. NA
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. NA
- [ ] UI elements (button names, page names, etc.) are bolded. NA
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
