### PR TITLE
Add resource_drift documentation for tfplan/v2

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/sentinel/import/tfplan-v2.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/sentinel/import/tfplan-v2.mdx
@@ -63,6 +63,17 @@ tfplan/v2
 │       ├── provider_name (string)
 │       ├── deposed (string)
 │       └── change (change representation)
+├── resource_drift
+│   └── (indexed by address[:deposed])
+│       ├── address (string)
+│       ├── module_address (string)
+│       ├── mode (string)
+│       ├── type (string)
+│       ├── name (string)
+│       ├── index (float (number) or string)
+│       ├── provider_name (string)
+│       ├── deposed (string)
+│       └── change (change representation)
 ├── output_changes
 │   └── (indexed by name)
 │       ├── name (string)
@@ -78,8 +89,10 @@ The collections are:
 * [`planned_values`](#the-planned_values-collection) - The state representation
   of _planned values_, or an estimation of what the state will look like after
   the plan is applied.
-* [`resource_changes`](#the-resource_changes-collection) - The set of change
+* [`resource_changes`](#the-resource_changes-and-resource_drift-collections) - The set of change
   operations for resources and data sources within this plan.
+* [`resource_drift`](#the-resource_changes-and-resource_drift-collections) - A description of the
+  changes Terraform detected when it compared the most recent state to the prior saved state.
 * [`output_changes`](#the-output_changes-collection) - The changes to outputs
   within this plan. This collection only contains outputs set in the root
   module.
@@ -304,12 +317,15 @@ representations, regardless of whether or not they existed before. Use
 [`resource_changes`](#the-resource_changes-collection) if awareness of unknown
 data is important.
 
-## The `resource_changes` Collection
+## The `resource_changes` and `resource_drift` Collections
 
-The `resource_changes` collection is the set of change operations for resources
+The `resource_changes` and `resource_drift` collections are a set of change operations for resources
 and data sources within this plan.
 
-This includes all resources that have been found in the configuration and state,
+The `resource_drift` collection provides a description of the changes Terraform detected
+when it compared the most recent state to the prior saved state.
+
+The `resource_changes` collection includes all resources that have been found in the configuration and state,
 regardless of whether or not they are changing.
 
 ~> When [resource targeting](/terraform/cli/commands/plan#resource-targeting) is in effect, the `resource_changes` collection will only include the resources specified as targets for the run. This may lead to unexpected outcomes if a policy expects a resource to be present in the plan. To prohibit targeted runs altogether, ensure [`tfrun.target_addrs`](/terraform/cloud-docs/policy-enforcement/sentinel/import/tfrun#value-target_addrs) is undefined or empty.


### PR DESCRIPTION
### What
Adding the `resource_drift` collection to the Sentinel `tfplan/v2` import.

### Why
This collection was recently added to `tfplan/v2`, and needs to be represented in documentation.

----------

### Merge Checklist

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] N/A Description links to related pull requests or issues, if any.

#### Content
- [x] N/A Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] N/A API documentation and the API Changelog have been updated. 
- [x] N/A Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] N/A Pages with related content are updated and link to this content when appropriate.
- [x] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
