### PR TITLE
Update tfrun docs to use null over undefined

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/sentinel/import/tfrun.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/sentinel/import/tfrun.mdx
@@ -123,7 +123,7 @@ Specifies whether the plan is in refresh-only mode, which ignores configuration 
 
 * **Value Type:** An array of strings representing [resource addresses](/terraform/cli/state/resource-addressing).
 
-Provides the targets specified using the [`-replace`](/terraform/cli/commands/plan#resource-targeting) flag in the CLI or the `replace-addrs` attribute in the API. Will be undefined if no resource targets are specified.
+Provides the targets specified using the [`-replace`](/terraform/cli/commands/plan#resource-targeting) flag in the CLI or the `replace-addrs` attribute in the API. Will be null if no resource targets are specified.
 
 ### Value: `speculative`
 
@@ -135,14 +135,14 @@ Specifies whether the plan associated with the run is a [speculative plan](/terr
 
 * **Value Type:** An array of strings representing [resource addresses](/terraform/cli/state/resource-addressing).
 
-Provides the targets specified using the [`-target`](/terraform/cli/commands/plan#resource-targeting) flag in the CLI or the `target-addrs` attribute in the API. Will be undefined if no resource targets are specified.
+Provides the targets specified using the [`-target`](/terraform/cli/commands/plan#resource-targeting) flag in the CLI or the `target-addrs` attribute in the API. Will be null if no resource targets are specified.
 
-To prohibit targeted runs altogether, make sure the `target_addrs` value is undefined or empty:
+To prohibit targeted runs altogether, make sure the `target_addrs` value is null or empty:
 
 ```
 import "tfrun"
 
-main = (length(tfrun.target_addrs) else 0) == 0
+main = tfrun.target_addrs is null or tfrun.target_addrs is empty
 ```
 
 ### Value: `variables`


### PR DESCRIPTION
### What
A recent change to the tfrun import means that certain values are now null instead of undefined. Updating the policy tfrun page to match this.

### Why
Users will not be guided to do the wrong thing.

[Related PR](https://github.com/hashicorp/tfe-sentinel-worker/pull/223)

----------

### Merge Checklist

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
- [X] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
