### PR TITLE
Adjustment to registry ownership FAQ

### DIFF
--- a/website/docs/registry/faq.mdx
+++ b/website/docs/registry/faq.mdx
@@ -123,4 +123,6 @@ If your GPG key or Github account has been compromised, please [reach out to us 
 
 ## Can I regain ownership of my artifact after losing access to my GitHub account?
 
-For support, please [reach out to us via email](/terraform/registry#getting-help).
+Artifacts in the Public Registry that were originally published by a GitHub user that no longer exists are routinely detected and marked as not having a maintainer on each artifacts' details page.
+
+If you are the owner of such an artifact, or for other artifact ownership issues, please [reach out to us](/terraform/registry#getting-help).

--- a/website/docs/registry/faq.mdx
+++ b/website/docs/registry/faq.mdx
@@ -123,6 +123,8 @@ If your GPG key or Github account has been compromised, please [reach out to us 
 
 ## Can I regain ownership of my artifact after losing access to my GitHub account?
 
-Artifacts in the Public Registry that were originally published by a GitHub user that no longer exists are routinely detected and marked as not having a maintainer on each artifacts' details page.
+Artifacts in the Public Registry that were originally published by a GitHub user that no longer exists are routinely detected and marked with a disclaimer.
+
+> The GitHub user that published this artifact no longer exists. See the FAQ for more information.
 
 If you are the owner of such an artifact, or for other artifact ownership issues, please [reach out to us](/terraform/registry#getting-help).


### PR DESCRIPTION
### What

Changes the registry publishing FAQ about lost artifact ownership to include a reference to new registry behavior to detect artifacts that were previously owned by a GitHub user that no longer exists.

### Why

The registry site will begin indicating this situation on pages detailing artifacts with invalid GitHub owners. That indication will reference this FAQ, which is our desired entrypoint for someone attempting to regain ownership.

### Screenshot

<img width="746" alt="Screenshot 2024-01-10 at 9 29 01 AM" src="https://github.com/hashicorp/terraform-docs-common/assets/515424/32689276-86ad-4862-b66a-b387c16e2e99">

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
