### PR TITLE
Policy Set Exclusion: Product Docs

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/index.mdx
@@ -25,7 +25,7 @@ You can use two policy-as-code frameworks to define fine-grained, logic-based po
 
 Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces in your organization. For each run in the selected workspaces, Terraform Cloud checks the Terraform plan against the policy set.
 
-You can exclude workspaces from any global or project-scoped policy sets. A policy set's policies will not be enforced on any runs in an excluded workspace. Excluded workspaces override included workspaces, so even if a policy set is applied directly to a workspace, the workspace can still be excluded from the policy set at the project level.
+You can also exclude specific workspaces from global or project-scoped policy sets. Terraform Cloud won't enforce a policy set's policies on any runs in an excluded workspace. For example, if you attach a policy set to a project and then exclude one of the project's workspaces from that policy set, Terraform Cloud will not enforce the policy set on the excluded workspace.
 
 You can create policy sets using the [Terraform Cloud user interface](/terraform/cloud-docs/policy-enforcement/manage-policy-sets#create-policy-sets), the Terraform Cloud API, or by connecting Terraform Cloud to your version control system. A policy set can only contain policies written in a single policy framework (Sentinel or OPA). However, you can add Sentinel or OPA policy sets to the same workspace.
 

--- a/website/docs/cloud-docs/policy-enforcement/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/index.mdx
@@ -23,7 +23,9 @@ You can use two policy-as-code frameworks to define fine-grained, logic-based po
 
 ## Apply Policy Sets to Workspaces and Projects
 
-Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces in your organization. For each run in the selected workspaces, Terraform Cloud checks the Terraform plan against the policy set. 
+Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces in your organization. For each run in the selected workspaces, Terraform Cloud checks the Terraform plan against the policy set.
+
+You can exclude workspaces from any global or project-scoped policy sets. A policy set's policies will not be enforced on any runs in an excluded workspace. Excluded workspaces override included workspaces, so even if a policy set is applied directly to a workspace, the workspace can still be excluded from the policy set at the project level.
 
 You can create policy sets using the [Terraform Cloud user interface](/terraform/cloud-docs/policy-enforcement/manage-policy-sets#create-policy-sets), the Terraform Cloud API, or by connecting Terraform Cloud to your version control system. A policy set can only contain policies written in a single policy framework (Sentinel or OPA). However, you can add Sentinel or OPA policy sets to the same workspace.
 

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -12,7 +12,7 @@ Policies are rules that Terraform Cloud enforces on Terraform runs. You can defi
 @include 'tfc-package-callouts/policies.mdx'
 <!-- END: TFC:only name:pnp-callout -->
 
-Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces in your organization. For each run in the associated workspaces, Terraform Cloud checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. You can exclude selected workspaces from a policy set if you don't want those workspaces' runs to be checked against the policy set.
+Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces in your organization. For each run in the applicable workspaces, Terraform Cloud checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. You can exclude selected workspaces from a policy set if you don't want Terraform Cloud to check those workspaces' runs against the policy set.
 
 ## Permissions
 

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -12,7 +12,7 @@ Policies are rules that Terraform Cloud enforces on Terraform runs. You can defi
 @include 'tfc-package-callouts/policies.mdx'
 <!-- END: TFC:only name:pnp-callout -->
 
-Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces in your organization. For each run in the applicable workspaces, Terraform Cloud checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. You can exclude selected workspaces from a policy set if you don't want Terraform Cloud to check those workspaces' runs against the policy set.
+Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces in your organization. For each run in the applicable workspaces, Terraform Cloud checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. If you do not want to enforce a policy set on a specific workspace, you can exclude the workspace from that set.
 
 ## Permissions
 

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -113,7 +113,7 @@ To create a policy set:
 1. Choose a policy set scope:
    - **Policies enforced globally:** Terraform Cloud automatically enforces this global policy set on all of an organization's existing and future workspaces.
    - **Policies enforced on selected projects and workspaces:** Use the text fields to find and select the workspaces and projects to enforce this policy set on. This affects all current and future workspaces for any chosen projects.
-1. **(Optional)** Add **Policy exclusions** for this policy set. Specify any workspaces in the policy set's scope that the policy set should not be enforced on.
+1. **(Optional)** Add **Policy exclusions** for this policy set. Specify any workspaces in the policy set's scope that Terraform Cloud will not enforce this policy set on.
 1. **(OPA Only)** Allow **Overrides**, which enables users with override policy permissions to apply plans that have [mandatory policy](#policy-enforcement-levels) failures.
 1. **(VCS Only)** Optionally specify the **VCS branch** within your VCS repository where Terraform Cloud should import new versions of policies. If you do not set this field, Terraform Cloud uses your selected VCS repository's default branch.
 1. **(VCS Only)** Specify where your policy set files live using the **Policies path**. This lets you maintain multiple policy sets within a single repository. Use a relative path from your root directory to the directory that contains either the `sentinel.hcl` (Sentinel) or `policies.hcl` (OPA) configuration files. If you do not set this field, Terraform Cloud uses the repository's root directory.

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -12,7 +12,7 @@ Policies are rules that Terraform Cloud enforces on Terraform runs. You can defi
 @include 'tfc-package-callouts/policies.mdx'
 <!-- END: TFC:only name:pnp-callout -->
 
-Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces in your organization. For each run in the selected workspaces, Terraform Cloud checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace.
+Policy sets are collections of policies you can apply globally or to specific [projects](/terraform/cloud-docs/workspaces/organize-workspaces-with-projects) and workspaces in your organization. For each run in the associated workspaces, Terraform Cloud checks the Terraform plan against the policy set. Depending on the [enforcement level](#policy-enforcement-levels), failed policies can stop a run in a workspace. You can exclude selected workspaces from a policy set if you don't want those workspaces' runs to be checked against the policy set.
 
 ## Permissions
 
@@ -113,6 +113,7 @@ To create a policy set:
 1. Choose a policy set scope:
    - **Policies enforced globally:** Terraform Cloud automatically enforces this global policy set on all of an organization's existing and future workspaces.
    - **Policies enforced on selected projects and workspaces:** Use the text fields to find and select the workspaces and projects to enforce this policy set on. This affects all current and future workspaces for any chosen projects.
+1. **(Optional)** Add **Policy exclusions** for this policy set. Specify any workspaces in the policy set's scope that the policy set should not be enforced on.
 1. **(OPA Only)** Allow **Overrides**, which enables users with override policy permissions to apply plans that have [mandatory policy](#policy-enforcement-levels) failures.
 1. **(VCS Only)** Optionally specify the **VCS branch** within your VCS repository where Terraform Cloud should import new versions of policies. If you do not set this field, Terraform Cloud uses your selected VCS repository's default branch.
 1. **(VCS Only)** Specify where your policy set files live using the **Policies path**. This lets you maintain multiple policy sets within a single repository. Use a relative path from your root directory to the directory that contains either the `sentinel.hcl` (Sentinel) or `policies.hcl` (OPA) configuration files. If you do not set this field, Terraform Cloud uses the repository's root directory.


### PR DESCRIPTION
### What

Users can now exclude policy set enforcement from specific workspaces. This PR updates the following pages:

- website/docs/cloud-docs/policy-enforcement/index.mdx
- website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx

### Why
It's currently possible to enforce a policy set at a global, project, or workspace level. However, some customers need policy set exceptions for individual workspaces (e.g. for special cases or testing). Without the ability to exclude workspaces from a policy set, they cannot scoping policy sets at a higher level and can manage policy set attachments only on individual workspaces.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

Should be merged alongside https://github.com/hashicorp/terraform-docs-common/pull/423.

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
