### PR TITLE
docs/registry: Add profile image question to FAQ

### DIFF
--- a/website/docs/registry/faq.mdx
+++ b/website/docs/registry/faq.mdx
@@ -43,6 +43,10 @@ The Terraform Registry is unaware if you remove a file, a tag, a release, or oth
 
 If you find a typo, bug, or other issues with a published version of your provider, module, or policy library, [we recommend fixing the problem and publishing a new release](#how-do-i-correct-bugs-in-published-versions).
 
+## How do I change the image associated with my artifacts?
+
+The image is associated with the GitHub user or organization profile. Customize the [user profile](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/personalizing-your-profile) or [organization profile](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile) to update the image.
+
 ## Can I change the name of my artifact?
 
 Once consumers start using your provider, module, or policy library, the name of the artifact must remain constant. Otherwise,  you could break your consumer's Terraform configuration.


### PR DESCRIPTION
### What

Add artifact image answer to Registry FAQ page. Not sure if there are additional steps or information necessary.

### Why

Reference: https://discuss.hashicorp.com/t/how-can-i-add-company-logo-for-the-terraform-provider/63773

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
