### PR TITLE
Update documentation to reflect the modified rate limits for runs list polling

### DIFF
--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -327,7 +327,7 @@ $ curl \
 
 ## Rate Limiting
 
-You can make up to 30 requests per second to the API as an authenticated or unauthenticated request. If you reach the rate limit then your access will be throttled and an error response will be returned. A few endpoints relating to user authentication and runs list polling have lower limits to prevent certain spam and abuse scenarios. Typical uses of the API should not notice those limits. If you receive a rate limited response, the limit will be reflected in the `x-ratelimit-limit` header once triggered.
+You can make up to 30 requests per second to the API as an authenticated or unauthenticated request. If you reach the rate limit then your access will be throttled and an error response will be returned. Some endpoints have lower rate limits to prevent abuse, including endpoints that poll Terraform for a list of runs and endpoints related to user authentication. The adjusted limits are unnoticeable under normal use. If you receive a rate-limited response, the limit is reflected in the `x-ratelimit-limit` header once triggered.
 
 Authenticated requests are allocated to the user associated with the authentication token. This means that a user with multiple tokens will still be limited to 30 requests per second, additional tokens will not allow you to increase the requests per second permitted.
 

--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -327,7 +327,7 @@ $ curl \
 
 ## Rate Limiting
 
-You can make up to 30 requests per second to the API as an authenticated or unauthenticated request. If you reach the rate limit then your access will be throttled and an error response will be returned. A few endpoints relating to user authentication and workspace polling have lower limits to prevent certain spam and abuse scenarios. Typical uses of the API should not notice those limits. If you receive a rate limited response, the limit will be reflected in the `x-ratelimit-limit` header once triggered.
+You can make up to 30 requests per second to the API as an authenticated or unauthenticated request. If you reach the rate limit then your access will be throttled and an error response will be returned. A few endpoints relating to user authentication and runs list polling have lower limits to prevent certain spam and abuse scenarios. Typical uses of the API should not notice those limits. If you receive a rate limited response, the limit will be reflected in the `x-ratelimit-limit` header once triggered.
 
 Authenticated requests are allocated to the user associated with the authentication token. This means that a user with multiple tokens will still be limited to 30 requests per second, additional tokens will not allow you to increase the requests per second permitted.
 

--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -327,7 +327,7 @@ $ curl \
 
 ## Rate Limiting
 
-You can make up to 30 requests per second to the API as an authenticated or unauthenticated request. If you reach the rate limit then your access will be throttled and an error response will be returned. A few endpoints relating to user authentication have lower limits to prevent certain spam and abuse scenarios. Typical uses of the API should not notice those limits. If you receive a rate limited response, the limit will be reflected in the `x-ratelimit-limit` header once triggered.
+You can make up to 30 requests per second to the API as an authenticated or unauthenticated request. If you reach the rate limit then your access will be throttled and an error response will be returned. A few endpoints relating to user authentication and workspace polling have lower limits to prevent certain spam and abuse scenarios. Typical uses of the API should not notice those limits. If you receive a rate limited response, the limit will be reflected in the `x-ratelimit-limit` header once triggered.
 
 Authenticated requests are allocated to the user associated with the authentication token. This means that a user with multiple tokens will still be limited to 30 requests per second, additional tokens will not allow you to increase the requests per second permitted.
 

--- a/website/docs/cloud-docs/api-docs/run.mdx
+++ b/website/docs/cloud-docs/api-docs/run.mdx
@@ -331,7 +331,7 @@ curl \
 | `workspace_id` | The workspace ID to list runs for. |
 
 By default, `plan_only` runs will be excluded from the results. To see all runs, use `filter[operation]` with all available operations included as a comma-separated list.
-This endpoint has an adjusted rate limit of 30 requests per minute as opposed to the standard limit of 30 requests per second.
+This endpoint has an adjusted rate limit of 30 requests per minute. Note that most endpoints are limited to 30 requests per second.
 
 | Status  | Response                                         | Reason                   |
 |---------|--------------------------------------------------|--------------------------|

--- a/website/docs/cloud-docs/api-docs/run.mdx
+++ b/website/docs/cloud-docs/api-docs/run.mdx
@@ -331,6 +331,7 @@ curl \
 | `workspace_id` | The workspace ID to list runs for. |
 
 By default, `plan_only` runs will be excluded from the results. To see all runs, use `filter[operation]` with all available operations included as a comma-separated list.
+This endpoint has an adjusted rate limit of 30 requests per minute as opposed to the standard limit of 30 requests per second.
 
 | Status  | Response                                         | Reason                   |
 |---------|--------------------------------------------------|--------------------------|


### PR DESCRIPTION
### What
Updated the rate-limit section in the api-docs index and the runs list endpoint to show that runs list polling has an adjusted rate limit.
### Why
Runs list polling uses a different rate limit than 30 requests per second and this should be reflected in the docs.
### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).

#### Content
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
