### PR TITLE
Add Data retention to TFC docs

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -12,6 +12,11 @@ Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 ## 2023-11-17
 * Add `authenticated-resource` relationship to the [Account API](/terraform/cloud-docs/api-docs/account)
 
+## 2023-11-15
+
+- Introduce configurable data retention policies at the [organization](/terraform/enterprise/users-teams-organizations/organizations#data-retention-policies) and [workspace](/terraform/enterprise/workspaces/settings/deletion#data-retention-policies) levels.
+- Add data retention policy documentation to [State Versions](/terraform/enterprise/api-docs/state-versions), [Configuration Versions](/terraform/enterprise/api-docs/configuration-versions), [Organizations](/terraform/enterprise/users-teams-organizations/organizations#destruction-and-deletion), and [Workspaces](/terraform/enterprise/workspaces/settings/deletion#data-retention-policies).
+
 ## 2023-11-07
 * Add `auto_destroy_activity_duration` to the [Workspaces API](/terraform/cloud-docs/api-docs/workspaces), which allows Terraform Cloud to schedule auto-destroy runs [based on workspace inactivity](/terraform/cloud-docs/workspaces/settings/deletion#automatically-destroy).
 

--- a/website/docs/cloud-docs/api-docs/configuration-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/configuration-versions.mdx
@@ -63,6 +63,8 @@ A configuration version created through the API or CLI can only be used in runs 
 | `uploaded`             | The configuration version is fully processed and can be used in runs.                                                                                                                                                                                                                                    |
 | `archived`             | All immediate runs are complete and Terraform Cloud has discarded the files associated with this configuration version. If the configuration version was created through a connected VCS repository, it can still be used in new runs. In those cases, Terraform Cloud will re-fetch the files from VCS. |
 | `errored`              | Terraform Cloud could not process this configuration version, and it cannot be used to create new runs. You can try again by pushing a new commit to your linked VCS repository or creating a new configuration version with the API or CLI.                                                             |
+| `backing_data_soft_deleted`  | <EnterpriseAlert inline /> Indicates that the configuration version's backing data is marked for garbage collection. If no action is taken, the backing data associated with this configuration version is permanently deleted after a set number of days. You can restore the backing data associated with the configuration version before it is permanently deleted. |                                                                                                              |
+| `backing_data_permanently_deleted`  | <EnterpriseAlert inline /> The configuration version's backing data has been permanently deleted and can no longer be restored.                                                                                                                                                                          |
 
 ## List Configuration Versions
 
@@ -424,6 +426,126 @@ curl \
   --location \
   https://app.terraform.io/api/v2/configuration-versions/cv-C6Py6WQ1cUXQX2x2/download \
   > export.tar.gz
+```
+
+## Mark a Configuration Version for Garbage Collection
+
+<EnterpriseAlert>
+This endpoint is exclusive to Terraform Enterprise, and not available in Terraform Cloud. <a href="https://developer.hashicorp.com/terraform/enterprise">Learn more about Terraform Enterprise</a>.
+</EnterpriseAlert>
+
+`POST /api/v2/configuration-versions/:configuration-id/actions/soft_delete_backing_data`
+
+| Parameter                   | Description                                    |
+| --------------------------- | ---------------------------------------------- |
+| `:configuration-id`  | The ID of the configuration version to soft delete. |
+
+This endpoint directs Terraform Enterprise to _soft delete_ the backing files associated with the configuration version. Soft deletion refers to marking the configuration version for garbage collection. Terraform permanently deletes configuration versions marked for soft deletion after a set number of days unless the configuration version is restored. Once a configuration version is soft deleted, any attempts to read the configuration version will fail. Refer to [Configuration Version States](#configuration-version-states) for information about all data states.
+
+This endpoint can only soft delete configuration versions that meet the following criteria:
+
+- Were created using the API or CLI,
+- are in an [`uploaded` state](#configuration-version-states),
+- and are not the current configuration version.
+
+Otherwise, the endpoint returns an error.
+
+| Status  | Response                  | Reason(s)                                                                                                                                     |
+| ------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [200][] | none                      | Terraform successfully marked the data for garbage collection.                                                                                               |
+| [400][] | [JSON API error object][] | Terraform failed to transition the state to `backing_data_soft_deleted`.                                                                          |
+| [404][] | [JSON API error object][] | Terraform did not find the configuration version or the user is not authorized to modify the configuration version state.                                                                                     |
+
+### Request Body
+
+This POST endpoint does not take a request body.
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  https://app.terraform.io/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7/actions/soft_delete_backing_data
+```
+
+## Restore Configuration Versions Marked for Garbage Collection
+
+<EnterpriseAlert>
+This endpoint is exclusive to Terraform Enterprise, and not available in Terraform Cloud. <a href="https://developer.hashicorp.com/terraform/enterprise">Learn more about Terraform Enterprise</a>.
+</EnterpriseAlert>
+
+`POST /api/v2/configuration-versions/:configuration-id/actions/restore_backing_data`
+
+| Parameter                   | Description                                    |
+| --------------------------- | ---------------------------------------------- |
+| `:configuration-id`  | The ID of the configuration version to restore back to its uploaded state if applicable. |
+
+This endpoint directs Terraform Enterprise to restore backing files associated with this configuration version. This endpoint can only restore delete configuration versions that meet the following criteria:
+
+- are not in a [`backing_data_permanently_deleted` state](#configuration-version-states).
+
+Otherwise, the endpoint returns an error. Terraform restores applicable configuration versions back to their `uploaded` state.
+
+| Status  | Response                  | Reason(s)                                                                                                                                     |
+| ------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [200][] | none                      | Terraform successfully initiated the restore process.                                                                                         |
+| [400][] | [JSON API error object][] | Terraform failed to transition the state to `uploaded`.                                                                                       |
+| [404][] | [JSON API error object][] | Terraform did not find the configuration version or the user is not authorized to modify the configuration version state.                        |
+
+### Request Body
+
+This POST endpoint does not take a request body.
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  https://app.terraform.io/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7/actions/restore_backing_data
+```
+
+## Permanently Delete a Configuration Version
+
+<EnterpriseAlert>
+This endpoint is exclusive to Terraform Enterprise, and not available in Terraform Cloud. <a href="https://developer.hashicorp.com/terraform/enterprise">Learn more about Terraform Enterprise</a>.
+</EnterpriseAlert>
+
+`POST /api/v2/configuration-versions/:configuration-id/actions/permanently_delete_backing_data`
+
+| Parameter                   | Description                                    |
+| --------------------------- | ---------------------------------------------- |
+| `:configuration-id`  | The ID of the configuration version to permanently delete. |
+
+This endpoint directs Terraform Enterprise to permanently delete backing files associated with this configuration version. This endpoint can only permanently delete configuration versions that meet the following criteria:
+
+- Were created using the API or CLI,
+- are in a [`backing_data_soft_deleted` state](#configuration-version-states),
+- and are not the current configuration version.
+
+Otherwise, the endpoint returns an error.
+
+| Status  | Response                  | Reason(s)                                                                                                                                     |
+| ------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| [200][] | none                      | Terraform successfully deleted the data permanently.                                                                                          |
+| [400][] | [JSON API error object][] | Terraform failed to transition the state to `backing_data_permanently_deleted`.                                                               |
+| [404][] | [JSON API error object][] | Terraform did not find the configuration version or the user is not authorized to modify the configuration version state.                        |
+
+### Request Body
+
+This POST endpoint does not take a request body.
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  https://app.terraform.io/api/v2/configuration-versions/cv-ntv3HbhJqvFzamy7/actions/permanently_delete_backing_data
 ```
 
 ## Available Related Resources

--- a/website/docs/cloud-docs/api-docs/state-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/state-versions.mdx
@@ -65,11 +65,14 @@ Attribute                        | Description
 ### State Version Status
 The state version status is found in `data.attributes.status`, and you can reference the following list of possible statuses.
 A state version created through the API or CLI will only be listed in the UI if it is has a `finalized` status.
-| State        | Description                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `pending`    | The initial status of a state version after it has been created without encoding the state data within the request. Pending state versions do not contain state data and will not appear in the UI. The workspace cannot be unlocked normally until the latest state version has been finalized.
-| `finalized`  | The state version has been uploaded successfully to Terraform Cloud or if the state version was created with a valid `state` attribute.                                                                                                                                                                                                              |
-| `discarded`  | The state version has been discarded because it was superseded by a newer state version before it could be uploaded. |
+
+| State | Description |
+| --- | --- |
+| `pending` | Indicates that a state version has been created but the state data is not encoded within the request. Pending state versions do not contain state data and do not appear in the UI. You cannot unlock the workspace until the latest state version is finalized. |
+| `finalized` | Indicates that the state version has been successfully uploaded to Terraform Cloud or that the state version was created with a valid `state` attribute. |
+| `discarded`  | The state version was discarded because it was superseded by a newer state version before it could be uploaded. |
+| `backing_data_soft_deleted`  | <EnterpriseAlert inline /> The backing files associated with this state version are marked for garbage collection. Terraform permanently deletes backing files associated with this state version after a set number of days, but you can restore the backing data associated with it before it is permanently deleted. |
+| `backing_data_permanently_deleted`  | <EnterpriseAlert inline /> The backing files associated with this state version have been permanently deleted and can no longer be restored. |
 
 ## Create a State Version
 
@@ -806,6 +809,410 @@ curl \
         },
         "links": {
             "self": "/api/v2/state-versions/sv-DmoXecHePnNznaA4"
+        }
+    }
+}
+```
+
+## Mark a State Version for Garbage Collection
+
+<EnterpriseAlert>
+This endpoint is exclusive to Terraform Enterprise, and not available in Terraform Cloud. <a href="https://developer.hashicorp.com/terraform/enterprise">Learn more about Terraform Enterprise</a>.
+</EnterpriseAlert>
+
+`POST /api/v2/state-versions/:state_version_id/actions/soft_delete_backing_data`
+
+This endpoint directs Terraform Enterprise to _soft delete_ the backing files associated with this state version. Soft deletion marks the state version for garbage collection. Terraform permanently deletes state versions after a set number of days unless the state version is restored. Once a state version is soft deleted, any attempts to read the state version will fail. Refer to [State Version Status](#state-version-status) for information about all data states.
+
+This endpoint can only soft delete state versions that are in an [`finalized` state](#state-version-status) and are not the current state version. Otherwise, calling this endpoint results in an error.
+
+You must have organization owner permissions to soft delete state versions. Refer to [Permissions](/terraform/enterprise/users-teams-organizations/permissions) for additional information about permissions.
+
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
+
+| Parameter           | Description                          |
+|---------------------|--------------------------------------|
+| `:state_version_id` | The ID of the state version to mark for garbage collection. |
+
+| Status  | Response                  | Reason                                                                                                        |
+|---------|---------------------------|---------------------------------------------------------------------------------------------------------------|
+| [200][] | [JSON API document][]     | Terraform successfully marked the data for garbage collection.                                                |
+| [400][] | [JSON API error object][] | Terraform failed to transition the state to `backing_data_soft_deleted`.                                      |
+| [404][] | [JSON API error object][] | Terraform did not find the state version or the user is not authorized to modify the state version.            |
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  https://app.terraform.io/api/v2/state-versions/sv-ntv3HbhJqvFzamy7/actions/soft_delete_backing_data
+```
+
+### Sample Response
+
+```json
+{
+    "data": {
+        "id": "sv-g4rqST72reoHMM5a",
+        "type": "state-versions",
+        "attributes": {
+            "created-at": "2021-06-08T01:22:03.794Z",
+            "size": 940,
+            "hosted-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-state-upload-url": null,
+            "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-json-state-upload-url": null,
+            "status": "backing_data_soft_deleted",
+            "intermediate": false,
+            "modules": {
+                "root": {
+                    "null-resource": 1,
+                    "data.terraform-remote-state": 1
+                }
+            },
+            "providers": {
+                "provider[\"terraform.io/builtin/terraform\"]": {
+                    "data.terraform-remote-state": 1
+                },
+                "provider[\"registry.terraform.io/hashicorp/null\"]": {
+                    "null-resource": 1
+                }
+            },
+            "resources": [
+                {
+                    "name": "other_username",
+                    "type": "data.terraform_remote_state",
+                    "count": 1,
+                    "module": "root",
+                    "provider": "provider[\"terraform.io/builtin/terraform\"]"
+                },
+                {
+                    "name": "random",
+                    "type": "null_resource",
+                    "count": 1,
+                    "module": "root",
+                    "provider": "provider[\"registry.terraform.io/hashicorp/null\"]"
+                }
+            ],
+            "resources-processed": true,
+            "serial": 9,
+            "state-version": 4,
+            "terraform-version": "0.15.4",
+            "vcs-commit-url": "https://gitlab.com/my-organization/terraform-test/-/commit/abcdef12345",
+            "vcs-commit-sha": "abcdef12345"
+        },
+        "relationships": {
+            "run": {
+                "data": {
+                    "id": "run-YfmFLWpgTv31VZsP",
+                    "type": "runs"
+                }
+            },
+            "created-by": {
+                "data": {
+                    "id": "user-onZs69ThPZjBK2wo",
+                    "type": "users"
+                },
+                "links": {
+                    "self": "/api/v2/users/user-onZs69ThPZjBK2wo",
+                    "related": "/api/v2/runs/run-YfmFLWpgTv31VZsP/created-by"
+                }
+            },
+            "workspace": {
+                "data": {
+                    "id": "ws-noZcaGXsac6aZSJR",
+                    "type": "workspaces"
+                }
+            },
+            "outputs": {
+                "data": [
+                    {
+                        "id": "wsout-V22qbeM92xb5mw9n",
+                        "type": "state-version-outputs"
+                    },
+                    {
+                        "id": "wsout-ymkuRnrNFeU5wGpV",
+                        "type": "state-version-outputs"
+                    },
+                    {
+                        "id": "wsout-v82BjkZnFEcscipg",
+                        "type": "state-version-outputs"
+                    }
+                ]
+            }
+        },
+        "links": {
+            "self": "/api/v2/state-versions/sv-g4rqST72reoHMM5a"
+        }
+    }
+}
+```
+
+## Restore a State Version Marked for Garbage Collection
+
+<EnterpriseAlert>
+This endpoint is exclusive to Terraform Enterprise, and not available in Terraform Cloud. <a href="https://developer.hashicorp.com/terraform/enterprise">Learn more about Terraform Enterprise</a>.
+</EnterpriseAlert>
+
+`POST /api/v2/state-versions/:state_version_id/actions/restore_backing_data`
+
+This endpoint directs Terraform Enterprise to restore backing files associated with this state version. This endpoint can only restore state versions that are not in a [`backing_data_permanently_deleted` state](#state-version-status). Terraform restores applicable state versions back to their `finalized` state. Otherwise, calling this endpoint results in an error.
+
+You must have organization owner permissions to restore state versions. Refer to [Permissions](/terraform/enterprise/users-teams-organizations/permissions) for additional information about permissions.
+
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
+
+| Parameter           | Description                          |
+|---------------------|--------------------------------------|
+| `:state_version_id` | The ID of the state version to restore. |
+
+| Status  | Response                  | Reason                                                                                                        |
+|---------|---------------------------|---------------------------------------------------------------------------------------------------------------|
+| [200][] | [JSON API document][]     | Terraform successfully initiated the restore process.                                                                   |
+| [400][] | [JSON API error object][] | Terraform failed to transition the state to `finalized`.                                                           |
+| [404][] | [JSON API error object][] | Terraform did not find the state version or the user is not authorized to modify the state version.                                           |
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  https://app.terraform.io/api/v2/state-versions/sv-ntv3HbhJqvFzamy7/actions/restore_backing_data
+```
+
+### Sample Response
+
+```json
+{
+    "data": {
+        "id": "sv-g4rqST72reoHMM5a",
+        "type": "state-versions",
+        "attributes": {
+            "created-at": "2021-06-08T01:22:03.794Z",
+            "size": 940,
+            "hosted-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-state-upload-url": null,
+            "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-json-state-upload-url": null,
+            "status": "uploaded",
+            "intermediate": false,
+            "modules": {
+                "root": {
+                    "null-resource": 1,
+                    "data.terraform-remote-state": 1
+                }
+            },
+            "providers": {
+                "provider[\"terraform.io/builtin/terraform\"]": {
+                    "data.terraform-remote-state": 1
+                },
+                "provider[\"registry.terraform.io/hashicorp/null\"]": {
+                    "null-resource": 1
+                }
+            },
+            "resources": [
+                {
+                    "name": "other_username",
+                    "type": "data.terraform_remote_state",
+                    "count": 1,
+                    "module": "root",
+                    "provider": "provider[\"terraform.io/builtin/terraform\"]"
+                },
+                {
+                    "name": "random",
+                    "type": "null_resource",
+                    "count": 1,
+                    "module": "root",
+                    "provider": "provider[\"registry.terraform.io/hashicorp/null\"]"
+                }
+            ],
+            "resources-processed": true,
+            "serial": 9,
+            "state-version": 4,
+            "terraform-version": "0.15.4",
+            "vcs-commit-url": "https://gitlab.com/my-organization/terraform-test/-/commit/abcdef12345",
+            "vcs-commit-sha": "abcdef12345"
+        },
+        "relationships": {
+            "run": {
+                "data": {
+                    "id": "run-YfmFLWpgTv31VZsP",
+                    "type": "runs"
+                }
+            },
+            "created-by": {
+                "data": {
+                    "id": "user-onZs69ThPZjBK2wo",
+                    "type": "users"
+                },
+                "links": {
+                    "self": "/api/v2/users/user-onZs69ThPZjBK2wo",
+                    "related": "/api/v2/runs/run-YfmFLWpgTv31VZsP/created-by"
+                }
+            },
+            "workspace": {
+                "data": {
+                    "id": "ws-noZcaGXsac6aZSJR",
+                    "type": "workspaces"
+                }
+            },
+            "outputs": {
+                "data": [
+                    {
+                        "id": "wsout-V22qbeM92xb5mw9n",
+                        "type": "state-version-outputs"
+                    },
+                    {
+                        "id": "wsout-ymkuRnrNFeU5wGpV",
+                        "type": "state-version-outputs"
+                    },
+                    {
+                        "id": "wsout-v82BjkZnFEcscipg",
+                        "type": "state-version-outputs"
+                    }
+                ]
+            }
+        },
+        "links": {
+            "self": "/api/v2/state-versions/sv-g4rqST72reoHMM5a"
+        }
+    }
+}
+```
+
+## Permanently Delete a State Version
+
+<EnterpriseAlert>
+This endpoint is exclusive to Terraform Enterprise, and not available in Terraform Cloud. <a href="https://developer.hashicorp.com/terraform/enterprise">Learn more about Terraform Enterprise</a>.
+</EnterpriseAlert>
+
+`POST /api/v2/state-versions/:state_version_id/actions/permanently_delete_backing_data`
+
+This endpoint directs Terraform Enterprise to permanently delete backing files associated with this state version. This endpoint can only permanently delete state versions that are in an [`backing_data_soft_deleted` state](#state-version-status) and are not the current state version. Otherwise, calling this endpoint results in an error.
+
+You must have organization owner permissions to permanently delete state versions. Refer to [Permissions](/terraform/enterprise/users-teams-organizations/permissions) for additional information about permissions.
+
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
+
+| Parameter           | Description                          |
+|---------------------|--------------------------------------|
+| `:state_version_id` | The ID of the state version to permanently delete. |
+
+| Status  | Response                  | Reason                                                                                                        |
+|---------|---------------------------|---------------------------------------------------------------------------------------------------------------|
+| [200][] | [JSON API document][]     | Terraform deleted the data permanently.                                                        |
+| [400][] | [JSON API error object][] | Terraform failed to transition the state to `backing_data_permanently_deleted`.                                   |
+| [404][] | [JSON API error object][] | Terraform did not find the state version or the user is not authorized to modify the state version data.                                           |
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  https://app.terraform.io/api/v2/state-versions/sv-ntv3HbhJqvFzamy7/actions/permanently_delete_backing_data
+```
+
+### Sample Response
+
+```json
+{
+    "data": {
+        "id": "sv-g4rqST72reoHMM5a",
+        "type": "state-versions",
+        "attributes": {
+            "created-at": "2021-06-08T01:22:03.794Z",
+            "size": 940,
+            "hosted-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-state-upload-url": null,
+            "hosted-json-state-download-url": "https://archivist.terraform.io/v1/object/...",
+            "hosted-json-state-upload-url": null,
+            "status": "backing_data_permanently_deleted",
+            "intermediate": false,
+            "modules": {
+                "root": {
+                    "null-resource": 1,
+                    "data.terraform-remote-state": 1
+                }
+            },
+            "providers": {
+                "provider[\"terraform.io/builtin/terraform\"]": {
+                    "data.terraform-remote-state": 1
+                },
+                "provider[\"registry.terraform.io/hashicorp/null\"]": {
+                    "null-resource": 1
+                }
+            },
+            "resources": [
+                {
+                    "name": "other_username",
+                    "type": "data.terraform_remote_state",
+                    "count": 1,
+                    "module": "root",
+                    "provider": "provider[\"terraform.io/builtin/terraform\"]"
+                },
+                {
+                    "name": "random",
+                    "type": "null_resource",
+                    "count": 1,
+                    "module": "root",
+                    "provider": "provider[\"registry.terraform.io/hashicorp/null\"]"
+                }
+            ],
+            "resources-processed": true,
+            "serial": 9,
+            "state-version": 4,
+            "terraform-version": "0.15.4",
+            "vcs-commit-url": "https://gitlab.com/my-organization/terraform-test/-/commit/abcdef12345",
+            "vcs-commit-sha": "abcdef12345"
+        },
+        "relationships": {
+            "run": {
+                "data": {
+                    "id": "run-YfmFLWpgTv31VZsP",
+                    "type": "runs"
+                }
+            },
+            "created-by": {
+                "data": {
+                    "id": "user-onZs69ThPZjBK2wo",
+                    "type": "users"
+                },
+                "links": {
+                    "self": "/api/v2/users/user-onZs69ThPZjBK2wo",
+                    "related": "/api/v2/runs/run-YfmFLWpgTv31VZsP/created-by"
+                }
+            },
+            "workspace": {
+                "data": {
+                    "id": "ws-noZcaGXsac6aZSJR",
+                    "type": "workspaces"
+                }
+            },
+            "outputs": {
+                "data": [
+                    {
+                        "id": "wsout-V22qbeM92xb5mw9n",
+                        "type": "state-version-outputs"
+                    },
+                    {
+                        "id": "wsout-ymkuRnrNFeU5wGpV",
+                        "type": "state-version-outputs"
+                    },
+                    {
+                        "id": "wsout-v82BjkZnFEcscipg",
+                        "type": "state-version-outputs"
+                    }
+                ]
+            }
+        },
+        "links": {
+            "self": "/api/v2/state-versions/sv-g4rqST72reoHMM5a"
         }
     }
 }

--- a/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations.mdx
@@ -229,6 +229,21 @@ Configure [VCS providers](/terraform/cloud-docs/vcs) to use in the organization.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
+
+### Destruction and Deletion
+
+#### Data Retention Policies
+
+<EnterpriseAlert>
+Data retention policies are exclusive to Terraform Enterprise, and not available in Terraform Cloud. <a href="https://developer.hashicorp.com/terraform/enterprise">Learn more about Terraform Enterprise</a>.
+</EnterpriseAlert>
+
+By default, the **Do not auto-delete data** option is enabled for an organization. This option directs Terraform Enterprise to retain data associated with configuration and state versions, but organization owners can define configurable data retention policies that allow Terraform to _soft delete_ the backing data associated with configuration versions and state versions. Soft deleting refers to marking a data object for garbage collection so that Terraform can delete the object after a set number of days.
+
+Once an object is soft deleted, any attempts to read the object will fail. Until the garbage collection process begins, you can restore soft deleted objects using the APIs described in the [configuration version documentation](/terraform/enterprise/api-docs/configuration-versions) and the [state version documentation](/terraform/enterprise/api-docs/state-versions). Terraform permanently deletes the archivist storage after the garbage collection grace period elapses.
+
+The organization policy is the default policy applied to all workspaces, but members of individual workspaces can set overriding policies for their workspaces that take precedence over the organization policy
+
 ## Trial Expired Organizations
 
 Terraform Cloud paid features are available as a free trial. When a free trial has expired, the organization displays a banner reading **TRIAL EXPIRED — Upgrade Required**.

--- a/website/docs/cloud-docs/workspaces/settings/deletion.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/deletion.mdx
@@ -87,3 +87,15 @@ Terraform does not automatically destroy managed infrastructure when you delete 
 After you delete the workspace and its state file, Terraform can _no longer track or manage_ that infrastructure. You must manually delete or [import](/terraform/cli/commands/import) any remaining resources into another Terraform workspace.
 
 By default, [workspace administrators](/terraform/cloud-docs/users-teams-organizations/permissions#workspace-admins) can only delete unlocked workspaces that are not managing any infrastructure. Organization owners can force delete a workspace to override these protections. Organization owners can also configure the [organization's settings](/terraform/cloud-docs/users-teams-organizations/organizations#general) to let workspace administrators force delete their own workspaces.
+
+## Data Retention Policies
+
+<EnterpriseAlert>
+Data retention policies are exclusive to Terraform Enterprise, and not available in Terraform Cloud. <a href="https://developer.hashicorp.com/terraform/enterprise">Learn more about Terraform Enterprise</a>.
+</EnterpriseAlert>
+
+Define configurable data retention policies for workspaces to help reduce object storage consumption. You can define a policy that allows Terraform to _soft delete_ the backing data associated with configuration versions and state versions. Soft deleting refers to marking a data object for garbage collection so that Terraform can automatically delete the object after a set number of days.
+
+Once an object is soft deleted, any attempts to read the object will fail. Until the garbage collection grace period elapses, you can still restore an object using the APIs described in the [configuration version documentation](/terraform/enterprise/api-docs/configuration-versions) and [state version documentation](/terraform/enterprise/api-docs/state-versions). After the garbage collection grace period elapses, Terraform permanently deletes the archivist storage.
+
+The [organization policy](/terraform/enterprise/users-teams-organizations/organizations#destruction-and-deletion) is the default policy applied to workspaces, but members of individual workspaces can override the policy for their workspaces. The workspace policy always overrides the organization policy.


### PR DESCRIPTION
### What
Adding [Data Retention documentation](https://github.com/hashicorp/ptfe-releases/pull/970) that was originally added to the TFE docs, but is sourced in the TFC docs and requires we update the corresponding TFC files. I also added TFE alerts denoting the TFE exclusivity of this feature. 

> Note that I kept the links in these changes pointing to the TFE docs. This was intentional because this is a TFE-exclusive feature and we want to route users to the TFE docs if they want to use this feature.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
