### PR TITLE
Remove PPRV beta tags

### DIFF
--- a/website/docs/cloud-docs/api-docs/policy-evaluations.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-evaluations.mdx
@@ -14,8 +14,6 @@ description: >-
 
 # Policy Evaluations API
 
--> **Note**: Sentinel policy evaluations are in beta.
-
 Policy evaluations are run within the [Terraform Cloud Agents](/terraform/cloud-docs/api-docs/agents) in Terraform Cloud's infrastructure. Policy evaluations do not have access to cost estimation data.
 This set of APIs provides endpoints to list and get policy evaluations and policy outcomes.
 

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -32,8 +32,6 @@ Only Sentinel policies can run as policy checks, and it is the default mode for 
 
 OPA policy sets can only run as policy evaluations, and you can enable policy evaluations for Sentinel policy sets by selecting the `Enhanced` policy set type. Policy evaluations run within the [Terraform Cloud Agent](/terraform/cloud-docs/agents) in Terraform Cloud's infrastructure. 
 
--> **Note:** Sentinel policy evaluations are currently in beta.
-
 For Sentinel policy sets, using policy evaluations lets you:
 - Enable overrides for soft-mandatory and hard-mandatory policies, letting any user with [Manage Policy Overrides permission](/terraform/cloud-docs/users-teams-organizations/permissions#manage-policy-overrides) proceed with a run in the event of policy failure.
 - Select a specific Sentinel runtime version for the policy set.
@@ -141,8 +139,6 @@ To create a policy set:
    - **Standard:** This is the default workflow. A Sentinel policy set uses a [policy check](#policy-checks) in Terraform Cloud and lets you access cost estimation data.
    - **Enhanced:** A Sentinel policy set uses a [policy evaluation](#policy-evaluations) in Terraform Cloud. This lets you enable policy overrides and enforce a Sentinel runtime version
 1. **(OPA Only)** Select a **Runtime version** for this policy set.
-
-    -> **Note**: Policy runtime version management is in beta.
 
 1. **(OPA Only)** Allow **Overrides**, which enables users with override policy permissions to apply plans that have [mandatory policy](#policy-enforcement-levels) failures.
 1. **(VCS Only)** Optionally specify the **VCS branch** within your VCS repository where Terraform Cloud should import new versions of policies. If you do not set this field, Terraform Cloud uses your selected VCS repository's default branch.

--- a/website/docs/cloud-docs/policy-enforcement/policy-results.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/policy-results.mdx
@@ -15,7 +15,6 @@ When you add [policy sets](/terraform/cloud-docs/policy-enforcement/manage-polic
 
 Terraform Cloud only evaluates policies for successful plans. Terraform Cloud evaluates Sentinel and OPA policy sets separately and at different points in the run.
 - Sentinel policy checks occur after Terraform completes the plan and after both [run tasks](/terraform/cloud-docs/workspaces/settings/run-tasks) and [cost estimation](https://terraform.io/cloud-dodcs/cost-estimation). This order lets you write Sentinel policies to restrict costs based on the data in the cost estimates.
--> **Note**: Sentinel policy evaluations are currently in beta
 - Sentinel policy evaluations occur after Terraform completes the plan and after any run tasks. Terraform Cloud evaluates Sentinel policy evaluations immediately before cost estimation.
 - OPA policy evaluations occur after Terraform completes the plan and after any run tasks. Terraform Cloud evaluates OPA policies immediately before cost estimation.
 
@@ -54,7 +53,6 @@ You can override `soft-mandatory` policies to allow the run to continue. Overrid
 You cannot override `hard-mandatory` policies, and all of these policies must pass for the run to continue.
 
 #### Policy evaluations
--> **Note:** Sentinel policy evaluations are currently in beta
 
 Policies with an `advisory` enforcement level never stop runs. If they fail, Terraform Cloud displays a warning in the policy results and the run continues.
 


### PR DESCRIPTION
### What
Removes the beta tags from documentation related to PPRV and Sentinel policy evaluations.

### Why
PPRV (TFC) is moving from beta to GA.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).

#### Content
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
