### PR TITLE
update info about the actions button and options start a run, which h…

### DIFF
--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -15,7 +15,7 @@ The default run mode of Terraform Cloud is to perform a plan and then apply it. 
 
 - **CLI:** Use `terraform apply` (without providing a saved plan file).
 - **API:** Create a run without specifying any options that select a different mode.
-- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Plan and apply (standard)** as the run type.
+- **UI:** From the workspace's overview page, click **+ New run**, and then choose **Plan and apply (standard)** as the run type.
 - **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a standard plan and apply when you add new commits to the selected branch of that repository.
 
 ## Destroy Mode
@@ -35,7 +35,7 @@ You can create speculative plans with a different Terraform version than the one
 Plan-only runs ignore the per-workspace run queue. Plan-only runs can proceed even if another run is in progress, can not become the workspace's current run, and do not block progress on a workspace's other runs.
 
 - **API:** Set the `plan-only` option to `true` and specify an available terraform version using the `terraform-version` field.
-- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Plan only** as the run type.
+- **UI:** From the workspace's overview page, click **+ New run**, and then choose **Plan only** as the run type.
 - **VCS:** When a workspace is connected to a VCS repository, Terraform Cloud automatically starts a speculative plan when someone opens a pull request (or merge request) against the selected branch of that repository.  The pull/merge request view in your VCS links to the speculative plan, and you can also find it in the workspace's run list.
 
 ## Saved Plans
@@ -62,7 +62,7 @@ To make such upgrades easier, empty apply runs will always auto-apply if their p
 ~> **Warning:** Terraform Cloud cannot guarantee that a plan in this mode will produce no changes. We recommend checking the plan for drift before proceeding to the apply stage.
 
 - **API:** Set the `allow-empty-apply` field to `true`.
-- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Allow empty apply** as the run type.
+- **UI:** From the workspace's overview page, click **+ New run**, and then choose **Allow empty apply** as the run type.
 
 ## Refresh-Only Mode
 
@@ -74,7 +74,7 @@ To make such upgrades easier, empty apply runs will always auto-apply if their p
 
 - **CLI:** Use `terraform plan -refresh-only` or `terraform apply -refresh-only`.
 - **API:** Use the `refresh-only` option.
-- **UI:** Open the workspace's **Actions** menu, select **Start new run**, and then choose **Refresh state** as the run type.
+- **UI:** From the workspace's overview page, click **+ New run**, and then choose **Refresh state** as the run type.
 
 ## Skipping Automatic State Refresh
 

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -77,7 +77,7 @@ Terraform Cloud has three main workflows for managing runs, and your chosen work
 - The [API-driven run workflow](/terraform/cloud-docs/run/api), which is more flexible but requires you to create some tooling.
 - The [CLI-driven run workflow](/terraform/cloud-docs/run/cli), which uses Terraform's standard CLI tools to execute runs in Terraform Cloud.
 
-You can initiate Terraform Cloud runs through the manual **Start new run** action in the workspace actions menu, VCS webhooks, the standard `terraform apply` command (with the CLI integration configured), and [the Runs API](/terraform/cloud-docs/api-docs/run) (or any tool that uses that API).
+You can initiate Terraform Cloud runs through the manual **+ New run** button at the top of workspace's page, VCS webhooks, the standard `terraform apply` command (with the CLI integration configured), and [the Runs API](/terraform/cloud-docs/api-docs/run) (or any tool that uses that API).
 
 ## Plans and Applies
 

--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -105,7 +105,7 @@ Speculative plans for pull requests use the contents of the head branch (the bra
 
 You can start a new [speculative plan][speculative plan] in the UI with the workspace's current configuration version and any Terraform version available to the organization.
 
-1. Click **Actions > Start New Run**. The **Start a new run** box appears.
+1. Click **+ New run**.
 1. Select **Plan only** as the run type.
 1. Select a version from the **Choose Terraform version** menu. The speculative plan will use this version without changing the workspace's settings.
 1. Click **Start run**.

--- a/website/docs/cloud-docs/workspaces/state.mdx
+++ b/website/docs/cloud-docs/workspaces/state.mdx
@@ -207,7 +207,7 @@ You can upgrade a workspace's state version to a new Terraform version without m
 
 1.  Run a [speculative plan](/terraform/cloud-docs/run/ui#testing-terraform-upgrades-with-speculative-plans) to test whether your configuration is compatible with the new Terraform version. You can run speculative plans with a Terraform version that is different than the one currently selected for the workspace.
 1.  Select **Settings > General** and select the desired new **Terraform Version**.
-1.  Click **Actions > Start new run** and then select **Allow empty apply** as the run type. An [empty apply](/terraform/cloud-docs/run/modes-and-options#allow-empty-apply) allows Terraform to apply a plan that produces no infrastructure changes. Terraform upgrades the state file version during the apply process.
+1.  Click **+ New run** and then select **Allow empty apply** as the run type. An [empty apply](/terraform/cloud-docs/run/modes-and-options#allow-empty-apply) allows Terraform to apply a plan that produces no infrastructure changes. Terraform upgrades the state file version during the apply process.
 
 -> **Note:** If the desired Terraform version is incompatible with a workspace's existing state version, the run fails and Terraform Cloud prompts you to run an apply with a compatible version first. Refer to the [Terraform upgrade guides](/terraform/language/upgrade-guides) for details about upgrading between versions.
 


### PR DESCRIPTION
…ave been replaced with the new run button

### What

Update the pages that mention "start new run" because this option is no longer available in the UI.

### Why
It has been replaced by the button "+ New run":

<img width="688" alt="Screenshot 2023-10-04 at 2 43 08 PM" src="https://github.com/hashicorp/terraform-docs-common/assets/21225410/7ebc6b5f-ed88-4e09-8925-5d9cd1fd969c">

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
