### PR TITLE
run task HMAC key example

### DIFF
--- a/website/docs/cloud-docs/integrations/run-tasks/index.mdx
+++ b/website/docs/cloud-docs/integrations/run-tasks/index.mdx
@@ -94,8 +94,15 @@ When creating your run task, you can supply an HMAC key which Terraform Cloud wi
 
 The signature is a sha512 sum of the webhook body using the provided HMAC key. The generation of the signature depends on your implementation, however an example of how to generate a signature in bash is provided below.
 
-```bash
-$ echo -n $WEBHOOK_BODY | openssl dgst -sha512 -hmac "$HMAC_KEY"
+payload.json
+```
+{"payload_version":1,"access_token":"aaaaaaaaaaaa.atlasv1.111111111111111111111111111aaaaaaaaaaaaaaaaaaa","stage":"pre_plan","is_speculative":true,"task_result_id":"taskrs-ogc2cody6o1ax6Wv","task_result_enforcement_level":"advisory","task_result_callback_url":"https://app.terraform.io/api/v2/task-results/af82c0ce-b0e1-4deb-a420-e6c55sdfefe7b4/callback","run_app_url":"https://app.terraform.io/app/hashicorp/example/runs/run-8GcqDzaLWZy4yZpe","run_id":"run-8GcqDzaLWZy4yZpe","run_message":"Triggered via UI","run_created_at":"2023-11-03T07:56:59.950Z","run_created_by":"hashicorp","workspace_id":"ws-vXoTsdm2Yj8MUeKtU","workspace_name":"example","workspace_app_url":"https://app.terraform.io/app/hashicorp/example","organization_name":"hashicorp","vcs_repo_url":"https://github.com/hashicorp/example","vcs_branch":"main","vcs_pull_request_url":null,"vcs_commit_url":"https://github.com/hashicorp/example/commit/9c1e0a44c2eba015c27cf87cbdda1aff5d9ce4e0","configuration_version_id":"cv-6dzKfWPVz9yY4wzo","configuration_version_download_url":"https://app.terraform.io/api/v2/configuration-versions/cv-6dzKfWPVz9yY4wzo/download","workspace_working_directory":"","capabilities":{"outcomes":true}}
+```
+- This has "double quotes"
+- No spaces
+
+```
+$ echo -n $(cat payload.json)  | openssl dgst -sha512 -hmac "$HMAC_KEY"
 ```
 
 ## HCP Packer Run Task


### PR DESCRIPTION
### What
https://github.com/hashicorp/terraform-docs-common/tree/main/website/docs/cloud-docs/integrations/run-tasks
/index.mdx

### Why
The example didn't work properly. Me and a customer made the same error. Once we had it working and an example payload it was all a lot easier. 

### Screenshots

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ (N/A] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ (N/A] Description links to related pull requests or issues, if any.

#### Content
- [(N/A ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [(N/A ] API documentation and the API Changelog have been updated. 
- [(N/A ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [(N/A ] Pages with related content are updated and link to this content when appropriate.
- [(N/A ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [(N/A ] New pages have metadata (page name and description) at the top.
- [(N/A ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [(N/A ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
