### PR TITLE
update the name of provisional state version to be intermediate state…

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,9 @@ description: >-
 
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
+## 2023-09-25
+* Add `intermediate` boolean attribute to the [State Versions API](/terraform/cloud-docs/api-docs/state-versions).
+
 ## 2023-09-19
 * Add [failed state upload recovery](/terraform/cloud-docs/api-docs/applies#recover-a-failed-state-upload-after-applying) endpoint.
 

--- a/website/docs/cloud-docs/api-docs/state-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/state-versions.mdx
@@ -52,7 +52,7 @@ Attribute                        | Description
 `hosted-state-upload-url`        | A URL to which you can upload state data in the format used Terraform uses internally. You can upload state data once per state version.
 `modules`                        | Extracted information about the Terraform modules in this state data. Populated asynchronously.
 `providers`                      | Extracted information about the Terraform providers used for resources in this state data. Populated asynchronously.
-`provisional`                    | A boolean flag that indicating that Terraform Cloud created a state version, but that version is not the current versions for a workspace yet.
+`intermediate`                   | A boolean flag that indicates the state version is a snapshot and not yet set as the current state version for a workspace. The last intermediate state version becomes the current state version when the workspace is unlocked.
 `resources`                      | Extracted information about the resources in this state data. Populated asynchronously.
 `resources-processed`            | A Boolean flag indicating whether Terraform Cloud has finished asynchronously extracting outputs, resources, and other information about this state data.
 `serial`                         | The serial number of this state instance, which increases every time Terraform creates new state in the workspace.
@@ -67,9 +67,9 @@ The state version status is found in `data.attributes.status`, and you can refer
 A state version created through the API or CLI will only be listed in the UI if it is has a `finalized` status.
 | State        | Description                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `pending`    | The initial status of a state version after it has been created without encoding the state data within the request. Pending state versions do not contain state data and will not appear in the UI. The workspace cannot be unlocked normally until the latest state version has been finalized.                                     |
+| `pending`    | The initial status of a state version after it has been created without encoding the state data within the request. Pending state versions do not contain state data and will not appear in the UI. The workspace cannot be unlocked normally until the latest state version has been finalized.
 | `finalized`  | The state version has been uploaded successfully to Terraform Cloud or if the state version was created with a valid `state` attribute.                                                                                                                                                                                                              |
-| `discarded` | The state version has been discarded because it was provisional and not promoted to be the current state version of the workspace. |
+| `discarded`  | The state version has been discarded because it was superseded by a newer state version before it could be uploaded. |
 
 ## Create a State Version
 
@@ -171,7 +171,7 @@ curl \
             "hosted-state-upload-url": null,
             "hosted-json-state-upload-url": null,
             "status": "finalized",
-            "provisional": true,
+            "intermediate": true,
             "serial": 1
         },
         "links": {
@@ -246,7 +246,7 @@ curl \
                 "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
                 "hosted-json-state-upload-url": null,
                 "status": "finalized",
-                "provisional": false,
+                "intermediate": false,
                 "modules": {
                     "root": {
                         "null-resource": 1,
@@ -339,7 +339,7 @@ curl \
                 "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
                 "hosted-json-state-upload-url": null,
                 "status": "finalized",
-                "provisional": false,
+                "intermediate": false,
                 "modules": {
                     "root": {
                         "data.terraform-remote-state": 1
@@ -471,7 +471,7 @@ curl \
             "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
             "hosted-json-state-upload-url": null,
             "status": "finalized",
-            "provisional": false,
+            "intermediate": false,
             "modules": {
                 "root": {
                     "null-resource": 1,
@@ -597,7 +597,7 @@ curl \
             "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
             "hosted-json-state-upload-url": null,
             "status": "finalized",
-            "provisional": false,
+            "intermediate": false,
             "modules": {
                 "root": {
                     "null-resource": 1,

--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -1580,7 +1580,7 @@ $ curl \
 
 ## Unlock a workspace
 
-This endpoint unlocks a workspace. Unlocking a workspace sets the current state version to the latest finalized provisional state version. If provisional state versions are available, but Terraform Cloud has not yet finalized the latest provisional state version, the unlock will fail.
+This endpoint unlocks a workspace. Unlocking a workspace sets the current state version to the latest finalized intermediate state version. If intermediate state versions are available, but Terraform Cloud has not yet finalized the latest intermediate state version, the unlock will fail with a 503 response. For this particular error, it's recommended to retry the unlock operation for a short period of time until the platform finalizes the state version. If you must force-unlock a workspace under these conditions, ensure that state was saved successfully by inspecting the latest state version using the [State Version List API](/terraform/cloud-docs/api-docs/state-versions#list-state-versions-for-a-workspace)
 
 `POST /workspaces/:workspace_id/actions/unlock`
 
@@ -1747,8 +1747,6 @@ $ curl \
 ## Force Unlock a workspace
 
 This endpoint force unlocks a workspace. Only users with admin access are authorized to force unlock a workspace.
-
-For a force unlock, Terraform Cloud attempts to find the latest finalized provisional state version and sets it as the current state version for a workspace. Terraform Cloud may select an earlier provisional state version as the current version for a workspace. This only occurs if Terraform Cloud has not yet finalized the latest provisional state version. Terraform Cloud will not prevent a force unlock if no finalized provisional state versions are available.
 
 `POST /workspaces/:workspace_id/actions/force-unlock`
 

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -17,9 +17,9 @@ In [remote runs](/terraform/cloud-docs/run/remote-operations), Terraform Cloud a
 
 In local runs (available for workspaces whose execution mode setting is set to "local"), you can use a workspace's state by configuring the [CLI integration](/terraform/cli/cloud) and authenticating with a user token that has permission to read and write state versions for the relevant workspace. When using a Terraform configuration that references outputs from another workspace, the authentication token must also have permission to read state outputs for that workspace. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))
 
-During a Terraform Cloud run, Terraform incrementally creates provisional state versions and marks them as finalized once it uploads the state content.  When a workspace is unlocked, Terraform Cloud selects the latest finalized state version as the current state version for that workspace.
+During a Terraform Cloud run, Terraform incrementally creates intermediate state versions and marks them as finalized once it uploads the state content.
 
-If Terraform Cloud has not finalized the latest state version when a workspace is unlocked, the workspace may need to be force unlocked. In the event of a force unlock, Terraform Cloud selects the latest finalized state version. When Terraform Cloud selects the current state version, it discards all pending provisional state versions.
+When a workspace is unlocked, Terraform Cloud selects the latest state and sets it as the current state version, deletes all other intermediate state versions that were saved as recovery snapshots for the duration of the lock, and discards all pending intermediate state versions that were superseded by newer state versions.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 


### PR DESCRIPTION
### What

These changes are related to the functionality that was implemented to support Terraform state snapshots. This commit updates the `provisional` field name because it will rename to `intermediate.`

Jira ticket: https://hashicorp.atlassian.net/browse/TF-9592

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
