### PR TITLE
Docs for dynamic credentials with Kubernetes

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -188,6 +188,7 @@
           { "title":  "AWS Configuration", "path":  "workspaces/dynamic-provider-credentials/aws-configuration" },
           { "title":  "GCP Configuration", "path":  "workspaces/dynamic-provider-credentials/gcp-configuration" },
           { "title":  "Azure Configuration", "path":  "workspaces/dynamic-provider-credentials/azure-configuration" },
+          { "title":  "Kubernetes Configuration", "path":  "workspaces/dynamic-provider-credentials/kubernetes-configuration" },
           { "title":  "Manually Generating Workload Identity Tokens", "path":  "workspaces/dynamic-provider-credentials/manual-generation" },
           { "title":  "Specifying Multiple Configurations", "path": "workspaces/dynamic-provider-credentials/specifying-multiple-configurations"},
           {

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/index.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/index.mdx
@@ -38,6 +38,7 @@ The process for each step is different for each cloud platform. Refer to the clo
 - [Amazon Web Services](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration)
 - [Google Cloud Platform](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration)
 - [Azure](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration)
+- [Kubernetes](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration)
 
 You can also use Vault to generate credentials for AWS, GCP, or Azure by setting up [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed), which take advantage of Vault's [secrets engines](/vault/docs/secrets) to generate temporary credentials.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -1,0 +1,198 @@
+---
+page_title: Dynamic Credentials with the Kubernetes and Helm Provider - Workspaces - Terraform Cloud
+description: >-
+  Use OpenID Connect to get short-term credentials for the Kubernetes and Helm Terraform providers in
+  your Terraform Cloud runs.
+---
+
+# Dynamic Credentials with the Kubernetes and Helm providers
+
+~> **Important:** If you are self-hosting [Terraform Cloud Agents](/terraform/cloud-docs/agents), ensure your agents use [v1.14.0](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+
+You can use Terraform Cloud’s native OpenID Connect integration with Kubernetes to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the Kubernetes and Helm providers in your Terraform Cloud runs. Configuring the integration requires the following steps:
+
+1. **[Configure Kubernetes](#configure-kubernetes):** Set up a trust configuration between Kubernetes and Terraform Cloud. Then, you must create Kubernetes role bindings for your Terraform Cloud identities.
+2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.
+3. **[Configure the Kubernetes or Helm provider](#configure-the-provider)** Set the required attributes on the provider block.
+
+Once you complete the setup, Terraform Cloud automatically authenticates to Kubernetes during each run. The Kubernetes and Helm providers' authentication is valid for the length of the plan or apply.
+
+## Configure Kubernetes
+
+You must enable and configure an OIDC identity provider in the Kubernetes API. The details of how to do this depend on the platform that is hosting your Kubernetes cluster. Of the major cloud providers with hosted Kubernetes offerings, AWS and GCP support configuring external OIDC providers in their Kubernetes services. Azure's AKS does not support this at the time of writing, but they might in the future.
+
+### Configure an OIDC Identity Provider
+
+AWS documentation describes setting up an EKS cluster for OIDC authentication here: [Authenticating users for your cluster from an OpenID Connect identity provider](https://docs.aws.amazon.com/eks/latest/userguide/authenticate-oidc-identity-provider.html).
+An example of how to translate those instructions to Terraform configuration is available here: https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/eks/trust
+
+GCP documentation describes setting up a GKE cluster for OIDC authentication here: [Use external identity providers to authenticate to GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/oidc). An example of how to translate those instructions to Terraform configuration is available here: https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/gke/trust
+
+The value for "issuer URL" should be set to the address of Terraform Cloud (e.g., https://app.terraform.io **without** a trailing slash) or the URL of your Terraform Enterprise instance. The value for "client ID" is your audience in OIDC terminology and it should match the value of the `TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE` environment variable in your workspace.
+
+The OIDC indentity will resolve authentication to the Kubernetes API, but it requires authorization in order to perform any concrete actions. You need to bind RBAC Roles to the OIDC identity in Kubernetes. You can use both "User" and "Group" subjects in your role bindings. For OIDC identities coming from TFC, the User value will have a prescribed format of `organization:<MY-ORG-NAME>:project:<MY-PROJECT-NAME>:workspace:<MY-WORKSPACE-NAME>:run_phase:<plan|apply>`. The Group value is extracted form the token claim configued for this purpose in your cluster OIDC configuration (see above for cloud provider specifics). The complete structure of the TFC token is described here: [Workload Identity](http://localhost:3000/terraform/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens)
+
+A RoleBinding for the TFC OIDC indentity will looks like this:
+```hcl
+resource "kubernetes_cluster_role_binding_v1" "oidc_role" {
+  metadata {
+    name = "odic-identity"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = var.rbac_group_cluster_role
+  }
+
+  // Option A - Bind RBAC roles to groups
+  //
+  // Groups are extracted from the token claim designated by 'rbac_group_oidc_claim'
+  //
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Group"
+    name      = var.tfc_organization_name
+  }
+
+  // Option B - Bind RBAC roles to user indentities
+  //
+  // Users are extracted from the 'sub' token claim.
+  // Plan and apply phases get assigned different users identities.
+  // For TFC tokens, the format of the user id is always the one described bellow.
+  //
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "User"
+    name      = "organization:${var.tfc_organization_name}:project:${var.tfc_project_name}:workspace:${var.tfc_workspace_name}:run_phase:plan"
+  }
+
+  subject {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "User"
+    name      = "organization:${var.tfc_organization_name}:project:${var.tfc_project_name}:workspace:${var.tfc_workspace_name}:run_phase:apply"
+  }
+}
+```
+
+-> **Note:** When using User subjects for the binding, be aware that Plan and Apply phases get assinged different indentities and they each need specific bindings. This way you can taylor the permissions for each phase. Planning usualy only requires read-only permissions while appling also requires write access.
+
+!> **Warning**: While you can assign the value of any of the claims in the identity token as a Group, you must keep in mind that only Organization names are unique, while names of Workspaces and Projects can be identical across different organizations. Using anything but `terraform_organization_name` and `terraform_full_workspace` as the groups claim can lead to leaking permissions. It is, however, safe to use any of the ID claims like `terraform_organization_id`, `terraform_project_id`, `terraform_workspace_id`.
+
+## Configure Terraform Cloud
+
+You’ll need to set some environment variables in your Terraform Cloud workspace in order to configure Terraform Cloud to authenticate with AWS using dynamic credentials. You can set these as workspace variables, or if you’d like to share one AWS role across multiple workspaces, you can use a variable set.
+
+### Required Environment Variables
+| Variable                | Value                                 | Notes                                                                                                                                                                                                                                                                                           |
+|-------------------------|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| TFC_KUBERNETES_PROVIDER_AUTH | `true` | Requires **v1.14.0** or later if self-managing agents. |
+| TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE | The audience of your choice | Should match the audience configured in your cluster OIDC configuration. Requires **v1.14.0** or later if self-managing agents. |
+
+You can also configure multiple identities within the same run, when using multiple provider aliases. For each configured alias, Terraform Cloud will issue a different identity token.
+
+To configure tokens for multiple aliases, append the alias name to the above variables, like this:
+
+| Variable                | Value                                 | Notes                                                                                                                                                                                                                                                                                           |
+|-------------------------|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| TFC_KUBERNETES_PROVIDER_AUTH_ALIAS1 | `true` | Requires **v1.14.0** or later if self-managing agents. |
+| TFC_KUBERNETES_PROVIDER_AUTH_ALIAS2 | `true` | Requires **v1.14.0** or later if self-managing agents. |
+| TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE_ALIAS1 | The audience of your choice | Should match the audience configured in your cluster OIDC configuration. Requires **v1.14.0** or later if self-managing agents. |
+| TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE_ALIAS2 | The audience of your choice | Should match the audience configured in your cluster OIDC configuration. Requires **v1.14.0** or later if self-managing agents. |
+
+
+## Configure the provider
+
+The Kubernetes and Helm providers share the same schema of configuration attributes for the provider block. The example below illustrates using the Kubernetes provider but the same applies to the Helm one.
+
+~> **Important:** Make sure that you’re not using any of the other arguments or methods mentioned in the [authentication](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication) section of the provider documentation as these settings may interfere with dynamic provider credentials. The only allowed attributes of the provider are `host` and `cluster_ca_certificate`.
+
+### Single provider instance
+
+Terraform Cloud will automatically set the KUBE_TOKEN environment variable, passing in the workload identity token. The provider picks up on the KUBE_TOKEN environment variable automatically.
+
+The provider needs to be configured with the URL of the API endpoint using the `host` attribute (or KUBE_HOST environment variable). In most cases, the `cluster_ca_certificate` (or KUBE_CLUSTER_CA_CERT_DATA environment variable) is also required.
+
+The provider configuration would look like this:
+```hcl
+provider "kubernetes" {
+  host                   = var.cluster-endpoint-url
+  cluster_ca_certificate = base64decode(var.cluster-endpoint-ca)
+}
+```
+
+### Multiple aliases
+
+When using multiple provider aliases, the KUBE_TOKEN environment variable will not be set. Instead, the tokens will be injected in a specifc Terraform variable with the following structure:
+```hcl
+variable "tfc_kubernetes_dynamic_credentials" {
+  description = "Object containing Kubernetes dynamic credentials configuration"
+  type = object({
+    default = object({
+      token_path = string
+    })
+    aliases = map(object({
+      token_path = string
+    }))
+  })
+}
+```
+~> **Important:** This exact definition for the variable needs to be included in your configuration. Terraform will set a value for it at runtime via the `TF_VAR_tfc_kubernetes_dynamic_credentials` environment variable.
+
+You then get the values of provider attributes for each alias provider block by indexing into the `var.tfc_kubernetes_dynamic_credentials.aliases` map using the alias name.
+
+The providers' configurations will then look like this:
+```hcl
+/* ----------------
+   Alias "ALIAS1"
+------------------*/
+
+provider "kubernetes" {
+  alias                  = "ALIAS1"
+  host                   = var.alias1-endpoint-url
+  cluster_ca_certificate = base64decode(var.alias1-cluster-ca)
+  token                  = file(var.tfc_kubernetes_dynamic_credentials.aliases["ALIAS1"].token_path)
+}
+
+resource "kubernetes_config_map" "some_stuff" {
+  provider = kubernetes.ALIAS1
+
+  metadata {
+    name = "test-1"
+  }
+  data = {
+    "foo" = "bar"
+  }
+}
+
+/* ----------------
+   Alias "ALIAS2"
+------------------*/
+
+provider "kubernetes" {
+  alias                  = "ALIAS2"
+  host                   = var.alias1-endpoint-url
+  cluster_ca_certificate = base64decode(var.alias1-cluster-ca)
+  token                  = file(var.tfc_kubernetes_dynamic_credentials.aliases["ALIAS2"].token_path)
+}
+
+resource "kubernetes_config_map" "some_other_stuff" {
+  provider = kubernetes.ALIAS2
+
+  metadata {
+    name = "test-2"
+  }
+  data = {
+    "foo" = "bar"
+  }
+}
+```
+
+The tfc_kubernetes_dynamic_credentials variable is also available to use for single provider configurations, instead of KUBE_TOKEN. In that case, the path of the token is available under `var.tfc_kubernetes_dynamic_credentials.default.token_path` and the provider block would look like this:
+```hcl
+provider "kubernetes" {
+  host                   = var.cluster-endpoint-url
+  cluster_ca_certificate = base64decode(var.cluster-endpoint-ca)
+  token                  = file(var.tfc_kubernetes_dynamic_credentials.default.token_path)
+}
+```

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -9,29 +9,33 @@ description: >-
 
 ~> **Important:** If you are self-hosting [Terraform Cloud Agents](/terraform/cloud-docs/agents), ensure your agents use [v1.14.0](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
 
-You can use Terraform Cloud’s native OpenID Connect integration with Kubernetes to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the Kubernetes and Helm providers in your Terraform Cloud runs. Configuring the integration requires the following steps:
+You can use Terraform Cloud’s native OpenID Connect integration with Kubernetes to use [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the Kubernetes and Helm providers in your Terraform Cloud runs. Configuring the integration requires the following steps:
 
-1. **[Configure Kubernetes](#configure-kubernetes):** Set up a trust configuration between Kubernetes and Terraform Cloud. Then, you must create Kubernetes role bindings for your Terraform Cloud identities.
-2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use Dynamic Credentials.
-3. **[Configure the Kubernetes or Helm provider](#configure-the-provider)** Set the required attributes on the provider block.
+1. **[Configure Kubernetes](#configure-kubernetes):** Set up a trust configuration between Kubernetes and Terraform Cloud. Next, create Kubernetes role bindings for your Terraform Cloud identities.
+2. **[Configure Terraform Cloud](#configure-terraform-cloud):** Add environment variables to the Terraform Cloud workspaces where you want to use dynamic credentials.
+3. **[Configure the Kubernetes or Helm provider](#configure-the-provider)**: Set the required attributes on the provider block.
 
-Once you complete the setup, Terraform Cloud automatically authenticates to Kubernetes during each run. The Kubernetes and Helm providers' authentication is valid for the length of the plan or apply.
+Once you complete the setup, Terraform Cloud automatically authenticates to Kubernetes during each run. The Kubernetes and Helm providers' authentication is valid for the length of a plan or apply operation.
 
 ## Configure Kubernetes
 
-You must enable and configure an OIDC identity provider in the Kubernetes API. The workflow to do this depend on the platform that is hosting your Kubernetes cluster. Dynamic provider credentials with Kubernetes is only supported in AWS and GCP.
+You must enable and configure an OIDC identity provider in the Kubernetes API. This workflow changes based on the platform hosting your Kubernetes cluster. Terraform Cloud only supports dynamic credentials with Kubernetes in AWS and GCP.
 
-### Configure an OIDC Identity Provider
+### Configure an OIDC identity provider
 
-AWS documentation describes setting up an EKS cluster for OIDC authentication here: [Authenticating users for your cluster from an OpenID Connect identity provider](https://docs.aws.amazon.com/eks/latest/userguide/authenticate-oidc-identity-provider.html). Refer to our [example Terraform configuration](https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/eks/trust).
+Refer to the AWS documentation for guidance on [setting up an EKS cluster for OIDC authentication](https://docs.aws.amazon.com/eks/latest/userguide/authenticate-oidc-identity-provider.html). You can also refer to our [example configuration](https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/eks/trust).
 
-GCP documentation describes setting up a GKE cluster for OIDC authentication here: [Use external identity providers to authenticate to GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/oidc). Refer to our [example Terraform configuration](https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/gke/trust).
+Refer to the GCP documentation for guidance on [setting up a GKE cluster for OIDC authentication](https://cloud.google.com/kubernetes-engine/docs/how-to/oidc). You can also refer to our [example configuration](https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/gke/trust).
 
-The value for "issuer URL" should be set to the address of Terraform Cloud (e.g., https://app.terraform.io **without** a trailing slash) or the URL of your Terraform Enterprise instance. The value for "client ID" is your audience in OIDC terminology and it should match the value of the `TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE` environment variable in your workspace.
+When inputting an "issuer URL", use the address of Terraform Cloud (`https://app.terraform.io` _without_ a trailing slash) or the URL of your Terraform Enterprise instance. The value of "client ID" is your audience in OIDC terminology, and it should match the value of the `TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE` environment variable in your workspace.
 
-The OIDC identity will resolve authentication to the Kubernetes API, but it requires authorization in order to interact with the Kubernetes API. You must bind RBAC roles to the OIDC identity in Kubernetes. You can use both "User" and "Group" subjects in your role bindings. For OIDC identities coming from TFC, the User value will have a format of `organization:<MY-ORG-NAME>:project:<MY-PROJECT-NAME>:workspace:<MY-WORKSPACE-NAME>:run_phase:<plan|apply>`. The Group value is extracted form the token claim configured for this purpose in your cluster OIDC configuration. The complete structure of the TFC token is described here: [Workload Identity](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens)
+The OIDC identity resolves authentication to the Kubernetes API, but it first requires authorization to interact with that API. So, you must bind RBAC roles to the OIDC identity in Kubernetes.
 
-A `RoleBinding` for the Terraform Cloud OIDC identity will looks like this:
+You can use both "User" and "Group" subjects in your role bindings. For OIDC identities coming from TFC, the "User" value is formatted like so: `organization:<MY-ORG-NAME>:project:<MY-PROJECT-NAME>:workspace:<MY-WORKSPACE-NAME>:run_phase:<plan|apply>`. 
+
+You can extract the "Group" value from the token claim you configured in your cluster OIDC configuration. For details on the structure of the TFC token, refer to [Workload Identity](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens).
+
+Below, we show an example of a `RoleBinding` for the Terraform Cloud OIDC identity.
 
 ```hcl
 resource "kubernetes_cluster_role_binding_v1" "oidc_role" {
@@ -75,13 +79,13 @@ resource "kubernetes_cluster_role_binding_v1" "oidc_role" {
 }
 ```
 
-When using User subjects for the binding, be aware that Plan and Apply phases get assigned different identities and they each need specific bindings. This way you can tailor the permissions for each phase. Plans usually only requires read-only permissions while applies also requires write access.
+If binding with "User" subjects, be aware that plan and apply phases are assigned different identities, each requiring specific bindings. Meaning you can tailor permissions for each Terraform operation. Planning operations usually require "read-only" permissions, while apply operations also require "write" access.
 
-!> **Warning**: you should always check, at minimum, the audience and the name of the organization in order to prevent unauthorized access from other Terraform Cloud organizations!
+!> **Warning**:  Always check, at minimum, the audience and the organization's name to prevent unauthorized access from other Terraform Cloud organizations.
 
 ## Configure Terraform Cloud
 
-You’ll need to set some environment variables in your Terraform Cloud workspace in order to configure Terraform Cloud to authenticate with AWS using dynamic credentials. You can set these as workspace variables, or if you’d like to share one AWS role across multiple workspaces, you can use a variable set.
+You must set certain environment variables in your Terraform Cloud workspace to configure Terraform Cloud to authenticate with Kubernetes and Helm using dynamic credentials. You can set these as workspace variables, or if you’d like to share one AWS role across multiple workspaces, you can use a variable set.
 
 ### Required Environment Variables
 | Variable                | Value                                 | Notes                                                                                                                                                                                                                                                                                           |
@@ -93,11 +97,11 @@ You’ll need to set some environment variables in your Terraform Cloud workspac
 
 The Kubernetes and Helm providers share the same schema of configuration attributes for the provider block. The example below illustrates using the Kubernetes provider but the same configuration applies to the Helm provider.
 
-Make sure that you are not using any of the other arguments or methods listed in the [authentication](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication) section of the provider documentation as these settings may interfere with dynamic provider credentials. The only allowed provider attributes `host` and `cluster_ca_certificate`.
+Make sure that you are not using any of the other arguments or methods listed in the [authentication](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication) section of the provider documentation as these settings may interfere with dynamic provider credentials. The only allowed provider attributes are `host` and `cluster_ca_certificate`.
 
 ### Single provider instance
 
-Terraform Cloud will automatically set the `KUBE_TOKEN` environment variable and include the workload identity token.
+Terraform Cloud automatically sets the `KUBE_TOKEN` environment variable and includes the workload identity token.
 
 The provider needs to be configured with the URL of the API endpoint using the `host` attribute (or `KUBE_HOST` environment variable). In most cases, the `cluster_ca_certificate` (or `KUBE_CLUSTER_CA_CERT_DATA` environment variable) is also required.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Dynamic Credentials with the Kubernetes and Helm providers
 
-~> **Important:** If you are self-hosting [Terraform Cloud Agents](/terraform/cloud-docs/agents), ensure your agents use [v1.14.0](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [Terraform Cloud Agents](/terraform/cloud-docs/agents), ensure your agents use [v1.13.1](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
 
 You can use Terraform Cloud’s native OpenID Connect integration with Kubernetes to use [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the Kubernetes and Helm providers in your Terraform Cloud runs. Configuring the integration requires the following steps:
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -19,20 +19,20 @@ Once you complete the setup, Terraform Cloud automatically authenticates to Kube
 
 ## Configure Kubernetes
 
-You must enable and configure an OIDC identity provider in the Kubernetes API. The details of how to do this depend on the platform that is hosting your Kubernetes cluster. Of the major cloud providers with hosted Kubernetes offerings, AWS and GCP support configuring external OIDC providers in their Kubernetes services. Azure's AKS does not support this at the time of writing, but they might in the future.
+You must enable and configure an OIDC identity provider in the Kubernetes API. The workflow to do this depend on the platform that is hosting your Kubernetes cluster. Dynamic provider credentials with Kubernetes is only supported in AWS and GCP.
 
 ### Configure an OIDC Identity Provider
 
-AWS documentation describes setting up an EKS cluster for OIDC authentication here: [Authenticating users for your cluster from an OpenID Connect identity provider](https://docs.aws.amazon.com/eks/latest/userguide/authenticate-oidc-identity-provider.html).
-An example of how to translate those instructions to Terraform configuration is available here: https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/eks/trust
+AWS documentation describes setting up an EKS cluster for OIDC authentication here: [Authenticating users for your cluster from an OpenID Connect identity provider](https://docs.aws.amazon.com/eks/latest/userguide/authenticate-oidc-identity-provider.html). Refer to our [example Terraform configuration](https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/eks/trust).
 
-GCP documentation describes setting up a GKE cluster for OIDC authentication here: [Use external identity providers to authenticate to GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/oidc). An example of how to translate those instructions to Terraform configuration is available here: https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/gke/trust
+GCP documentation describes setting up a GKE cluster for OIDC authentication here: [Use external identity providers to authenticate to GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/oidc). Refer to our [example Terraform configuration](https://github.com/hashicorp-education/learn-terraform-dynamic-credentials/tree/main/gke/trust).
 
 The value for "issuer URL" should be set to the address of Terraform Cloud (e.g., https://app.terraform.io **without** a trailing slash) or the URL of your Terraform Enterprise instance. The value for "client ID" is your audience in OIDC terminology and it should match the value of the `TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE` environment variable in your workspace.
 
-The OIDC indentity will resolve authentication to the Kubernetes API, but it requires authorization in order to perform any concrete actions. You need to bind RBAC Roles to the OIDC identity in Kubernetes. You can use both "User" and "Group" subjects in your role bindings. For OIDC identities coming from TFC, the User value will have a prescribed format of `organization:<MY-ORG-NAME>:project:<MY-PROJECT-NAME>:workspace:<MY-WORKSPACE-NAME>:run_phase:<plan|apply>`. The Group value is extracted form the token claim configued for this purpose in your cluster OIDC configuration (see above for cloud provider specifics). The complete structure of the TFC token is described here: [Workload Identity](http://localhost:3000/terraform/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens)
+The OIDC identity will resolve authentication to the Kubernetes API, but it requires authorization in order to interact with the Kubernetes API. You must bind RBAC roles to the OIDC identity in Kubernetes. You can use both "User" and "Group" subjects in your role bindings. For OIDC identities coming from TFC, the User value will have a format of `organization:<MY-ORG-NAME>:project:<MY-PROJECT-NAME>:workspace:<MY-WORKSPACE-NAME>:run_phase:<plan|apply>`. The Group value is extracted form the token claim configured for this purpose in your cluster OIDC configuration. The complete structure of the TFC token is described here: [Workload Identity](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens)
 
-A RoleBinding for the TFC OIDC indentity will looks like this:
+A `RoleBinding` for the Terraform Cloud OIDC identity will looks like this:
+
 ```hcl
 resource "kubernetes_cluster_role_binding_v1" "oidc_role" {
   metadata {
@@ -75,9 +75,9 @@ resource "kubernetes_cluster_role_binding_v1" "oidc_role" {
 }
 ```
 
--> **Note:** When using User subjects for the binding, be aware that Plan and Apply phases get assinged different indentities and they each need specific bindings. This way you can taylor the permissions for each phase. Planning usualy only requires read-only permissions while appling also requires write access.
+When using User subjects for the binding, be aware that Plan and Apply phases get assigned different identities and they each need specific bindings. This way you can tailor the permissions for each phase. Plans usually only requires read-only permissions while applies also requires write access.
 
-!> **Warning**: While you can assign the value of any of the claims in the identity token as a Group, you must keep in mind that only Organization names are unique, while names of Workspaces and Projects can be identical across different organizations. Using anything but `terraform_organization_name` and `terraform_full_workspace` as the groups claim can lead to leaking permissions. It is, however, safe to use any of the ID claims like `terraform_organization_id`, `terraform_project_id`, `terraform_workspace_id`.
+!> **Warning**: you should always check, at minimum, the audience and the name of the organization in order to prevent unauthorized access from other Terraform Cloud organizations!
 
 ## Configure Terraform Cloud
 
@@ -86,34 +86,23 @@ You’ll need to set some environment variables in your Terraform Cloud workspac
 ### Required Environment Variables
 | Variable                | Value                                 | Notes                                                                                                                                                                                                                                                                                           |
 |-------------------------|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| TFC_KUBERNETES_PROVIDER_AUTH | `true` | Requires **v1.14.0** or later if self-managing agents. |
-| TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE | The audience of your choice | Should match the audience configured in your cluster OIDC configuration. Requires **v1.14.0** or later if self-managing agents. |
-
-You can also configure multiple identities within the same run, when using multiple provider aliases. For each configured alias, Terraform Cloud will issue a different identity token.
-
-To configure tokens for multiple aliases, append the alias name to the above variables, like this:
-
-| Variable                | Value                                 | Notes                                                                                                                                                                                                                                                                                           |
-|-------------------------|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| TFC_KUBERNETES_PROVIDER_AUTH_ALIAS1 | `true` | Requires **v1.14.0** or later if self-managing agents. |
-| TFC_KUBERNETES_PROVIDER_AUTH_ALIAS2 | `true` | Requires **v1.14.0** or later if self-managing agents. |
-| TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE_ALIAS1 | The audience of your choice | Should match the audience configured in your cluster OIDC configuration. Requires **v1.14.0** or later if self-managing agents. |
-| TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE_ALIAS2 | The audience of your choice | Should match the audience configured in your cluster OIDC configuration. Requires **v1.14.0** or later if self-managing agents. |
-
+| TFC_KUBERNETES_PROVIDER_AUTH | `true` | Requires **v1.14.0** or later if self-managing agents. Must be present and set to `true`, or Terraform Cloud will not attempt to authenticate to Kubernetes. |
+| TFC_KUBERNETES_WORKLOAD_IDENTITY_AUDIENCE | The audience name in your cluster's OIDC configuration, such as `kubernetes`. | Requires **v1.14.0** or later if self-managing agents. |
 
 ## Configure the provider
 
-The Kubernetes and Helm providers share the same schema of configuration attributes for the provider block. The example below illustrates using the Kubernetes provider but the same applies to the Helm one.
+The Kubernetes and Helm providers share the same schema of configuration attributes for the provider block. The example below illustrates using the Kubernetes provider but the same configuration applies to the Helm provider.
 
-~> **Important:** Make sure that you’re not using any of the other arguments or methods mentioned in the [authentication](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication) section of the provider documentation as these settings may interfere with dynamic provider credentials. The only allowed attributes of the provider are `host` and `cluster_ca_certificate`.
+Make sure that you are not using any of the other arguments or methods listed in the [authentication](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#authentication) section of the provider documentation as these settings may interfere with dynamic provider credentials. The only allowed provider attributes `host` and `cluster_ca_certificate`.
 
 ### Single provider instance
 
-Terraform Cloud will automatically set the KUBE_TOKEN environment variable, passing in the workload identity token. The provider picks up on the KUBE_TOKEN environment variable automatically.
+Terraform Cloud will automatically set the `KUBE_TOKEN` environment variable and include the workload identity token.
 
-The provider needs to be configured with the URL of the API endpoint using the `host` attribute (or KUBE_HOST environment variable). In most cases, the `cluster_ca_certificate` (or KUBE_CLUSTER_CA_CERT_DATA environment variable) is also required.
+The provider needs to be configured with the URL of the API endpoint using the `host` attribute (or `KUBE_HOST` environment variable). In most cases, the `cluster_ca_certificate` (or `KUBE_CLUSTER_CA_CERT_DATA` environment variable) is also required.
 
-The provider configuration would look like this:
+#### Example Usage
+
 ```hcl
 provider "kubernetes" {
   host                   = var.cluster-endpoint-url
@@ -123,7 +112,14 @@ provider "kubernetes" {
 
 ### Multiple aliases
 
-When using multiple provider aliases, the KUBE_TOKEN environment variable will not be set. Instead, the tokens will be injected in a specifc Terraform variable with the following structure:
+You can add additional configurations to handle multiple distinct Kubernetes clusters, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace.
+
+For more details, see [Specifying Multiple Configurations](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations).
+
+#### Required Terraform Variable
+
+To use additional configurations, add the following code to your Terraform configuration. This lets Terraform Cloud supply variable values that you can then use to map authentication and configuration details to the correct provider blocks.
+
 ```hcl
 variable "tfc_kubernetes_dynamic_credentials" {
   description = "Object containing Kubernetes dynamic credentials configuration"
@@ -137,16 +133,10 @@ variable "tfc_kubernetes_dynamic_credentials" {
   })
 }
 ```
-~> **Important:** This exact definition for the variable needs to be included in your configuration. Terraform will set a value for it at runtime via the `TF_VAR_tfc_kubernetes_dynamic_credentials` environment variable.
 
-You then get the values of provider attributes for each alias provider block by indexing into the `var.tfc_kubernetes_dynamic_credentials.aliases` map using the alias name.
+#### Example Usage
 
-The providers' configurations will then look like this:
 ```hcl
-/* ----------------
-   Alias "ALIAS1"
-------------------*/
-
 provider "kubernetes" {
   alias                  = "ALIAS1"
   host                   = var.alias1-endpoint-url
@@ -154,41 +144,16 @@ provider "kubernetes" {
   token                  = file(var.tfc_kubernetes_dynamic_credentials.aliases["ALIAS1"].token_path)
 }
 
-resource "kubernetes_config_map" "some_stuff" {
-  provider = kubernetes.ALIAS1
-
-  metadata {
-    name = "test-1"
-  }
-  data = {
-    "foo" = "bar"
-  }
-}
-
-/* ----------------
-   Alias "ALIAS2"
-------------------*/
-
 provider "kubernetes" {
   alias                  = "ALIAS2"
   host                   = var.alias1-endpoint-url
   cluster_ca_certificate = base64decode(var.alias1-cluster-ca)
   token                  = file(var.tfc_kubernetes_dynamic_credentials.aliases["ALIAS2"].token_path)
 }
-
-resource "kubernetes_config_map" "some_other_stuff" {
-  provider = kubernetes.ALIAS2
-
-  metadata {
-    name = "test-2"
-  }
-  data = {
-    "foo" = "bar"
-  }
-}
 ```
 
-The tfc_kubernetes_dynamic_credentials variable is also available to use for single provider configurations, instead of KUBE_TOKEN. In that case, the path of the token is available under `var.tfc_kubernetes_dynamic_credentials.default.token_path` and the provider block would look like this:
+The `tfc_kubernetes_dynamic_credentials` variable is also available to use for single provider configurations, instead of the `KUBE_TOKEN` environment variable.
+
 ```hcl
 provider "kubernetes" {
   host                   = var.cluster-endpoint-url

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -59,7 +59,7 @@ resource "kubernetes_cluster_role_binding_v1" "oidc_role" {
     name      = var.tfc_organization_name
   }
 
-  // Option B - Bind RBAC roles to user indentities
+  // Option B - Bind RBAC roles to user identities
   //
   // Users are extracted from the 'sub' token claim.
   // Plan and apply phases get assigned different users identities.
@@ -85,7 +85,7 @@ If binding with "User" subjects, be aware that plan and apply phases are assigne
 
 ## Configure Terraform Cloud
 
-You must set certain environment variables in your Terraform Cloud workspace to configure Terraform Cloud to authenticate with Kubernetes and Helm using dynamic credentials. You can set these as workspace variables, or if you’d like to share one AWS role across multiple workspaces, you can use a variable set.
+You must set certain environment variables in your Terraform Cloud workspace to configure Terraform Cloud to authenticate with Kubernetes or Helm using dynamic credentials. You can set these as workspace variables, or if you’d like to share one Kubernetes role across multiple workspaces, you can use a variable set.
 
 ### Required Environment Variables
 | Variable                | Value                                 | Notes                                                                                                                                                                                                                                                                                           |


### PR DESCRIPTION
### What

Adding a new page describing how to use dynamic credentials with Kubernetes.

### Why

TFC is about to get support for dynamic credentials with Kubernetes.

https://github.com/hashicorp/atlas/pull/17256

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [X] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [X] Pages with related content are updated and link to this content when appropriate.
- [X] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [X] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [X] The Vercel website preview successfully deployed.

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
