### PR TITLE
Update terraform test documentation for TF_VAR_x env variables

### DIFF
--- a/website/docs/cloud-docs/registry/test.mdx
+++ b/website/docs/cloud-docs/registry/test.mdx
@@ -41,7 +41,7 @@ To add environment variables to your module's tests:
 
 1. On the module overview screen, click **Configure Tests**. 
 1. In the **Variables** section on the **Tests Settings** screen, click **+ Add variable**. 
-1. Provide a **Key** and **Value** for your environment variable, and if you want to protect the variable's value, click the **Sensitive** checkbox. 
+1. Provide a **Key** and **Value** for your environment variable, and if you want to protect the variable's value, click the **Sensitive** checkbox. TF_VAR_x variables of a string type that are not defined in a config must be wrapped in double-quotes.
 1. Click **Add variable** to save it.
 
 <!-- BEGIN: TFC:only name:generate-module-tests -->


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Updated website/docs/cloud-docs/registry/test.mdx to explain better usage for TF_VAR_x variables within Terraform Test in the Private Module Registry
### Why
<!-- Explain why this change is necessary and how it benefits users. -->
In order to draw users attention to particular guidelines around string type variables.
### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
