### PR TITLE
Be explicit that function names should use underscores to separate words

### DIFF
--- a/website/docs/plugin/best-practices/naming.mdx
+++ b/website/docs/plugin/best-practices/naming.mdx
@@ -34,6 +34,8 @@ in the AWS provider returns a list of availability zones.
 
 Function names are verbs, since they encapsulate computational logic for usage in practitioner configurations. Unlike resource and data source naming, function names should _NOT_ include the provider name since the configuration language syntax for calling the function must already specify the provider name separately. For example, a `time` provider-defined function that parses RFC3339 timestamp strings should be named `parse_rfc3339` since it would be called via `provider::time::parse_rfc3339`.
 
+Function names should be all lowercase and use underscores to separate words. The built-in functions in the Terraform language do not use underscores for historical reasons, but all functions defined in providers should use underscores to improve readability.
+
 ### Attribute Names
 
 Below is an example of a resource configuration block which illustrates some


### PR DESCRIPTION
### What
I've added an extra paragraph to the "Naming Best Practices" page that explicitly says to use underscores to separate words in function names. That convention was previously only implied by the example name `parse_rfc3339`.

### Why
This is worth calling out because we're intentionally differing from the convention used for Terraform's built-in functions.

The convention of using no word separators whatsoever was a historical design mistake in the Terraform language that we've preserved for consistency, but provider functions already have a different convention for calling them and so this presents an opportunity to correct that historical mistake for these new functions.

I intentionally included the historical context about the difference in convention from built-in functions because I expect that consistency-prioritizing readers would otherwise find the ambiguity confusing, and would be unsure whether this recommendation is valid or outdated.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any. (n/a)

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages. (n/a)
- [x] API documentation and the API Changelog have been updated. (n/a)
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.). (n/a)
- [x] Pages with related content are updated and link to this content when appropriate. (n/a)
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (n/a)
- [x] New pages have metadata (page name and description) at the top. (n/a)
- [x] New images are 2048 px wide. (n/a)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. (n/a)
- [x] UI elements (button names, page names, etc.) are bolded. (n/a)
- [x] The Vercel website preview successfully deployed. [Rendered Preview](https://terraform-docs-common-git-function-naming-underscores-hashicorp.vercel.app/terraform/plugin/best-practices/naming#function-names)

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
