### PR TITLE
Clarify that project names cannot start or end with a space

### DIFF
--- a/website/docs/cloud-docs/api-docs/projects.mdx
+++ b/website/docs/cloud-docs/api-docs/projects.mdx
@@ -56,10 +56,10 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-| Key path               | Type   | Default | Description                                                                                                                                                             |
-|------------------------|--------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `data.type`            | string |         | Must be `"projects"`.                                                                                                                                                   |
-| `data.attributes.name` | string |         | The name of the project, which can only include letters, numbers, spaces, `-`, and `_`. It must be at least 3 characters long and no more than 36 characters long. |
+| Key path               | Type   | Default | Description                                                                                                                                                                                           |
+|------------------------|--------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `data.type`            | string |         | Must be `"projects"`.                                                                                                                                                                                 |
+| `data.attributes.name` | string |         | The name of the project. The name can contain letters, numbers, spaces, `-`, and `_`, but cannot start or end with spaces. It must be at least 3 characters long and no more than 36 characters long. |
 
 ### Sample Payload
 
@@ -119,10 +119,10 @@ These PATCH endpoints require a JSON object with the following properties as a r
 
 Properties without a default value are required.
 
-| Key path               | Type   | Default          | Description                                                                                                                                                                |
-|------------------------|--------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `data.type`            | string |                  | Must be `"projects"`.                                                                                                                                                      |
-| `data.attributes.name` | string | (previous value) | A new name for the project, which can only include letters, numbers, spaces, `-`, and `_`. It must be at least 3 characters long and no more than 36 characters long. |
+| Key path               | Type   | Default          | Description                                                                                                                                                                                              |
+|------------------------|--------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `data.type`            | string |                  | Must be `"projects"`.                                                                                                                                                                                    |
+| `data.attributes.name` | string | (previous value) | A new name for the project. The name can contain letters, numbers, spaces, `-`, and `_`, but cannot start or end with spaces. It must be at least 3 characters long and no more than 36 characters long. |
 
 ### Sample Payload
 


### PR DESCRIPTION
### What

Update the Project API docs to clarify that project names cannot start or end with a space.

### Why

This was noticed thanks to a PR that is adding project name validation to the TFE provider: https://github.com/hashicorp/terraform-provider-tfe/pull/1093

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
