### PR TITLE
TF-11711-update workspace version setting doc

### DIFF
--- a/website/docs/cloud-docs/workspaces/settings/index.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/index.mdx
@@ -90,11 +90,11 @@ Auto-apply has the following exception:
 
 ### Terraform Version
 
-The Terraform version to use for all operations in the workspace. The default value is whichever release was current when the workspace was created. The workspace Terraform version can be updated to an exact version or a valid [version constraint](/terraform/language/expressions/version-constraints).
+The Terraform version to use for all operations in the workspace. The default value is whichever release was current when Terraform Cloud created the workspace. You can also update a workspace's Terraform version to an exact version or a valid [version constraint](/terraform/language/expressions/version-constraints).
 
 > **Hands-on:** Try the [Upgrade Terraform Version in Terraform Cloud](/terraform/tutorials/cloud/cloud-versions) tutorial.
 
--> **API:** You can specify a Terraform version when [creating a workspace](/terraform/cloud-docs/api-docs/workspaces#create-a-workspace) via the API.
+-> **API:** You can specify a Terraform version when you [create a workspace](/terraform/cloud-docs/api-docs/workspaces#create-a-workspace) with the API.
 
 ### Terraform Working Directory
 

--- a/website/docs/cloud-docs/workspaces/settings/index.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/index.mdx
@@ -90,11 +90,11 @@ Auto-apply has the following exception:
 
 ### Terraform Version
 
-The Terraform version to use for all operations in the workspace. The default value is whichever release was current when the workspace was created.
+The Terraform version to use for all operations in the workspace. The default value is whichever release was current when the workspace was created. The workspace Terraform version can be updated to an exact version or a valid [version constraint](/terraform/language/expressions/version-constraints).
 
 > **Hands-on:** Try the [Upgrade Terraform Version in Terraform Cloud](/terraform/tutorials/cloud/cloud-versions) tutorial.
 
--> **API:** You can specify a Terraform version when [creating a workspace](/terraform/cloud-docs/api-docs/workspaces#create-a-workspace) via the API. The API also supports setting a valid [version constraint](/terraform/language/expressions/version-constraints) as the Terraform version.
+-> **API:** You can specify a Terraform version when [creating a workspace](/terraform/cloud-docs/api-docs/workspaces#create-a-workspace) via the API.
 
 ### Terraform Working Directory
 


### PR DESCRIPTION
### What
Updated Workspace version setting doc to reflect version constraint setting in the UI as well as API.

### Why
Previously, version constraint  could only be set via API, but it can now be set via UI version dropdown as well.

### Screenshots
#### Previous look
<img width="701" alt="Screenshot 2024-01-03 at 11 44 49 AM" src="https://github.com/hashicorp/terraform-docs-common/assets/22062046/e467c90f-04ff-492b-bb38-21d4eb84ad17">


#### Proposed change
<img width="688" alt="Screenshot 2024-01-03 at 11 49 59 AM" src="https://github.com/hashicorp/terraform-docs-common/assets/22062046/3e4c6922-4044-4fb4-be5e-a33f51c30f9d">

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
