### PR TITLE
Remove beta flag from tfc testing page [IPE-481]

### DIFF
--- a/website/docs/cloud-docs/registry/test.mdx
+++ b/website/docs/cloud-docs/registry/test.mdx
@@ -2,7 +2,6 @@
 page_title: Testing Private Modules - Private Registry - Terraform Cloud
 description: >-
   Enable automated module testing in the private registry
-tfc_only: true
 ---
 
 # Test-integrated modules in the Terraform Cloud private registry
@@ -44,7 +43,7 @@ To add environment variables to your module's tests:
 1. In the **Variables** section on the **Tests Settings** screen, click **+ Add variable**. 
 1. Provide a **Key** and **Value** for your environment variable, and if you want to protect the variable's value, click the **Sensitive** checkbox. 
 1. Click **Add variable** to save it.
-
+<!-- BEGIN: TFC:only -->
 ## Generated module tests
 
 ~> **Note**: Generated module tests are available in Terraform Cloud **Plus** Edition and are in public beta. Refer to [Terraform Cloud pricing](https://www.hashicorp.com/products/terraform/pricing) for details.
@@ -58,3 +57,4 @@ To generate tests for your module:
 1. Terraform Cloud displays generated configuration. To download all of the test files, click **Download generated tests**.
 1. Create a `tests` directory in your configuration.
 1. Unzip the downloaded files into the new `tests` directory.
+<!-- END: TFC:only -->

--- a/website/docs/cloud-docs/registry/test.mdx
+++ b/website/docs/cloud-docs/registry/test.mdx
@@ -43,7 +43,9 @@ To add environment variables to your module's tests:
 1. In the **Variables** section on the **Tests Settings** screen, click **+ Add variable**. 
 1. Provide a **Key** and **Value** for your environment variable, and if you want to protect the variable's value, click the **Sensitive** checkbox. 
 1. Click **Add variable** to save it.
+
 <!-- BEGIN: TFC:only -->
+
 ## Generated module tests
 
 ~> **Note**: Generated module tests are available in Terraform Cloud **Plus** Edition and are in public beta. Refer to [Terraform Cloud pricing](https://www.hashicorp.com/products/terraform/pricing) for details.

--- a/website/docs/cloud-docs/registry/test.mdx
+++ b/website/docs/cloud-docs/registry/test.mdx
@@ -59,4 +59,5 @@ To generate tests for your module:
 1. Terraform Cloud displays generated configuration. To download all of the test files, click **Download generated tests**.
 1. Create a `tests` directory in your configuration.
 1. Unzip the downloaded files into the new `tests` directory.
+
 <!-- END: TFC:only -->

--- a/website/docs/cloud-docs/registry/test.mdx
+++ b/website/docs/cloud-docs/registry/test.mdx
@@ -7,8 +7,6 @@ tfc_only: true
 
 # Test-integrated modules in the Terraform Cloud private registry
 
--> **Note:** Test-integrated module publishing is in beta.
-
 You can configure Terraform Cloud to automatically run tests for modules in your private registry. When enabled, Terraform Cloud will run tests for every commit to the designated branch. This lets you verify that it is safe to publish new module versions.
 
 ## Enable testing


### PR DESCRIPTION
### What
Removed the beta flag from cloud-docs/registry/test.mdx
### Why
This change alerts users that the tf test functionality is no longer in beta.
### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
