### PR TITLE
Adds documentation for multiple dynamic credentials config support for the AzureAD provider

### DIFF
--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -109,7 +109,7 @@ variable "tfc_azure_dynamic_credentials" {
 ```hcl
 provider "azurerm" {
   features {}
-  // use_cli should be set to false yield more accurate error messages on auth failure.
+  // use_cli should be set to false to yield more accurate error messages on auth failure.
   use_cli              = false
   // use_oidc must be explicitly set to true when using multiple configurations.
   use_oidc             = true
@@ -121,7 +121,7 @@ provider "azurerm" {
 
 provider "azurerm" {
   features {}
-  // use_cli should be set to false yield more accurate error messages on auth failure.
+  // use_cli should be set to false to yield more accurate error messages on auth failure.
   use_cli              = false
   // use_oidc must be explicitly set to true when using multiple configurations.
   use_oidc             = true
@@ -138,7 +138,7 @@ provider "azurerm" {
 ```hcl
 provider "azuread" {
   features {}
-  // use_cli should be set to false yield more accurate error messages on auth failure.
+  // use_cli should be set to false to yield more accurate error messages on auth failure.
   use_cli              = false
   // use_oidc must be explicitly set to true when using multiple configurations.
   use_oidc             = true
@@ -150,7 +150,7 @@ provider "azuread" {
 
 provider "azuread" {
   features {}
-  // use_cli should be set to false yield more accurate error messages on auth failure.
+  // use_cli should be set to false to yield more accurate error messages on auth failure.
   use_cli              = false
   // use_oidc must be explicitly set to true when using multiple configurations.
   use_oidc             = true

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -74,6 +74,8 @@ Make sure that you’re _not_ setting values for `client_id`, `use_oidc`, or `oi
 
 ### Specifying Multiple Configurations
 
+~> **Important:** Ensure you are using version **3.60.0** or later of the **AzureRM provider** and version **2.43.0** or later of the **AzureAD provider** as required functionality was introduced in these provider versions.
+
 ~> **Important:** If you are self-hosting [Terraform Cloud Agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
 
 You can add additional configurations to handle multiple distinct Azure setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace.
@@ -102,9 +104,13 @@ variable "tfc_azure_dynamic_credentials" {
 
 #### Example Usage
 
+##### AzureRM Provider
+
 ```hcl
 provider "azurerm" {
   features {}
+  // use_cli should be set to false yield more accurate error messages on auth failure.
+  use_cli              = false
   // use_oidc must be explicitly set to true when using multiple configurations.
   use_oidc             = true
   client_id_file_path  = var.tfc_azure_dynamic_credentials.default.client_id_file_path
@@ -115,6 +121,37 @@ provider "azurerm" {
 
 provider "azurerm" {
   features {}
+  // use_cli should be set to false yield more accurate error messages on auth failure.
+  use_cli              = false
+  // use_oidc must be explicitly set to true when using multiple configurations.
+  use_oidc             = true
+  alias                = "ALIAS1"
+  client_id_file_path  = var.tfc_azure_dynamic_credentials.aliases["ALIAS1"].client_id_file_path
+  oidc_token_file_path = var.tfc_azure_dynamic_credentials.aliases["ALIAS1"].oidc_token_file_path
+  subscription_id      = "00000000-0000-0000-0000-000000000000"
+  tenant_id            = "20000000-0000-0000-0000-000000000000"
+}
+```
+
+##### AzureAD Provider
+
+```hcl
+provider "azuread" {
+  features {}
+  // use_cli should be set to false yield more accurate error messages on auth failure.
+  use_cli              = false
+  // use_oidc must be explicitly set to true when using multiple configurations.
+  use_oidc             = true
+  client_id_file_path  = var.tfc_azure_dynamic_credentials.default.client_id_file_path
+  oidc_token_file_path = var.tfc_azure_dynamic_credentials.default.oidc_token_file_path
+  subscription_id      = "00000000-0000-0000-0000-000000000000"
+  tenant_id            = "10000000-0000-0000-0000-000000000000"
+}
+
+provider "azuread" {
+  features {}
+  // use_cli should be set to false yield more accurate error messages on auth failure.
+  use_cli              = false
   // use_oidc must be explicitly set to true when using multiple configurations.
   use_oidc             = true
   alias                = "ALIAS1"

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -60,6 +60,8 @@ This includes the [`vault_azure_access_credentials`](https://registry.terraform.
 
 ### Specifying Multiple Configurations
 
+~> **Important:** Ensure you are using version **3.60.0** or later of the **AzureRM provider** and version **2.43.0** or later of the **AzureAD provider** as required functionality was introduced in these provider versions.
+
 ~> **Important:** If you are self-hosting [Terraform Cloud Agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
 
 You can add additional configurations to handle multiple distinct Vault-backed Azure setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace.
@@ -88,9 +90,13 @@ variable "tfc_vault_backed_azure_dynamic_credentials" {
 
 #### Example Usage
 
+##### AzureRM Provider
+
 ```hcl
 provider "azurerm" {
   features {}
+  // use_cli should be set to false yield more accurate error messages on auth failure.
+  use_cli                 = false
   client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.default.client_id_file_path
   client_secret_file_path = var.tfc_vault_backed_azure_dynamic_credentials.default.client_secret_file_path
   subscription_id         = "00000000-0000-0000-0000-000000000000"
@@ -99,6 +105,33 @@ provider "azurerm" {
 
 provider "azurerm" {
   features {}
+  // use_cli should be set to false yield more accurate error messages on auth failure.
+  use_cli                 = false
+  alias                   = "ALIAS1"
+  client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.aliases["ALIAS1"].client_id_file_path
+  client_secret_file_path = var.tfc_vault_backed_azure_dynamic_credentials.aliases["ALIAS1"].client_secret_file_path
+  subscription_id         = "00000000-0000-0000-0000-000000000000"
+  tenant_id               = "20000000-0000-0000-0000-000000000000"
+}
+```
+
+##### AzureAD Provider
+
+```hcl
+provider "azuread" {
+  features {}
+  // use_cli should be set to false yield more accurate error messages on auth failure.
+  use_cli                 = false
+  client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.default.client_id_file_path
+  client_secret_file_path = var.tfc_vault_backed_azure_dynamic_credentials.default.client_secret_file_path
+  subscription_id         = "00000000-0000-0000-0000-000000000000"
+  tenant_id               = "10000000-0000-0000-0000-000000000000"
+}
+
+provider "azuread" {
+  features {}
+  // use_cli should be set to false yield more accurate error messages on auth failure.
+  use_cli                 = false
   alias                   = "ALIAS1"
   client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.aliases["ALIAS1"].client_id_file_path
   client_secret_file_path = var.tfc_vault_backed_azure_dynamic_credentials.aliases["ALIAS1"].client_secret_file_path

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -95,7 +95,7 @@ variable "tfc_vault_backed_azure_dynamic_credentials" {
 ```hcl
 provider "azurerm" {
   features {}
-  // use_cli should be set to false yield more accurate error messages on auth failure.
+  // use_cli should be set to false to yield more accurate error messages on auth failure.
   use_cli                 = false
   client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.default.client_id_file_path
   client_secret_file_path = var.tfc_vault_backed_azure_dynamic_credentials.default.client_secret_file_path
@@ -105,7 +105,7 @@ provider "azurerm" {
 
 provider "azurerm" {
   features {}
-  // use_cli should be set to false yield more accurate error messages on auth failure.
+  // use_cli should be set to false to yield more accurate error messages on auth failure.
   use_cli                 = false
   alias                   = "ALIAS1"
   client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.aliases["ALIAS1"].client_id_file_path
@@ -120,7 +120,7 @@ provider "azurerm" {
 ```hcl
 provider "azuread" {
   features {}
-  // use_cli should be set to false yield more accurate error messages on auth failure.
+  // use_cli should be set to false to yield more accurate error messages on auth failure.
   use_cli                 = false
   client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.default.client_id_file_path
   client_secret_file_path = var.tfc_vault_backed_azure_dynamic_credentials.default.client_secret_file_path
@@ -130,7 +130,7 @@ provider "azuread" {
 
 provider "azuread" {
   features {}
-  // use_cli should be set to false yield more accurate error messages on auth failure.
+  // use_cli should be set to false to yield more accurate error messages on auth failure.
   use_cli                 = false
   alias                   = "ALIAS1"
   client_id_file_path     = var.tfc_vault_backed_azure_dynamic_credentials.aliases["ALIAS1"].client_id_file_path


### PR DESCRIPTION
### What
Adds documentation for AzureAD support for multiple provider configurations

### Why
Support for multiple provider configuration for the AzureAD provider was added in the most recently provider release (v2.43.0).

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.

#### External Links
- [JIRA](https://hashicorp.atlassian.net/browse/TF-9426)
