### PR TITLE
Add subscription and tenant id to Azure example TF

### DIFF
--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -105,18 +105,22 @@ variable "tfc_azure_dynamic_credentials" {
 ```hcl
 provider "azurerm" {
   features {}
-  // Set this to true as we are using OIDC
-  use_oidc = true
-  client_id_file_path = var.tfc_azure_dynamic_credentials.default.client_id_file_path
+  // use_oidc must be explicitly set to true when using multiple configurations.
+  use_oidc             = true
+  client_id_file_path  = var.tfc_azure_dynamic_credentials.default.client_id_file_path
   oidc_token_file_path = var.tfc_azure_dynamic_credentials.default.oidc_token_file_path
+  subscription_id      = "00000000-0000-0000-0000-000000000000"
+  tenant_id            = "10000000-0000-0000-0000-000000000000"
 }
 
 provider "azurerm" {
   features {}
-  // Set this to true as we are using OIDC
-  use_oidc = true
-  alias = "ALIAS1"
-  client_id_file_path = var.tfc_azure_dynamic_credentials.aliases["ALIAS1"].client_id_file_path
+  // use_oidc must be explicitly set to true when using multiple configurations.
+  use_oidc             = true
+  alias                = "ALIAS1"
+  client_id_file_path  = var.tfc_azure_dynamic_credentials.aliases["ALIAS1"].client_id_file_path
   oidc_token_file_path = var.tfc_azure_dynamic_credentials.aliases["ALIAS1"].oidc_token_file_path
+  subscription_id      = "00000000-0000-0000-0000-000000000000"
+  tenant_id            = "20000000-0000-0000-0000-000000000000"
 }
 ```

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -91,15 +91,18 @@ variable "tfc_vault_backed_azure_dynamic_credentials" {
 ```hcl
 provider "azurerm" {
   features {}
-  client_id_file_path = var.tfc_vault_backed_azure_dynamic_credentials.default.client_id_file_path
+  client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.default.client_id_file_path
   client_secret_file_path = var.tfc_vault_backed_azure_dynamic_credentials.default.client_secret_file_path
+  subscription_id         = "00000000-0000-0000-0000-000000000000"
+  tenant_id               = "10000000-0000-0000-0000-000000000000"
 }
 
 provider "azurerm" {
   features {}
-  alias = "ALIAS1"
-  client_id_file_path = var.tfc_vault_backed_azure_dynamic_credentials.aliases["ALIAS1"].client_id_file_path
+  alias                   = "ALIAS1"
+  client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.aliases["ALIAS1"].client_id_file_path
   client_secret_file_path = var.tfc_vault_backed_azure_dynamic_credentials.aliases["ALIAS1"].client_secret_file_path
+  subscription_id         = "00000000-0000-0000-0000-000000000000"
+  tenant_id               = "20000000-0000-0000-0000-000000000000"
 }
-
 ```


### PR DESCRIPTION
### What
Updates the Azure dynamic credentials and Vault-backed Azure credentials example TF for multiple configurations to show explicitly setting `tenant_id` and `subscription_id`.

### Why
This is being done in an effort to avoid confusion around whether these provider arguments are required for multiple configurations, as some end users did not specify them when attempting to use this functionality and received confusing error output.

### External Links
- [JIRA](https://hashicorp.atlassian.net/browse/TF-9144)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
