### PR TITLE
TF-10033 Update the CLI-driven Run Workflow documentation

### DIFF
--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -105,7 +105,7 @@ Automatically created workspaces might not be immediately ready to use, so use T
 
 ### Implicit Project Creation
 
-If you configure the [`workspaces` block](/terraform/cli/cloud/settings#workspaces) to use a [project](/terraform/cli/cloud/settings#project) that does not yet exist in your organization, Terraform Cloud will create a new project with that name when you run `terraform init` and notify you in the command output.
+If you configure the [`workspaces` block](/terraform/cli/cloud/settings#workspaces) to use a [project](/terraform/cli/cloud/settings#project) that does not yet exist in your organization, Terraform Cloud will attempt to create a new project with that name when you run `terraform init` and notify you in the command output.
 
 If you specify both the `project` argument and [`TF_CLOUD_PROJECT`](/terraform/cli/cloud/settings#tf_cloud_project) environment variable, the `project` argument takes precedence.
 

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -105,9 +105,9 @@ Automatically created workspaces might not be immediately ready to use, so use T
 
 ### Implicit Project Creation
 
-If you configure the [`workspaces` block](/terraform/cli/cloud/settings#workspaces) to use a [project](/terraform/cli/cloud/settings#project) that doesn't yet exist in your organization, Terraform Cloud will create a new project with that name when you run `terraform init`. The output of `terraform init` will inform you when this happens.
+If you configure the [`workspaces` block](/terraform/cli/cloud/settings#workspaces) to use a [project](/terraform/cli/cloud/settings#project) that does not yet exist in your organization, Terraform Cloud will create a new project with that name when you run `terraform init` and notify you in the command output.
 
-If both the project argument and [`TF_CLOUD_PROJECT`](/terraform/cli/cloud/settings#tf_cloud_project) environment variable are specified, the `cloud` block configuration takes precedence.
+If you specify both the `project` argument and [`TF_CLOUD_PROJECT`](/terraform/cli/cloud/settings#tf_cloud_project) environment variable, the `project` argument takes precedence.
 
 ## Variables in CLI-Driven Runs
 

--- a/website/docs/cloud-docs/run/cli.mdx
+++ b/website/docs/cloud-docs/run/cli.mdx
@@ -103,6 +103,12 @@ Automatically created workspaces might not be immediately ready to use, so use T
 - New workspaces are not automatically connected to a VCS repository and do not have a working directory specified.
 - A new workspace's Terraform version defaults to the most recent release of Terraform at the time the workspace was created.
 
+### Implicit Project Creation
+
+If you configure the [`workspaces` block](/terraform/cli/cloud/settings#workspaces) to use a [project](/terraform/cli/cloud/settings#project) that doesn't yet exist in your organization, Terraform Cloud will create a new project with that name when you run `terraform init`. The output of `terraform init` will inform you when this happens.
+
+If both the project argument and [`TF_CLOUD_PROJECT`](/terraform/cli/cloud/settings#tf_cloud_project) environment variable are specified, the `cloud` block configuration takes precedence.
+
 ## Variables in CLI-Driven Runs
 
 Remote runs in Terraform Cloud use:


### PR DESCRIPTION
### What and Why
This PR updates the CLI-Driven Run Workflow documentation to include information on implicit project creation and precedence over the `TF_CLOUD_PROJECT` environment variable. 

See [Jira](https://hashicorp.atlassian.net/browse/TF-10033)

### Screenshots
<img width="1509" alt="Screenshot 2023-10-24 at 3 23 39 PM" src="https://github.com/hashicorp/terraform-docs-common/assets/30316203/5a489f5d-5d37-429e-9375-3855636b5d31">

----------

### Merge Checklist

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages. **N/A**
- [x] API documentation and the API Changelog have been updated. **N/A**
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate. **N/A**
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. **N/A**
- [x] New pages have metadata (page name and description) at the top. **N/A**
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. **N/A**
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. **N/A**
- [x] UI elements (button names, page names, etc.) are bolded. **N/A**
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
