### PR TITLE
Adding errored state endpoint docs

### DIFF
--- a/website/docs/cloud-docs/api-docs/applies.mdx
+++ b/website/docs/cloud-docs/api-docs/applies.mdx
@@ -153,7 +153,7 @@ _Using Terraform Cloud Agents_
 }
 ```
 
-## Recover a failed state upload
+## Recover a failed state upload after applying
 
 `GET /applies/:id/errored-state`
 

--- a/website/docs/cloud-docs/api-docs/applies.mdx
+++ b/website/docs/cloud-docs/api-docs/applies.mdx
@@ -161,13 +161,13 @@ _Using Terraform Cloud Agents_
 | --------- | ----------------------------------------- |
 | `id`      | The ID of the apply to recover state for. |
 
-It is possible that during the course of a Run, Terraform may fail to upload
-a state file. This can happen for a variety of reasons, but should be an
-exceptionally rare occurance. Terraform Cloud Agent versions 1.5.1+ include a
-fallback mechanism which attempts to upload the state directly to Terraform
-Cloud's backend storage system in these cases. This endpoint then makes the
-raw data from these failed uploads available to users who are authorized to
-read the state contents.
+It is possible that during the course of a Run, Terraform may fail to upload a
+state file. This can happen for a variety of reasons, but should be an
+exceptionally rare occurance. Terraform Cloud Agent versions greater than 1.5.0
+include a fallback mechanism which attempts to upload the state directly to
+Terraform Cloud's backend storage system in these cases. This endpoint then
+makes the raw data from these failed uploads available to users who are
+authorized to read the state contents.
 
 | Status  | Response                                     | Reason                                                                              |
 | ------- | -------------------------------------------- | ----------------------------------------------------------------------------------- |

--- a/website/docs/cloud-docs/api-docs/applies.mdx
+++ b/website/docs/cloud-docs/api-docs/applies.mdx
@@ -163,7 +163,7 @@ _Using Terraform Cloud Agents_
 
 It is possible that during the course of a Run, Terraform may fail to upload a
 state file. This can happen for a variety of reasons, but should be an
-exceptionally rare occurance. Terraform Cloud Agent versions greater than 1.5.0
+exceptionally rare occurance. Terraform Cloud Agent versions greater than 1.12.0
 include a fallback mechanism which attempts to upload the state directly to
 Terraform Cloud's backend storage system in these cases. This endpoint then
 makes the raw data from these failed uploads available to users who are

--- a/website/docs/cloud-docs/api-docs/applies.mdx
+++ b/website/docs/cloud-docs/api-docs/applies.mdx
@@ -6,31 +6,9 @@ description: >-
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 
-[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
-
-[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
-
-[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
-
-[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
-
-[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
-
-[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+[307]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
 
 [404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
-
-[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
-
-[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
-
-[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-
-[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
-
-[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-
-[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
 
 [JSON API document]: /terraform/cloud-docs/api-docs#json-api-documents
 
@@ -173,4 +151,51 @@ _Using Terraform Cloud Agents_
     }
   }
 }
+```
+
+## Recover a failed state upload
+
+`GET /applies/:id/errored-state`
+
+| Parameter | Description                               |
+| --------- | ----------------------------------------- |
+| `id`      | The ID of the apply to recover state for. |
+
+It is possible that during the course of a Run, Terraform may fail to upload
+a state file. This can happen for a variety of reasons, but should be an
+exceptionally rare occurance. Terraform Cloud Agent versions 1.5.1+ include a
+fallback mechanism which attempts to upload the state directly to Terraform
+Cloud's backend storage system in these cases. This endpoint then makes the
+raw data from these failed uploads available to users who are authorized to
+read the state contents.
+
+| Status  | Response                                     | Reason                                                                              |
+| ------- | -------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [307][] | HTTP temporary redirect to state storage URL | Errored state available and user is authorized to read it                           |
+| [404][] | [JSON API error object][]                    | Apply not found, errored state not uploaded, or user unauthorized to perform action |
+
+When a 307 redirect is returned, the storage URL to the raw state file will be
+present in the `Location` header of the response. The URL in the `Location`
+header will expire after one minute. It is recommended for the API client to
+follow the redirect immediately. Each successful request to the errored-state
+endpoint will generate a new, unique storage URL with the same one minute
+expiration window.
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  https://app.terraform.io/api/v2/applies/apply-47MBvjwzBG8YKc2v/errored-state
+```
+
+### Sample Response
+
+```
+HTTP/1.1 307 Temporary Redirect
+Content-Length: 22
+Content-Type: text/plain
+Location: https://archivist.terraform.io/v1/object/dmF1bHQ6djE6OFA1eEdlSFVHRSs4YUcwaW83a1dRRDA0U2E3T3FiWk1HM2NyQlNtcS9JS1hHN3dmTXJmaFhEYTlHdTF1ZlgxZ2wzVC9kVTlNcjRPOEJkK050VFI3U3dvS2ZuaUhFSGpVenJVUFYzSFVZQ1VZYno3T3UyYjdDRVRPRE5pbWJDVTIrNllQTENyTndYd1Y0ak1DL1dPVlN1VlNxKzYzbWlIcnJPa2dRRkJZZGtFeTNiaU84YlZ4QWs2QzlLY3VJb3lmWlIrajF4a1hYZTlsWnFYemRkL2pNOG9Zc0ZDakdVMCtURUE3dDNMODRsRnY4cWl1dUN5dUVuUzdnZzFwL3BNeHlwbXNXZWRrUDhXdzhGNnF4c3dqaXlZS29oL3FKakI5dm9uYU5ZKzAybnloREdnQ3J2Rk5WMlBJemZQTg
+
+307 Temporary Redirect
 ```

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,9 @@ description: >-
 
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
+## 2023-08-17
+* Add [failed state upload recovery](/terraform/cloud-docs/api-docs/applies#recover-a-failed-state-upload) endpoint.
+
 ## 2023-08-10
 * Add `provisional` to `configuration-versions` endpoint.
 

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -10,7 +10,7 @@ description: >-
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 ## 2023-08-17
-* Add [failed state upload recovery](/terraform/cloud-docs/api-docs/applies#recover-a-failed-state-upload) endpoint.
+* Add [failed state upload recovery](/terraform/cloud-docs/api-docs/applies#recover-a-failed-state-upload-after-applying) endpoint.
 
 ## 2023-08-10
 * Add `provisional` to `configuration-versions` endpoint.


### PR DESCRIPTION
### What
Adds docs for the new [errored state endpoint](https://github.com/hashicorp/atlas/pull/16678).

### Why
Because docs.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
