### PR TITLE
TF-12190: document 300 changed files limit

### DIFF
--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -27,6 +27,8 @@ The Terraform code for a normal run always comes from version control, and is al
 
 In a workspace linked to a VCS repository, runs start automatically when you merge or commit changes to version control.
 
+-> **Note:** If you're using GitHub as your VCS provider and 300 files are reported as changed by the GitHub API when your PR is merged, Terraform Cloud will trigger all connected workspaces for that given repository. This is due to the fact that GitHub limits the number of changed files that it reports for a PR merge at 300, therefore necessitating the need for Terraform Cloud to proactively trigger workspaces to ensure that changes are not missed.
+
 A workspace is linked to one branch of a VCS repository and ignores changes to other branches. You can specify which files and directories within your repository trigger runs. Terraform Cloud can also automatically trigger runs when you create Git tags. Refer to [Automatic Run Triggering](/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering) for details.
 
 -> **Note:** A workspace with no runs will not accept new runs via VCS webhook. At least one run must be manually queued to confirm that the workspace is ready for further runs.

--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -27,7 +27,7 @@ The Terraform code for a normal run always comes from version control, and is al
 
 In a workspace linked to a VCS repository, runs start automatically when you merge or commit changes to version control.
 
--> **Note:** If you're using GitHub as your VCS provider and 300 files are reported as changed by the GitHub API when your PR is merged, Terraform Cloud will trigger all connected workspaces for that given repository. This is due to the fact that GitHub limits the number of changed files that it reports for a PR merge at 300, therefore necessitating the need for Terraform Cloud to proactively trigger workspaces to ensure that changes are not missed.
+If you use GitHub as your VCS provider and merge a PR changing 300 or more files, Terraform Cloud automatically triggers runs for every workspace connected to that repository. The GitHub API has a limit of 300 reported changed files for a PR merge. To address this, Terraform Cloud initiates workspace runs proactively, preventing oversight of file changes beyond this limit.
 
 A workspace is linked to one branch of a VCS repository and ignores changes to other branches. You can specify which files and directories within your repository trigger runs. Terraform Cloud can also automatically trigger runs when you create Git tags. Refer to [Automatic Run Triggering](/terraform/cloud-docs/workspaces/settings/vcs#automatic-run-triggering) for details.
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Added a note about undocumented behavior that is specific to Github-backed TFC/E workspaces.

It will be visible at https://developer.hashicorp.com/terraform/cloud-docs/run/ui#automatically-starting-runs
(`UI/VCS-driven Runs - Runs - Terraform Cloud`)

https://hashicorp.atlassian.net/browse/TF-12190

### Why
This explains why all their workspaces may be triggered for a given PR merge.

### Screenshots
https://terraform-docs-common-git-paul-300-hashicorp.vercel.app/terraform/cloud-docs/run/ui

![image](https://github.com/hashicorp/terraform-docs-common/assets/155981/ccd0d693-be8a-4a13-b2ef-bda93370feab)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
