### PR TITLE
plugin: Fix code gen schema link

### DIFF
--- a/website/docs/plugin/code-generation/specification.mdx
+++ b/website/docs/plugin/code-generation/specification.mdx
@@ -12,7 +12,7 @@ Code Generation is currently in tech preview.
 
 The Provider Code Specification is a versioned interface between source(s) and provider code; this interface creates a separation of concerns between any potential source(s) of information and potential consumer(s) of that information.
 
-The implementation is a [JSON schema](https://github.com/hashicorp/terraform-plugin-codegen-spec/blob/main/spec/schema.json) with associated [Go bindings](https://github.com/hashicorp/terraform-plugin-codegen-spec/blob/main/spec/specification.go) which defines the structure and types of the interface. The interface is hierarchical, and describes structures from their most granular form (e.g., data sources, provider, resources), through to the fine-grained details of the individual types contained therein (e.g., required, sensitive).
+The implementation is a [JSON schema](https://github.com/hashicorp/terraform-plugin-codegen-spec/blob/main/spec/v0.1/schema.json) with associated [Go bindings](https://github.com/hashicorp/terraform-plugin-codegen-spec/blob/main/spec/specification.go) which defines the structure and types of the interface. The interface is hierarchical, and describes structures from their most granular form (e.g., data sources, provider, resources), through to the fine-grained details of the individual types contained therein (e.g., required, sensitive).
 
 Refer to the [Intermediate Representation](https://github.com/hashicorp/terraform-plugin-codegen-framework/blob/main/internal/cmd/testdata/custom_and_external/ir.json) within the [terraform-plugin-codegen-framework](https://github.com/hashicorp/terraform-plugin-codegen-framework) repository for further examples of Provider Code Specification usage.
 


### PR DESCRIPTION
### What

Quick fix on a broken link to the framework code gen repository

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x]Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
