### PR TITLE
Clarify usage of data sources with Vault dynamic credentials

### DIFF
--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -137,10 +137,9 @@ You may need to set these variables, depending on your Vault configuration and u
 ## Vault Provider Configuration
 Once you set up dynamic credentials for a workspace, Terraform Cloud automatically authenticates to Vault for each run. Do not pass the `address`, `token`, or `namespace` arguments into the provider configuration block. Terraform Cloud sets these values as environment variables in the run environment.
 
-You can use the Vault provider to read secrets from Vault and use them with other Terraform resources. You can also access the other resources and data sources available in the [Vault provider documentation](https://registry.terraform.io/providers/hashicorp/vault/latest). You must adjust your [Vault policy](#create-a-vault-policy) to give your Terraform Cloud workspace access to all required Vault paths.
+You can use the Vault provider to read static secrets from Vault and use them with other Terraform resources. You can also access the other resources and data sources available in the [Vault provider documentation](https://registry.terraform.io/providers/hashicorp/vault/latest). You must adjust your [Vault policy](#create-a-vault-policy) to give your Terraform Cloud workspace access to all required Vault paths.
 
-### Vault Dynamic Secrets Engines
-You can use Vault's dynamic secrets engines for AWS, GCP, and Azure by adding additional configurations. For more details, see [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed).
+~> **Important:** data sources that use secrets engines to generate dynamic secrets must not be used with Vault dynamic credentials. You can use Vault's dynamic secrets engines for AWS, GCP, and Azure by adding additional configurations. For more details, see [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed).
 
 ### Specifying Multiple Configurations
 
@@ -180,10 +179,10 @@ variable "tfc_vault_dynamic_credentials" {
 
 ```hcl
 provider "vault" {
-  // Set this to true as TFC manages the token lifecycle
+  // skip_child_token must be explicitly set to true as TFC manages the token lifecycle
   skip_child_token = true
-  address = var.tfc_vault_dynamic_credentials.default.address
-  namespace = var.tfc_vault_dynamic_credentials.default.namespace
+  address          = var.tfc_vault_dynamic_credentials.default.address
+  namespace        = var.tfc_vault_dynamic_credentials.default.namespace
 
   auth_login_token_file {
     filename = var.tfc_vault_dynamic_credentials.default.token_filename
@@ -191,11 +190,11 @@ provider "vault" {
 }
 
 provider "vault" {
-  // Set this to true as TFC manages the token lifecycle
+  // skip_child_token must be explicitly set to true as TFC manages the token lifecycle
   skip_child_token = true
-  alias = "ALIAS1"
-  address = var.tfc_vault_dynamic_credentials.aliases["ALIAS1"].address
-  namespace = var.tfc_vault_dynamic_credentials.aliases["ALIAS1"].namespace
+  alias            = "ALIAS1"
+  address          = var.tfc_vault_dynamic_credentials.aliases["ALIAS1"].address
+  namespace        = var.tfc_vault_dynamic_credentials.aliases["ALIAS1"].namespace
 
   auth_login_token_file {
     filename = var.tfc_vault_dynamic_credentials.aliases["ALIAS1"].token_filename


### PR DESCRIPTION
### What
Clarifies the usage of data sources with Vault dynamic credentials to call out that using dynamic secrets engines to generate short-lived credentials outside of the Vault-backed flows is not supported.

### Why
Users were attempting to generate short-lived secrets via data sources that interface with dynamic secrets engines and were running into issues with credentials expiring between plan and apply operations.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.

### External links
- [JIRA](https://hashicorp.atlassian.net/browse/TF-9074)
