### PR TITLE
exclusion tags for exlorer content in workspace health

### DIFF
--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -92,15 +92,19 @@ On the organization's **Workspaces** page, Terraform Cloud displays a **Health w
 On the right of a workspace’s overview page, Terraform Cloud displays a **Health** bar that summarizes the results of the last health assessment.
 - The **Drift** summary shows the total number of resources in the configuration and the number of resources that have drifted.
 - The **Checks** summary shows the number of passed, failed, and unknown statuses for objects with continuous validation checks.
-
+<!-- BEGIN: TFC:only name:health-in-explorer -->
 ### View Workspace Health in Explorer
 
-With [Explorer](/terraform/cloud-docs/workspaces/explorer), you can produce a report that provides a condensed overview of the health status of the workspaces within your organization.
+The [Explorer page](/terraform/cloud-docs/workspaces/explorer) presents a condensed overview of the health status of the workspaces within your organization. You can see the following information:
 
-You can see whether workspaces have enabled Workspace Health, the status of any configured Continuous Validation checks, and the count of drifted resources for each workspace. For additional details on the data available for reporting, refer to the [Explorer](/terraform/cloud-docs/workspaces/explorer) documentation.
+- Workspaces that are monitoring workspace health 
+- Status of any configured continuous validation checks 
+- Count of drifted resources for each workspace 
+
+For additional details on the data available for reporting, refer to the [Explorer](/terraform/cloud-docs/workspaces/explorer) documentation.
 
 ![Viewing Workspace Health in Explorer](/img/docs/tfc-explorer-health.png)
-
+<!-- END: TFC:only name:health-in-explorer -->
 ## Drift Detection
 
 Drift detection helps you identify situations where your actual infrastructure no longer matches the configuration defined in Terraform. This deviation is known as _configuration drift_. Configuration drift occurs when changes are made outside Terrafoto's regular process, leading to inconsistencies between the remote objects and your configured infrastructure.


### PR DESCRIPTION
### What
Added TFC-only exclusion tags for explorer content and links on the workspace health page. 

### Why
Explorer view is TFC only 

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [N/A] Description links to related pull requests or issues, if any.

#### Content
- [N/A ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ N/A] API documentation and the API Changelog have been updated. 
- [N/A ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [N/A ] Pages with related content are updated and link to this content when appropriate.
- [N/A ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [N/A ] New pages have metadata (page name and description) at the top.
- [N/A ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [N/A ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [N/A ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
