### PR TITLE
website/docs/cloud-docs/integrations/kubernetes: Add annotations and labels page

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -497,6 +497,10 @@
             "path": "integrations/kubernetes/api-reference"
           },
           {
+            "title": "Annotations and Labels",
+            "path": "integrations/kubernetes/annotations-and-labels"
+          },
+          {
             "title": "Migration Guide",
             "path": "integrations/kubernetes/ops-v2-migration"
           }

--- a/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
@@ -16,4 +16,4 @@ description: >-
 
 ## Labels
 
-Terraform Cloud Operator uses no labels.
+The Terraform Cloud Operator for Kubernetes does not use any labels.

--- a/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: Annotations and Labels used by Terraform Cloud Operator for Kubernetes
 description: >-
-  Full list of annotations and labels used by Terraform Cloud Operator.
+  Full list of annotations and labels used by Terraform Cloud Operator for Kubernetes.
 ---
 
 # Annotations and Labels used by Terraform Cloud Operator

--- a/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
@@ -1,0 +1,19 @@
+---
+page_title: Annotations and Labels used by Terraform Cloud Operator
+description: >-
+  Full list of annotations and labels used by Terraform Cloud Operator.
+---
+
+# Annotations and Labels used by Terraform Cloud Operator
+
+## Annotations
+
+| Annotation key | Target resources | Possible values | Description |
+| --- | --- | --- | --- |
+| `workspace.app.terraform.io/run-new` | Workspace | "true" | Set this annotation to `"true"` to trigger a new run. Example: `kubectl annotate workspace <WORKSPACE-NAME> workspace.app.terraform.io/run-new="true"`. |
+| `workspace.app.terraform.io/run-type` | Workspace | `plan`, `apply`, `refresh` | Specify the run type. More information: [Run Modes and Options](https://developer.hashicorp.com/terraform/cloud-docs/run/modes-and-options). It defaults to `plan`. Changing this annotation **DOES NOT** trigger a new run. |
+| `workspace.app.terraform.io/run-terraform-version` | Workspace | valid Terraform version | Specify the Terraform version to use. This setting works only when the annotation `workspace.app.terraform.io/run-type` is set to `plan`. It defaults to the Workspace version. Changing this annotation **DOES NOT** trigger a new run. |
+
+## Labels
+
+Terraform Cloud Operator uses no labels.

--- a/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
@@ -11,7 +11,7 @@ description: >-
 | Annotation key | Target resources | Possible values | Description |
 | --- | --- | --- | --- |
 | `workspace.app.terraform.io/run-new` | Workspace | `"true"` | Set this annotation to `"true"` to trigger a new run. Example: `kubectl annotate workspace <WORKSPACE-NAME> workspace.app.terraform.io/run-new="true"`. |
-| `workspace.app.terraform.io/run-type` | Workspace | `plan`, `apply`, `refresh` | Specify the run type. More information: [Run Modes and Options](https://developer.hashicorp.com/terraform/cloud-docs/run/modes-and-options). It defaults to `plan`. Changing this annotation **DOES NOT** trigger a new run. |
+| `workspace.app.terraform.io/run-type` | Workspace | `plan`, `apply`, `refresh` | Specifies the run type. Changing this annotation does not start a new run. Refer to [Run Modes and Options](https://developer.hashicorp.com/terraform/cloud-docs/run/modes-and-options) for more information. Defaults to `"plan"`. |
 | `workspace.app.terraform.io/run-terraform-version` | Workspace | valid Terraform version | Specify the Terraform version to use. This setting works only when the annotation `workspace.app.terraform.io/run-type` is set to `plan`. It defaults to the Workspace version. Changing this annotation **DOES NOT** trigger a new run. |
 
 ## Labels

--- a/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
@@ -10,7 +10,7 @@ description: >-
 
 | Annotation key | Target resources | Possible values | Description |
 | --- | --- | --- | --- |
-| `workspace.app.terraform.io/run-new` | Workspace | "true" | Set this annotation to `"true"` to trigger a new run. Example: `kubectl annotate workspace <WORKSPACE-NAME> workspace.app.terraform.io/run-new="true"`. |
+| `workspace.app.terraform.io/run-new` | Workspace | `"true"` | Set this annotation to `"true"` to trigger a new run. Example: `kubectl annotate workspace <WORKSPACE-NAME> workspace.app.terraform.io/run-new="true"`. |
 | `workspace.app.terraform.io/run-type` | Workspace | `plan`, `apply`, `refresh` | Specify the run type. More information: [Run Modes and Options](https://developer.hashicorp.com/terraform/cloud-docs/run/modes-and-options). It defaults to `plan`. Changing this annotation **DOES NOT** trigger a new run. |
 | `workspace.app.terraform.io/run-terraform-version` | Workspace | valid Terraform version | Specify the Terraform version to use. This setting works only when the annotation `workspace.app.terraform.io/run-type` is set to `plan`. It defaults to the Workspace version. Changing this annotation **DOES NOT** trigger a new run. |
 

--- a/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Annotations and Labels used by Terraform Cloud Operator
+page_title: Annotations and Labels used by Terraform Cloud Operator for Kubernetes
 description: >-
   Full list of annotations and labels used by Terraform Cloud Operator.
 ---

--- a/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
@@ -12,7 +12,7 @@ description: >-
 | --- | --- | --- | --- |
 | `workspace.app.terraform.io/run-new` | Workspace | `"true"` | Set this annotation to `"true"` to trigger a new run. Example: `kubectl annotate workspace <WORKSPACE-NAME> workspace.app.terraform.io/run-new="true"`. |
 | `workspace.app.terraform.io/run-type` | Workspace | `plan`, `apply`, `refresh` | Specifies the run type. Changing this annotation does not start a new run. Refer to [Run Modes and Options](https://developer.hashicorp.com/terraform/cloud-docs/run/modes-and-options) for more information. Defaults to `"plan"`. |
-| `workspace.app.terraform.io/run-terraform-version` | Workspace | valid Terraform version | Specify the Terraform version to use. This setting works only when the annotation `workspace.app.terraform.io/run-type` is set to `plan`. It defaults to the Workspace version. Changing this annotation **DOES NOT** trigger a new run. |
+| `workspace.app.terraform.io/run-terraform-version` | Workspace | Any valid Terraform version | Specifies the Terraform version to use. Changing this annotation does not start a new run. Only valid when the annotation `workspace.app.terraform.io/run-type` is set to `plan`. Defaults to the Workspace version. |
 
 ## Labels
 


### PR DESCRIPTION
### What

Add a new Terraform Cloud Operator v2 page "Annotations and Labels used by Terraform Cloud Operator".

⚠️ Please, do not merge this PR until version `2.3.0` of the [Operator](https://github.com/hashicorp/terraform-cloud-operator) is available.

### Why

https://hashicorp.atlassian.net/browse/TFECO-5675

### Screenshots

N/A.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
