### PR TITLE
Run workflow updates for saved cloud plans

### DIFF
--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -27,19 +27,23 @@ The [CLI integration](/terraform/cli/cloud) brings Terraform Cloud's collaborati
 
 You can start runs with the standard `terraform plan` and `terraform apply` commands and then watch the progress of the run from your terminal. These runs execute remotely in Terraform Cloud, use variables from the appropriate workspace, enforce any applicable [Sentinel or OPA policies](/terraform/cloud-docs/policy-enforcement), and can access Terraform Cloud's [private registry][private] and remote state inputs.
 
-Terraform Cloud offers two kinds of CLI-driven runs, to support different stages of your workflow:
+Terraform Cloud offers three kinds of CLI-driven runs, to support different stages of your workflow:
 
 - `terraform plan` starts a [speculative plan][] in a Terraform Cloud workspace, using configuration files from a local directory. You can quickly check the results of edits (including compliance with Sentinel policies) without needing to copy sensitive variables to your local machine.
 
   Speculative plans work with all workspaces, and can co-exist with the [VCS-driven workflow](/terraform/cloud-docs/run/ui).
 
-- `terraform apply` starts a normal plan and apply in a Terraform Cloud workspace, using configuration files from a local directory.
+- `terraform apply` starts a standard plan and apply in a Terraform Cloud workspace, using configuration files from a local directory.
 
   Remote `terraform apply` is for workspaces without a linked VCS repository. It replaces the VCS-driven workflow with a more traditional CLI workflow.
 
-To supplement these remote operations, you can also use the optional [Terraform Enterprise Provider][tfe-provider], which interacts with the resources supported by Terraform Cloud. It can be useful for editing variables and workspace settings through the Terraform CLI.
+- `terraform plan -out <FILE>` and `terraform apply <FILE>` perform a two-part [saved plan run](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans) in a Terraform Cloud workspace, using configuration files from a local directory; the first command performs and saves the plan, and the second command applies it. You can use `terraform show <FILE>` to inspect a saved plan.
 
--> **Note:** The [Structured Run Output](/terraform/cloud-docs/workspaces/settings#user-interface) user interface will not apply to runs executed using the CLI-driven workflow, regardless of the setting in the Terraform Cloud workspace.
+    Like remote `terraform apply`, remote saved plans are for workspaces without a linked VCS repository.
+
+    -> **Version note:** Saved plans require at least Terraform CLI v1.6.0.
+
+To supplement these remote operations, you can also use the optional [Terraform Enterprise Provider][tfe-provider], which interacts with the resources supported by Terraform Cloud. It can be useful for editing variables and workspace settings through the Terraform CLI.
 
 ## Configuration
 
@@ -205,6 +209,33 @@ If you prefer to use the CLI in a non-interactive environment, we recommend firs
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
+## Remote Saved Plans
+
+-> **Version note:** Saved plans require at least Terraform CLI v1.6.0.
+
+In workspaces that support `terraform apply`, you also have the option of performing the plan and apply as separate steps, using the standard variations of the relevant Terraform commands:
+
+- `terraform plan -out <FILE>` will perform and save a plan.
+- `terraform apply <FILE>` will apply a previously saved plan.
+- `terraform show <FILE>` (and `terraform show -json <FILE>`) will inspect a previously saved plan.
+
+Saved plan runs are halfway between speculative plans and standard plan and apply runs. They allow you to:
+
+- Perform cheap exploratory plans, while retaining the option of applying a specific plan once you are satisfied with your work.
+- Perform other tasks in your terminal between the plan and apply stages.
+- Perform the plan and apply operations on separate machines (as is common in continuous integration workflows).
+
+Saved plans become _stale_ once the state they were planned against is no longer valid (usually due to a different run being applied). In Terraform Cloud, stale saved plan runs are automatically detected and discarded. When examining a remote saved plan, the `terraform show` command (without the `-json` option) will inform you if a plan has been discarded or is otherwise unable to be applied.
+
+### File Contents and Permissions
+
+In order to abide by Terraform Cloud's permissions model, remote saved plans do not use the same local file format as locally executed saved plans; instead, they are a thin reference to a remote run, and Terraform CLI relies on authenticated network requests to inspect and apply remote plans. This helps avoid the accidental exposure of credentials or other sensitive information.
+
+The `terraform show -json` command requires workspace admin permissions when performed with a remote saved plan; this is because the [machine-readable JSON plan format](/terraform/internals/json-format) contains unredacted sensitive information (alongside redaction hints for use by systems that consume the format). The human-readable version of `terraform show` receives pre-redacted information, so it only requires the read runs permission.
+
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
+
+Locally executed saved plans cannot be applied in a remote Terraform Cloud workspace, and remote saved plans cannot be applied locally.
 
 ## Policy Enforcement
 
@@ -212,13 +243,13 @@ If you prefer to use the CLI in a non-interactive environment, we recommend firs
 @include 'tfc-package-callouts/policies.mdx'
 <!-- END: TFC:only name:pnp-callout -->
 
-Policies are rules that Terraform Cloud enforces on Terraform runs. You can use two policy-as-code frameworks to define fine-grained, logic-based policies: Sentinel and Open Policy Agent (OPA). 
+Policies are rules that Terraform Cloud enforces on Terraform runs. You can use two policy-as-code frameworks to define fine-grained, logic-based policies: Sentinel and Open Policy Agent (OPA).
 
 If the specified workspace uses policies, Terraform Cloud runs those policies against all speculative plans and remote applies in that workspace. Failed policies can pause or prevent an apply, depending on the enforcement level. Refer to [Policy Enforcement](/terraform/cloud-docs/policy-enforcement) for details.
 
 For Sentinel, the Terraform CLI prints policy results for CLI-driven runs. CLI support for policy results is not available for OPA.
 
-The following example shows Sentinel policy output in the terminal.  
+The following example shows Sentinel policy output in the terminal.
 
 ```
 $ terraform apply

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -37,13 +37,13 @@ Terraform Cloud offers three kinds of CLI-driven runs, to support different stag
 
   Remote `terraform apply` is for workspaces without a linked VCS repository. It replaces the VCS-driven workflow with a more traditional CLI workflow.
 
-- `terraform plan -out <FILE>` and `terraform apply <FILE>` perform a two-part [saved plan run](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans) in a Terraform Cloud workspace, using configuration files from a local directory; the first command performs and saves the plan, and the second command applies it. You can use `terraform show <FILE>` to inspect a saved plan.
+- `terraform plan -out <FILE>` and `terraform apply <FILE>` perform a two-part [saved plan run](/terraform/cloud-docs/run/modes-and-options/#saved-plans) in a Terraform Cloud workspace, using configuration files from a local directory. The first command performs and saves the plan, and the second command applies it. You can use `terraform show <FILE>` to inspect a saved plan.
 
     Like remote `terraform apply`, remote saved plans are for workspaces without a linked VCS repository.
 
-    -> **Version note:** Saved plans require at least Terraform CLI v1.6.0.
+    Saved plans require at least Terraform CLI v1.6.0.
 
-To supplement these remote operations, you can also use the optional [Terraform Enterprise Provider][tfe-provider], which interacts with the resources supported by Terraform Cloud. It can be useful for editing variables and workspace settings through the Terraform CLI.
+To supplement these remote operations, you can also use the optional [Terraform Enterprise Provider][tfe-provider], which interacts with the Terraform Cloud-supported resources. This provider is useful for editing variables and workspace settings through the Terraform CLI.
 
 ## Configuration
 
@@ -215,23 +215,23 @@ If you prefer to use the CLI in a non-interactive environment, we recommend firs
 
 In workspaces that support `terraform apply`, you also have the option of performing the plan and apply as separate steps, using the standard variations of the relevant Terraform commands:
 
-- `terraform plan -out <FILE>` will perform and save a plan.
-- `terraform apply <FILE>` will apply a previously saved plan.
-- `terraform show <FILE>` (and `terraform show -json <FILE>`) will inspect a previously saved plan.
+- `terraform plan -out <FILE>` performs and saves a plan.
+- `terraform apply <FILE>` applies a previously saved plan.
+- `terraform show <FILE>` (and `terraform show -json <FILE>`) inspect a plan you previously saved.
 
-Saved plan runs are halfway between speculative plans and standard plan and apply runs. They allow you to:
+Saved plan runs are halfway between [speculative plans](#remote-speculative-plans) and standard [plan and apply runs](#remote-applies). They allow you to:
 
-- Perform cheap exploratory plans, while retaining the option of applying a specific plan once you are satisfied with your work.
+- Perform cheap exploratory plans while retaining the option of applying a specific plan you are satisfied with.
 - Perform other tasks in your terminal between the plan and apply stages.
 - Perform the plan and apply operations on separate machines (as is common in continuous integration workflows).
 
-Saved plans become _stale_ once the state they were planned against is no longer valid (usually due to a different run being applied). In Terraform Cloud, stale saved plan runs are automatically detected and discarded. When examining a remote saved plan, the `terraform show` command (without the `-json` option) will inform you if a plan has been discarded or is otherwise unable to be applied.
+Saved plans become _stale_ once the state Terraform planned them against is no longer valid (usually due to someone applying a different run). In Terraform Cloud, stale saved plan runs are automatically detected and discarded. When examining a remote saved plan, the `terraform show` command (without the `-json` option) informs you if a plan has been discarded or is otherwise unable to be applied.
 
 ### File Contents and Permissions
 
-In order to abide by Terraform Cloud's permissions model, remote saved plans do not use the same local file format as locally executed saved plans; instead, they are a thin reference to a remote run, and Terraform CLI relies on authenticated network requests to inspect and apply remote plans. This helps avoid the accidental exposure of credentials or other sensitive information.
+In order to abide by Terraform Cloud's permissions model, remote saved plans do not use the same local file format as locally executed saved plans. Instead, remote saved plans are a thin reference to a remote run, and the Terraform CLI relies on authenticated network requests to inspect and apply remote plans. This helps avoid the accidental exposure of credentials or other sensitive information.
 
-The `terraform show -json` command requires workspace admin permissions when performed with a remote saved plan; this is because the [machine-readable JSON plan format](/terraform/internals/json-format) contains unredacted sensitive information (alongside redaction hints for use by systems that consume the format). The human-readable version of `terraform show` receives pre-redacted information, so it only requires the read runs permission.
+The `terraform show -json` command requires [workspace admin permissions](/terraform/cloud-docs/users-teams-organizations/permissions#workspace-admins) to inspect a remote saved plan; this is because the [machine-readable JSON plan format](/terraform/internals/json-format) contains unredacted sensitive information (alongside redaction hints for use by systems that consume the format). The human-readable version of `terraform show` only requires the read runs permission, because it uses pre-redacted information.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -229,13 +229,13 @@ Saved plans become _stale_ once the state Terraform planned them against is no l
 
 ### File Contents and Permissions
 
+You can only apply remote saved plans in the same remote Terraform Cloud workspace that performed the plan. Additionally, you can not apply locally executed saved plans in a remote workspace.
+
 In order to abide by Terraform Cloud's permissions model, remote saved plans do not use the same local file format as locally executed saved plans. Instead, remote saved plans are a thin reference to a remote run, and the Terraform CLI relies on authenticated network requests to inspect and apply remote plans. This helps avoid the accidental exposure of credentials or other sensitive information.
 
 The `terraform show -json` command requires [workspace admin permissions](/terraform/cloud-docs/users-teams-organizations/permissions#workspace-admins) to inspect a remote saved plan; this is because the [machine-readable JSON plan format](/terraform/internals/json-format) contains unredacted sensitive information (alongside redaction hints for use by systems that consume the format). The human-readable version of `terraform show` only requires the read runs permission, because it uses pre-redacted information.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
-
-Locally executed saved plans cannot be applied in a remote Terraform Cloud workspace, and remote saved plans cannot be applied locally.
 
 ## Policy Enforcement
 

--- a/website/docs/cloud-docs/run/manage.mdx
+++ b/website/docs/cloud-docs/run/manage.mdx
@@ -65,7 +65,7 @@ You can lock the workspace to temporarily stop runs from proceeding. Locking a w
 
 A lock prevents Terraform Cloud from performing any applies in the workspace, and also prevents many kinds of plans. New runs remain in the **Pending** state until the workspace unlocks.
 
-Locking **does not** affect plan-only runs or the planning stages of saved plan runs. These actions are allowed because they cannot affect infrastructure resources, they do not attempt to lock the workspace themselves, and they might provide important information about tasks to perform before removing the lock. Note that saved-plan runs cannot be _applied_ while the workspace is locked, and will be automatically discarded if the workspace's state is changed before they can be applied.
+Locking **does not** affect [plan-only runs](/terraform/cloud-docs/run/remote-operations#speculative-plans) or the planning stages of [saved plan runs](/terraform/cloud-docs/run/cli#remote-saved-plans). Terraform allows these types of runs because they can not affect infrastructure resources, do not attempt to lock the workspace themselves, and might provide important information about tasks to perform before removing the lock. Note that you can not _apply_ saved-plan runs while the workspace is locked, and Terraform Cloud automatically discards these runs if the workspace's state is changed before they can be applied.
 
 Terraform Cloud shows the lock status in the workspace's header, next to the **Actions** menu.
 

--- a/website/docs/cloud-docs/run/manage.mdx
+++ b/website/docs/cloud-docs/run/manage.mdx
@@ -61,9 +61,11 @@ Force-canceling requires admin access to the workspace because it can have dange
 
 ## Locking Workspaces (Preventing Runs)
 
-You can lock the workspace to temporarily stop runs from being queued. Locking a workspace requires [permission to lock and unlock the workspace](/terraform/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions).
+You can lock the workspace to temporarily stop runs from proceeding. Locking a workspace requires [permission to lock and unlock the workspace](/terraform/cloud-docs/users-teams-organizations/permissions#general-workspace-permissions), and requires that the workspace is not currently locked by an in-progress run.
 
-A lock prevents Terraform Cloud from performing any plans or applies in the workspace. This lock includes automatic runs due to new commits in the VCS repository, manual runs queued via the UI, runs started on the command line with `terraform plan` and `terraform apply`, and runs created with the API. New runs remain in the **Pending** state until the workspace unlocks.
+A lock prevents Terraform Cloud from performing any applies in the workspace, and also prevents many kinds of plans. New runs remain in the **Pending** state until the workspace unlocks.
+
+Locking **does not** affect plan-only runs or the planning stages of saved plan runs. These actions are allowed because they cannot affect infrastructure resources, they do not attempt to lock the workspace themselves, and they might provide important information about tasks to perform before removing the lock. Note that saved-plan runs cannot be _applied_ while the workspace is locked, and will be automatically discarded if the workspace's state is changed before they can be applied.
 
 Terraform Cloud shows the lock status in the workspace's header, next to the **Actions** menu.
 

--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -9,6 +9,15 @@ description: >-
 
 Terraform Cloud runs support many of the same modes and options available in the Terraform CLI.
 
+## Plan and Apply (Standard)
+
+The default run mode of Terraform Cloud is to perform a plan, then apply it. If auto-apply is enabled, a successful plan will apply immediately; otherwise the run will wait for user confirmation before applying.
+
+- **CLI:** Use `terraform apply` (without providing a saved plan file).
+- **API:** Create a run without specifying any options that would select a different mode.
+- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Plan and apply (standard)** as the run type.
+- **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a standard plan and apply when new commits are added to the selected branch of that repository.
+
 ## Destroy Mode
 
 [Destroy mode](/terraform/cli/commands/plan#planning-modes) instructs Terraform to create a plan which destroys all objects, regardless of configuration changes.
@@ -16,6 +25,21 @@ Terraform Cloud runs support many of the same modes and options available in the
 - **CLI:** Use `terraform plan -destroy` or `terraform destroy`
 - **API:** Use the `is-destroy` option.
 - **UI:** Use a workspace's **Destruction and Deletion** settings page.
+
+## Saved Plans
+
+-> **Version note:** Using saved plans from the CLI with Terraform Cloud requires at least Terraform CLI v1.6.0.
+
+Saved plan runs are very similar to standard plan and apply runs: they perform a plan, and then optionally apply it. There are three main differences:
+
+1. _No wait for planning._ Saved plan runs ignore the per-workspace run queue during their plan and checks; like plan-only runs, they can begin planning even if another run is in progress, without blocking progress on other runs. They only become the current run (and block other runs) once they are confirmed for apply.
+2. _No auto-apply._ Saved plan runs are never auto-applied, even if auto-apply is enabled for the workspace; they will only apply when confirmed by a user.
+3. _Automatic discard for stale plans._ If another run is applied (or the state is otherwise modified) before a saved plan run is confirmed, Terraform Cloud will automatically discard that saved plan, since it would no longer make sense to apply it. Saved plans may also be automatically discarded if they are not confirmed within a few weeks.
+
+Saved plans are ideal for interactive CLI workflows (where you might perform many exploratory plans and then choose one to apply), or for custom continuous integration workflows where the default run queue behavior isn't suitable.
+
+- **CLI:** Use `terraform plan -out <FILE>` to perform and save a plan, then use `terraform apply <FILE>` to apply the saved plan. Use `terraform show <FILE>` if you need to inspect a saved plan before applying it.
+- **API:** Use the `save-plan` option when creating a run. If you create a new configuration version for a saved plan run, use the `provisional` option so that it will not become the workspace's current configuration version until you decide to apply the run.
 
 ## Refresh-Only Mode
 
@@ -27,7 +51,7 @@ Terraform Cloud runs support many of the same modes and options available in the
 
 - **CLI:** Use `terraform plan -refresh-only` or `terraform apply -refresh-only`.
 - **API:** Use the `refresh-only` option.
-- **UI:** Use the "Start new plan" action from a workspace's "Actions" menu, then choose the "Refresh-only" plan type in the new plan dialog.
+- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Refresh state** as the run type.
 
 ## Skipping Automatic State Refresh
 
@@ -47,19 +71,26 @@ The [replace option](/terraform/cli/commands/plan#replace-address) instructs Ter
 
 ## Allow Empty Apply
 
-A no-operation (empty) apply enables Terraform Cloud to apply a run from a plan that contains no infrastructure changes. During apply, Terraform can upgrade the state version if required. You can use this option to upgrade the state in your Terraform Cloud workspace to a new Terraform version.
+A no-operation (empty) apply enables Terraform Cloud to apply a run from a plan that contains no infrastructure changes. During apply, Terraform can upgrade the state version if required. You can use this option to upgrade the state in your Terraform Cloud workspace to a new Terraform version. Only some Terraform versions require this, most notably 0.13.
+
+To make such upgrades easier, empty apply runs will always auto-apply if their plan contains no changes.
 
 ~> **Warning:** Terraform Cloud cannot guarantee that a plan in this mode will produce no changes. We recommend checking the plan for drift before proceeding to the apply stage.
 
 - **API:** Set the `allow-empty-apply` field to `true`.
-- **UI:** Open the workspace's **Actions** menu, select **Start new plan**, and then choose **Allow empty apply** as the run type.
+- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Allow empty apply** as the run type.
 
 ## Plan Only/Speculative Plan
 
-This option creates a [speculative plan](/terraform/cloud-docs/run/remote-operations#speculative-plans). The speculative plan shows a set of possible changes and checks them against Sentinel policies, but Terraform cannot apply it. You can create speculative plans with a Terraform version that is different from the one currently selected for the workspace. This lets you check whether your configuration is compatible with a newer Terraform version without changing the workspace settings.
+This option creates a [speculative plan](/terraform/cloud-docs/run/remote-operations#speculative-plans). The speculative plan shows a set of possible changes and checks them against Sentinel policies, but Terraform cannot apply it.
 
-- **API:** Set the `plan-only` field to `true` and specify an available terraform version using the `terraform-version` field.
-- **UI:** Open the workspace's **Actions** menu, select **Start new plan**, and then choose **Plan only** as the run type.
+You can create speculative plans with a Terraform version that is different from the one currently selected for the workspace. This lets you check whether your configuration is compatible with a newer Terraform version without changing the workspace settings.
+
+Plan-only runs ignore the per-workspace run queue; they can proceed even if another run is in progress, they cannot become the workspace's current run, and they do not block progress on other runs in the workspace.
+
+- **API:** Set the `plan-only` option to `true` and specify an available terraform version using the `terraform-version` field.
+- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Plan only** as the run type.
+- **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a speculative plan when a pull request (or merge request) is opened against the selected branch of that repository. The plan will be linked from the pull/merge request view in your VCS, and can also be found in the workspace's run list.
 
 ## Targeted Plan and Apply
 

--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -26,6 +26,18 @@ The default run mode of Terraform Cloud is to perform a plan, then apply it. If 
 - **API:** Use the `is-destroy` option.
 - **UI:** Use a workspace's **Destruction and Deletion** settings page.
 
+## Plan Only/Speculative Plan
+
+This option creates a [speculative plan](/terraform/cloud-docs/run/remote-operations#speculative-plans). The speculative plan shows a set of possible changes and checks them against Sentinel policies, but Terraform cannot apply it.
+
+You can create speculative plans with a Terraform version that is different from the one currently selected for the workspace. This lets you check whether your configuration is compatible with a newer Terraform version without changing the workspace settings.
+
+Plan-only runs ignore the per-workspace run queue; they can proceed even if another run is in progress, they cannot become the workspace's current run, and they do not block progress on other runs in the workspace.
+
+- **API:** Set the `plan-only` option to `true` and specify an available terraform version using the `terraform-version` field.
+- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Plan only** as the run type.
+- **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a speculative plan when a pull request (or merge request) is opened against the selected branch of that repository. The plan will be linked from the pull/merge request view in your VCS, and can also be found in the workspace's run list.
+
 ## Saved Plans
 
 -> **Version note:** Using saved plans from the CLI with Terraform Cloud requires at least Terraform CLI v1.6.0.
@@ -40,6 +52,17 @@ Saved plans are ideal for interactive CLI workflows (where you might perform man
 
 - **CLI:** Use `terraform plan -out <FILE>` to perform and save a plan, then use `terraform apply <FILE>` to apply the saved plan. Use `terraform show <FILE>` if you need to inspect a saved plan before applying it.
 - **API:** Use the `save-plan` option when creating a run. If you create a new configuration version for a saved plan run, use the `provisional` option so that it will not become the workspace's current configuration version until you decide to apply the run.
+
+## Allow Empty Apply
+
+A no-operation (empty) apply enables Terraform Cloud to apply a run from a plan that contains no infrastructure changes. During apply, Terraform can upgrade the state version if required. You can use this option to upgrade the state in your Terraform Cloud workspace to a new Terraform version. Only some Terraform versions require this, most notably 0.13.
+
+To make such upgrades easier, empty apply runs will always auto-apply if their plan contains no changes.
+
+~> **Warning:** Terraform Cloud cannot guarantee that a plan in this mode will produce no changes. We recommend checking the plan for drift before proceeding to the apply stage.
+
+- **API:** Set the `allow-empty-apply` field to `true`.
+- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Allow empty apply** as the run type.
 
 ## Refresh-Only Mode
 
@@ -68,29 +91,6 @@ The [replace option](/terraform/cli/commands/plan#replace-address) instructs Ter
 
 - **CLI:** Use `terraform plan -replace=ADDRESS` or `terraform apply -replace=ADDRESS`.
 - **API:** Use the `replace-addrs` option.
-
-## Allow Empty Apply
-
-A no-operation (empty) apply enables Terraform Cloud to apply a run from a plan that contains no infrastructure changes. During apply, Terraform can upgrade the state version if required. You can use this option to upgrade the state in your Terraform Cloud workspace to a new Terraform version. Only some Terraform versions require this, most notably 0.13.
-
-To make such upgrades easier, empty apply runs will always auto-apply if their plan contains no changes.
-
-~> **Warning:** Terraform Cloud cannot guarantee that a plan in this mode will produce no changes. We recommend checking the plan for drift before proceeding to the apply stage.
-
-- **API:** Set the `allow-empty-apply` field to `true`.
-- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Allow empty apply** as the run type.
-
-## Plan Only/Speculative Plan
-
-This option creates a [speculative plan](/terraform/cloud-docs/run/remote-operations#speculative-plans). The speculative plan shows a set of possible changes and checks them against Sentinel policies, but Terraform cannot apply it.
-
-You can create speculative plans with a Terraform version that is different from the one currently selected for the workspace. This lets you check whether your configuration is compatible with a newer Terraform version without changing the workspace settings.
-
-Plan-only runs ignore the per-workspace run queue; they can proceed even if another run is in progress, they cannot become the workspace's current run, and they do not block progress on other runs in the workspace.
-
-- **API:** Set the `plan-only` option to `true` and specify an available terraform version using the `terraform-version` field.
-- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Plan only** as the run type.
-- **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a speculative plan when a pull request (or merge request) is opened against the selected branch of that repository. The plan will be linked from the pull/merge request view in your VCS, and can also be found in the workspace's run list.
 
 ## Targeted Plan and Apply
 

--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -11,12 +11,12 @@ Terraform Cloud runs support many of the same modes and options available in the
 
 ## Plan and Apply (Standard)
 
-The default run mode of Terraform Cloud is to perform a plan, then apply it. If auto-apply is enabled, a successful plan will apply immediately; otherwise the run will wait for user confirmation before applying.
+The default run mode of Terraform Cloud is to perform a plan and then apply it. If you have enabled auto-apply, a successful plan applies immediately. Otherwise, the run waits for user confirmation before applying.
 
 - **CLI:** Use `terraform apply` (without providing a saved plan file).
-- **API:** Create a run without specifying any options that would select a different mode.
+- **API:** Create a run without specifying any options that select a different mode.
 - **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Plan and apply (standard)** as the run type.
-- **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a standard plan and apply when new commits are added to the selected branch of that repository.
+- **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a standard plan and apply when you add new commits to the selected branch of that repository.
 
 ## Destroy Mode
 
@@ -28,29 +28,29 @@ The default run mode of Terraform Cloud is to perform a plan, then apply it. If 
 
 ## Plan Only/Speculative Plan
 
-This option creates a [speculative plan](/terraform/cloud-docs/run/remote-operations#speculative-plans). The speculative plan shows a set of possible changes and checks them against Sentinel policies, but Terraform cannot apply it.
+This option creates a [speculative plan](/terraform/cloud-docs/run/remote-operations#speculative-plans). The speculative plan shows a set of possible changes and checks them against Sentinel policies, but Terraform can _not_ apply this plan.
 
-You can create speculative plans with a Terraform version that is different from the one currently selected for the workspace. This lets you check whether your configuration is compatible with a newer Terraform version without changing the workspace settings.
+You can create speculative plans with a different Terraform version than the one currently selected for a workspace. This lets you check whether your configuration is compatible with a newer Terraform version without changing the workspace settings.
 
-Plan-only runs ignore the per-workspace run queue; they can proceed even if another run is in progress, they cannot become the workspace's current run, and they do not block progress on other runs in the workspace.
+Plan-only runs ignore the per-workspace run queue. Plan-only runs can proceed even if another run is in progress, can not become the workspace's current run, and do not block progress on a workspace's other runs.
 
 - **API:** Set the `plan-only` option to `true` and specify an available terraform version using the `terraform-version` field.
 - **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Plan only** as the run type.
-- **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a speculative plan when a pull request (or merge request) is opened against the selected branch of that repository. The plan will be linked from the pull/merge request view in your VCS, and can also be found in the workspace's run list.
+- **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a speculative plan when someone opens a pull request (or merge request) against the selected branch of that repository.  The pull/merge request view in your VCS links to the speculative plan, and you can also find it in the workspace's run list.
 
 ## Saved Plans
 
 -> **Version note:** Using saved plans from the CLI with Terraform Cloud requires at least Terraform CLI v1.6.0.
 
-Saved plan runs are very similar to standard plan and apply runs: they perform a plan, and then optionally apply it. There are three main differences:
+Saved plan runs are very similar to standard plan and apply runs: they perform a plan and then optionally apply it. There are three main differences:
 
-1. _No wait for planning._ Saved plan runs ignore the per-workspace run queue during their plan and checks; like plan-only runs, they can begin planning even if another run is in progress, without blocking progress on other runs. They only become the current run (and block other runs) once they are confirmed for apply.
-2. _No auto-apply._ Saved plan runs are never auto-applied, even if auto-apply is enabled for the workspace; they will only apply when confirmed by a user.
-3. _Automatic discard for stale plans._ If another run is applied (or the state is otherwise modified) before a saved plan run is confirmed, Terraform Cloud will automatically discard that saved plan, since it would no longer make sense to apply it. Saved plans may also be automatically discarded if they are not confirmed within a few weeks.
+1. _No wait for planning._ Saved plan runs ignore the per-workspace run queue during their plan and checks. Like plan-only runs, saved plans can begin planning even if another run is in progress, without blocking progress on other runs.
+2. _No auto-apply._ Saved plan runs are never auto-applied, even if you enabled auto-apply for the workspace. Saved plans only apply if you confirm them.
+3. _Automatic discard for stale plans._ If another run is applied (or the state is otherwise modified) before a saved plan run is confirmed, Terraform Cloud automatically discards that saved plan. Terraform Cloud may also automatically discard saved plans if they are not confirmed within a few weeks.
 
-Saved plans are ideal for interactive CLI workflows (where you might perform many exploratory plans and then choose one to apply), or for custom continuous integration workflows where the default run queue behavior isn't suitable.
+Saved plans are ideal for interactive CLI workflows, where you can perform many exploratory plans and then choose one to apply, or for custom continuous integration workflows where the default run queue behavior isn't suitable.
 
-- **CLI:** Use `terraform plan -out <FILE>` to perform and save a plan, then use `terraform apply <FILE>` to apply the saved plan. Use `terraform show <FILE>` if you need to inspect a saved plan before applying it.
+- **CLI:** Use `terraform plan -out <FILE>` to perform and save a plan, then use `terraform apply <FILE>` to apply the saved plan. Use `terraform show <FILE>` to inspect a saved plan before applying it.
 - **API:** Use the `save-plan` option when creating a run. If you create a new configuration version for a saved plan run, use the `provisional` option so that it will not become the workspace's current configuration version until you decide to apply the run.
 
 ## Allow Empty Apply

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -49,13 +49,23 @@ Each workspace in Terraform Cloud maintains its own queue of runs, and processes
 
 Whenever a new run is initiated, it's added to the end of the queue. If there's already a run in progress, the new run won't start until the current one has completely finished — Terraform Cloud won't even plan the run yet, because the current run might change what a future run would do. Runs that are waiting for other runs to finish are in a _pending_ state, and a workspace might have any number of pending runs.
 
+There are two exceptions to the run queue, which can proceed at any time and do not block the progress of other runs:
+
+- Plan-only runs.
+- The planning stages of [saved plan runs](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans). (Note that you can only _apply_ a saved plan if no other run is in progress, and the apply will block the run queue like normal.)
+
 When you initiate a run, Terraform Cloud locks the run to a particular configuration version and set of variable values. If you change variables or commit new code before the run finishes, it will only affect future runs, not runs that are already pending, planning, or awaiting apply.
 
 ### Workspace Locks
 
-When a workspace is _locked,_ new runs can be queued (automatically or manually) but no new runs can begin until the workspace is unlocked.
+When a workspace is _locked,_ new runs can be created (automatically or manually) but will not begin until the workspace is unlocked.
 
 When a run is in progress, that run locks the workspace, as described above under "Ordering and Timing".
+
+There are two kinds of run operation that can ignore workspace locking:
+
+- Plan-only runs.
+- The planning stages of [saved plan runs](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans). (Note that you can only _apply_ a saved plan if the workspace is unlocked, and the apply will lock the workspace like normal.)
 
 A user or team can also deliberately lock a workspace, to perform maintenance or for any other reason. For more details, see [Locking Workspaces (Preventing Runs)](/terraform/cloud-docs/run/manage#locking-workspaces-preventing-runs-).
 
@@ -71,11 +81,13 @@ You can initiate Terraform Cloud runs through the manual **Start new run** actio
 
 ## Plans and Applies
 
-Terraform Cloud enforces Terraform's division between _plan_ and _apply_ operations. It always plans first, saves the plan's output, and uses that output for the apply.
+Terraform Cloud enforces Terraform's division between _plan_ and _apply_ operations. It always plans first, then uses that plan's output for the apply.
 
 In the default configuration, Terraform Cloud waits for user approval before running an apply, but you can configure workspaces to [automatically apply](/terraform/cloud-docs/workspaces/settings#auto-apply-and-manual-apply) successful plans. Some plans can't be auto-applied, like plans queued by [run triggers](/terraform/cloud-docs/workspaces/settings/run-triggers) or by users without permission to apply runs for the workspace. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))
 
-[permissions-citation]: #intentionally-unused---keep-for-maintainers)
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
+
+If a plan contains no changes, Terraform Cloud won't attempt to apply it; instead, the run will end with a status of "Planned and finished". (The [allow empty apply](/terraform/cloud-docs/run/modes-and-options#allow-empty-apply) run mode can override this behavior.)
 
 ### Speculative Plans
 
@@ -98,6 +110,14 @@ Retrying a plan requires permission to queue plans for that workspace. ([More ab
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 Retrying the run will create a new run with the same configuration version. If it is a VCS-backed workspace, the pull request interface will receive the status of the new run, along with a link to the new run.
+
+### Saved Plans
+
+-> **Version note:** Using saved plans from the CLI with Terraform Cloud requires at least Terraform CLI v1.6.0.
+
+Terraform Cloud also supports saved plan runs. With the [CLI integration](/terraform/cli/cloud) configured, you can use `terraform plan -out <FILE>` to perform and save a plan, `terraform apply <FILE>` to apply a saved plan, and `terraform show <FILE>` to inspect a saved plan before applying it. You can also create saved plan runs via the API by using the `save-plan` option.
+
+Saved plan runs affect the run queue differently from normal runs, and can sometimes be automatically discarded. For more details, see [Run Modes and Options: Saved Plans](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans).
 
 ## Planning Modes and Options
 

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -52,20 +52,20 @@ Whenever a new run is initiated, it's added to the end of the queue. If there's 
 There are two exceptions to the run queue, which can proceed at any time and do not block the progress of other runs:
 
 - Plan-only runs.
-- The planning stages of [saved plan runs](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans). (Note that you can only _apply_ a saved plan if no other run is in progress, and the apply will block the run queue like normal.)
+- The planning stages of [saved plan runs](/terraform/cloud-docs/run/modes-and-options/#saved-plans). You can only _apply_ a saved plan if no other run is in progress, and applying that plan blocks the run queue as usual.
 
 When you initiate a run, Terraform Cloud locks the run to a particular configuration version and set of variable values. If you change variables or commit new code before the run finishes, it will only affect future runs, not runs that are already pending, planning, or awaiting apply.
 
 ### Workspace Locks
 
-When a workspace is _locked,_ new runs can be created (automatically or manually) but will not begin until the workspace is unlocked.
+When a workspace is _locked,_ Terraform Cloud can create new runs (automatically or manually), but those runs do not begin until you unlock the workspace.
 
 When a run is in progress, that run locks the workspace, as described above under "Ordering and Timing".
 
 There are two kinds of run operation that can ignore workspace locking:
 
 - Plan-only runs.
-- The planning stages of [saved plan runs](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans). (Note that you can only _apply_ a saved plan if the workspace is unlocked, and the apply will lock the workspace like normal.)
+- The planning stages of [saved plan runs](/terraform/cloud-docs/run/modes-and-options/#saved-plans). You can only _apply_ a saved plan if the workspace is unlocked, and applying that plan locks the workspace as usual.
 
 A user or team can also deliberately lock a workspace, to perform maintenance or for any other reason. For more details, see [Locking Workspaces (Preventing Runs)](/terraform/cloud-docs/run/manage#locking-workspaces-preventing-runs-).
 
@@ -87,7 +87,7 @@ In the default configuration, Terraform Cloud waits for user approval before run
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-If a plan contains no changes, Terraform Cloud won't attempt to apply it; instead, the run will end with a status of "Planned and finished". (The [allow empty apply](/terraform/cloud-docs/run/modes-and-options#allow-empty-apply) run mode can override this behavior.)
+If a plan contains no changes, Terraform Cloud does not attempt to apply it. Instead, the run ends with a status of "Planned and finished". The [allow empty apply](/terraform/cloud-docs/run/modes-and-options#allow-empty-apply) run mode can override this behavior.
 
 ### Speculative Plans
 
@@ -115,9 +115,9 @@ Retrying the run will create a new run with the same configuration version. If i
 
 -> **Version note:** Using saved plans from the CLI with Terraform Cloud requires at least Terraform CLI v1.6.0.
 
-Terraform Cloud also supports saved plan runs. With the [CLI integration](/terraform/cli/cloud) configured, you can use `terraform plan -out <FILE>` to perform and save a plan, `terraform apply <FILE>` to apply a saved plan, and `terraform show <FILE>` to inspect a saved plan before applying it. You can also create saved plan runs via the API by using the `save-plan` option.
+Terraform Cloud also supports saved plan runs. If you have configured the [CLI integration](/terraform/cli/cloud) you can use `terraform plan -out <FILE>` to perform and save a plan, `terraform apply <FILE>` to apply a saved plan, and `terraform show <FILE>` to inspect a saved plan before applying it. You can also create saved plan runs via the API by using the `save-plan` option.
 
-Saved plan runs affect the run queue differently from normal runs, and can sometimes be automatically discarded. For more details, see [Run Modes and Options: Saved Plans](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans).
+Saved plan runs affect the run queue differently from normal runs, and can sometimes be automatically discarded. For more details, refer to [Run Modes and Options: Saved Plans](/terraform/cloud-docs/run/modes-and-options#saved-plans).
 
 ## Planning Modes and Options
 

--- a/website/docs/cloud-docs/workspaces/settings/index.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/index.mdx
@@ -146,7 +146,12 @@ The Console UI experience is the traditional Terraform experience, where live te
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-If you need to prevent Terraform runs for any reason, you can lock a workspace. This prevents users with permission to queue plans from manually queueing runs, prevents automatic runs due to changes to the backing VCS repo, and prevents the creation of runs via the API. To enable runs again, a user must unlock the workspace.
+If you need to prevent Terraform runs for any reason, you can lock a workspace. This prevents all applies (and many kinds of plans) from proceeding, and affects runs created via UI, CLI, API, and automated systems. To enable runs again, a user must unlock the workspace.
+
+There are two kinds of run operation that can ignore workspace locking, since they cannot affect resources or state and do not attempt to lock the workspace themselves:
+
+- Plan-only runs.
+- The planning stages of [saved plan runs](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans). (Note that you can only _apply_ a saved plan if the workspace is unlocked, and the apply will lock the workspace like normal.)
 
 Locking a workspace also restricts state uploads. In order to upload state, the workspace must be locked by the user who is uploading state.
 

--- a/website/docs/cloud-docs/workspaces/settings/index.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/index.mdx
@@ -148,10 +148,10 @@ The Console UI experience is the traditional Terraform experience, where live te
 
 If you need to prevent Terraform runs for any reason, you can lock a workspace. This prevents all applies (and many kinds of plans) from proceeding, and affects runs created via UI, CLI, API, and automated systems. To enable runs again, a user must unlock the workspace.
 
-There are two kinds of run operation that can ignore workspace locking, since they cannot affect resources or state and do not attempt to lock the workspace themselves:
+Two kinds of run operations can ignore workspace locking because they cannot affect resources or state and do not attempt to lock the workspace themselves:
 
 - Plan-only runs.
-- The planning stages of [saved plan runs](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans). (Note that you can only _apply_ a saved plan if the workspace is unlocked, and the apply will lock the workspace like normal.)
+- The planning stages of [saved plan runs](/terraform/cloud-docs/run/modes-and-options.mdx#saved-plans). You can only _apply_ a saved plan if the workspace is unlocked, and applying that plan locks the workspace as usual.
 
 Locking a workspace also restricts state uploads. In order to upload state, the workspace must be locked by the user who is uploading state.
 


### PR DESCRIPTION
### What

New sections and updated content in existing pages, mostly within the `run/` directory. 

- cloud-docs/run/cli.mdx
- cloud-docs/run/manage.mdx
- cloud-docs/run/modes-and-options.mdx
- cloud-docs/run/remote-operations.mdx
- cloud-docs/workspaces/settings/index.mdx

### Why

TFC now supports saved plans (`terraform plan -out NAME`, then `terraform apply NAME`), when used with the upcoming Terraform CLI v1.6 (betas coming soon). 

These runs behave a bit differently from standard plan+apply runs — they'll finish their plan and checks without trying to grab the workspace lock and without preventing other runs from proceeding. This results in a sort of hybrid run: the plan portion acts like a speculative plan (cheap, fast, easy, gets automatically discarded eventually if you never choose to apply it), but the apply portion is subject to the normal run queue controls (locks the workspace, can only apply if workspace is currently unlocked). Behind the scenes, this is all managed via the `save-plan` run attribute in the run creation API. (See #428)

Since this results in some behavior that used to be considered "impossible," the new feature required some wide-ranging updates to the runs section. 

### When

This should probably not be merged until the first Terraform 1.6 beta is released, since there's not currently a ready-made build you can use with this feature. 

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] n/a Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] n/a API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] n/a Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] n/a New pages have metadata (page name and description) at the top.
- [x] n/a New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] n/a New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
