### PR TITLE
Add VCS status checks and reorganize the organization docs a bit

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -275,7 +275,10 @@
       { "title": "Teams", "path": "users-teams-organizations/teams" },
       {
         "title": "Organizations",
-        "path": "users-teams-organizations/organizations"
+        "routes": [
+          {"title": "Overview","path": "users-teams-organizations/organizations"},
+          { "title": "VCS Status Checks", "path": "users-teams-organizations/organizations/vcs-status-checks" }
+        ]
       },
       {
         "title": "Permissions",

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -10,7 +10,7 @@ description: >-
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 ## 2024-1-4
-* Update the [Organizations API](/terraform/cloud-docs/api-docs/organizations) to support the `aggregated-commit-status-enabled` attribute, which controls whether [Aggregated Status Checks](/terraform/cloud-docs/workspaces/settings/vcs-status-checks) are enabled.
+* Update the [Organizations API](/terraform/cloud-docs/api-docs/organizations) to support the `aggregated-commit-status-enabled` attribute, which controls whether [Aggregated Status Checks](/terraform/cloud-docs/users-teams-organizations/organizations/vcs-status-checks) are enabled.
 
 ## 2023-11-17
 

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -10,7 +10,7 @@ description: >-
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
 ## 2024-1-4
-* Update the [Organizations API](/terraform/cloud-docs/api-docs/organizations) to support the `aggregated-commit-status-enabled` attribute, which controls whether [Aggregated Status Checks](/terraform/cloud-docs/users-teams-organizations/organizations#aggregated-status-checks) are enabled.
+* Update the [Organizations API](/terraform/cloud-docs/api-docs/organizations) to support the `aggregated-commit-status-enabled` attribute, which controls whether [Aggregated Status Checks](/terraform/cloud-docs/workspaces/settings/vcs-status-checks) are enabled.
 
 ## 2023-11-17
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
@@ -210,37 +210,6 @@ Organization owners can set up an SSO provider for the organization.
 
 ### Version Control
 
-#### Status Checks
-
-Status checks are notifications sent to your version control system VCS provider, providing details about specific commits, including the present status of the Terraform Cloud run. Please refer to your VCS provider's documentation regarding status checks (e.g., [GitHub Status Checks Documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks)).
-
-Organization owners can choose between _aggregated_ (default) and _non-aggregated_ status checks. This setting determines whether detailed information and links are accessed directly from the VCS provider or Terraform Cloud.
-This setting also determines the number of status checks directly sent to the VCS Provider in response to actions such as pull or merge requests.
-
-##### Aggregated Status Checks
-
-Aggregated status checks offer a streamlined experience if you have a single repository containing configuration for many workspaces (a.k.a., a monorepo).
-
-When aggregated status checks are enabled, Terraform Cloud sends one VCS status check for all runs triggered by a VCS event. If multiple workspaces are tied to a shared repository, Terraform Cloud aggregates the status checks for these workspaces into one summary. This summary is unique to the workspace's organization and VCS client connection.
-
-You can access additional information about an aggregated status check in Terraform Cloud by clicking the **Details** link that the status check provides. This link navigates you to a Terraform Cloud page that offers the consolidated status check results across multiple workspaces, highlighting details such as resource changes and issues that require attention.
-
-![Screenshot: Organization Aggregated status checks](/img/docs/organization-vcs-general-aggregated-status-checks.png)
-
-##### Non-aggregated Status Checks
-
-The alternative behavior of VCS providers is that a provider receives a status for each triggered workspace and related run stage in response to a VCS event. For example, a VCS push triggers checks for each related workspace's run stages, including the plan operation, policy checks, cost estimation, run tasks, and more.
-
-![Screenshot: Organization Non-aggregated status checks](/img/docs/organization-vcs-general-non-aggregated-status-checks.png)
-
-###### Send passing commit statuses
-
--> **Note:** Organization owners can only enable the **Send passing commit statuses** setting if the **Aggregated status checks** setting is disabled.
-
-Workspaces that use part of a shared repository do not typically run plans for changes that do not affect their files. This includes [speculative plans](/terraform/cloud-docs/run/remote-operations#speculative-plans) on pull requests. Since **pending** status checks can block pull requests, workspaces automatically send passing commit statuses for any PRs that do not affect their files.
-
-You can disable this behavior if it creates too many status checks to your VCS provider. You may want to do this if you have a large number of workspaces sharing one VCS repository.
-
 #### VCS Events
 
 -> **Note:** This feature is in beta.
@@ -251,9 +220,7 @@ Review the event logs for GitLab.com connections.
 
 Configure [VCS providers](/terraform/cloud-docs/vcs) to use in the organization. You must have [permission to manage VCS settings](/terraform/cloud-docs/users-teams-organizations/permissions).
 
-
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
-
 
 ### Destruction and Deletion
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations/vcs-status-checks.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations/vcs-status-checks.mdx
@@ -1,0 +1,47 @@
+---
+page_title: VCS Status Checks
+description: Learn how VCS status checks work in Terraform Cloud.
+---
+
+# VCS Status Checks
+
+Status checks are notifications sent to your version control system's VCS provider, providing details about specific commits, including the present status of the Terraform Cloud run. Please refer to your VCS provider's documentation regarding status checks (e.g., [GitHub Status Checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks)).
+
+## Permissions
+
+To modify VCS Status Checks settings, you must have [Manage VCS Settings](/terraform/cloud-docs/users-teams-organizations/permissions#manage-vcs-settings) permissions.
+
+## Managing organization VCS status check settings
+
+Organization owners can choose between _aggregated_ (default) and _non-aggregated_ status checks. This setting determines whether detailed information and links are accessed directly from the VCS provider or Terraform Cloud.
+
+This setting also determines the number of status checks directly sent to the VCS Provider in response to actions such as pull or merge requests.
+
+To view and manage an organization’s VCS Status Check settings, click **Settings** then **Version Control**.
+
+### Aggregated status checks
+
+Aggregated status checks offer a streamlined experience if you have a single repository containing configuration for many workspaces (a.k.a., a monorepo).
+
+When aggregated status checks are enabled, Terraform Cloud sends one VCS status check for all runs triggered by a VCS event. If multiple workspaces rely on a shared repository, Terraform Cloud aggregates the status checks for these workspaces into one summary. This summary is unique to the workspace's organization and VCS client connection.
+
+You can access additional information about an aggregated status check in Terraform Cloud by clicking the **Details** link a status check provides. This link directs you to a Terraform Cloud page that offers the consolidated status check results across multiple workspaces, highlighting details such as resource changes and issues that require attention.
+
+![Screenshot: Organization Aggregated status checks](/img/docs/organization-vcs-general-aggregated-status-checks.png)
+
+### Non-aggregated status checks
+
+Non-aggregated status checks send your VCS provider a status check for each triggered workspace and related run stage in response to a VCS event. For example, a VCS push triggers checks for each related workspace's run stages, including the plan operation, policy checks, cost estimation, run tasks, and more.
+
+If you have a manageable amount of workspaces and want to visualize status checks on your VCS Provider rather than in Terraform Cloud, use non-aggregated status checks.
+
+![Screenshot: Organization Non-aggregated status checks](/img/docs/organization-vcs-general-non-aggregated-status-checks.png)
+
+#### Send passing commit statuses
+
+-> **Note:** Organization owners can only enable the **Send passing commit statuses** setting if the **Aggregated status checks** setting is disabled.
+
+Workspaces that use part of a shared repository do not typically run plans for changes that do not affect their files. This includes [speculative plans](/terraform/cloud-docs/run/remote-operations#speculative-plans) on pull requests. Since **pending** VCS status checks can block pull requests, workspaces automatically send passing commit statuses for any PRs that do not affect their files.
+
+You can disable this behavior if it creates too many status checks for your VCS provider. You may want to do this if you have a large number of workspaces sharing one VCS repository.
+


### PR DESCRIPTION
Creating a PR based on @mjyocca's work (drafted [in this usage doc template](https://docs.google.com/document/d/1oz51Wlu0VG7nLeOlhTWSWa2NFgePAXaAbu4wNu3z7mI/edit?usp=sharing)). 

As part of adding this work I :
1. Added a new page 
2. Removed the content from where it originally lived in the "Organizations" page
3. I scooted the original "organizations" page into a new "organizations" folder, and renamed the original `.mdx` file to `index.mdx`. 

Because I renamed the `organizations.mdx` file to `index.mdx` I don't need to change any links pointing to `/terraform/cloud-docs/users-teams-organizations/organizations` because the URL stays the same.
