### PR TITLE
Update global run tasks documentation for general release

### DIFF
--- a/website/docs/cloud-docs/api-docs/run-tasks/run-tasks.mdx
+++ b/website/docs/cloud-docs/api-docs/run-tasks/run-tasks.mdx
@@ -76,18 +76,18 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required unless otherwise specified.
 
-| Key path                                                            | Type            | Default | Description                                                                                                                                                      |
-| ------------------------------------------------------------------- | --------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data.type`                                                         | string          |         | Must be `"tasks"`.                                                                                                                                               |
-| `data.attributes.name`                                              | string          |         | The name of the task. Can include letters, numbers, `-`, and `_`.                                                                                                |
-| `data.attributes.url`                                               | string          |         | URL to send a run task payload.                                                                                                                                  |
-| `data.attributes.description`                                       | string          |         | The description of the run task. Can be up to 300 characters long including spaces, letters, numbers, and special characters.                                    |
-| `data.attributes.category`                                          | string          |         | Must be `"task"`.                                                                                                                                                |
-| `data.attributes.hmac-key`                                          | string          |         | (Optional) HMAC key to verify run task.                                                                                                                          |
-| `data.attributes.enabled`                                           | bool            | true    | (Optional) Whether the task will be run.                                                                                                                         |
-| `data.attributes.global-configuration.enabled` **(beta)**           | bool            | false   | (Optional) Whether the task will be associated on all workspaces.                                                                                                |
-| `data.attributes.global-configuration.stages` **(beta)**            | array |         | (Optional) An array of strings representing the stages of the run lifecycle when the run task should begin. Must be one or more of `"pre_plan"`, `"post_plan"`, `"pre_apply"`, or `"post_apply"`. |
-| `data.attributes.global-configuration.enforcement-level` **(beta)** | string          |         | (Optional) The enforcement level of the workspace task. Must be `"advisory"` or `"mandatory"`.                                                                   |
+| Key path                                                 | Type            | Default | Description                                                                                                                                                      |
+| -------------------------------------------------------- | --------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data.type`                                              | string          |         | Must be `"tasks"`.                                                                                                                                               |
+| `data.attributes.name`                                   | string          |         | The name of the task. Can include letters, numbers, `-`, and `_`.                                                                                                |
+| `data.attributes.url`                                    | string          |         | URL to send a run task payload.                                                                                                                                  |
+| `data.attributes.description`                            | string          |         | The description of the run task. Can be up to 300 characters long including spaces, letters, numbers, and special characters.                                    |
+| `data.attributes.category`                               | string          |         | Must be `"task"`.                                                                                                                                                |
+| `data.attributes.hmac-key`                               | string          |         | (Optional) HMAC key to verify run task.                                                                                                                          |
+| `data.attributes.enabled`                                | bool            | true    | (Optional) Whether the task will be run.                                                                                                                         |
+| `data.attributes.global-configuration.enabled`           | bool            | false   | (Optional) Whether the task will be associated on all workspaces.                                                                                                |
+| `data.attributes.global-configuration.stages`            | array |         | (Optional) An array of strings representing the stages of the run lifecycle when the run task should begin. Must be one or more of `"pre_plan"`, `"post_plan"`, `"pre_apply"`, or `"post_apply"`. |
+| `data.attributes.global-configuration.enforcement-level` | string          |         | (Optional) The enforcement level of the workspace task. Must be `"advisory"` or `"mandatory"`.                                                                   |
 
 ### Sample Payload
 
@@ -333,18 +333,18 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 Properties without a default value are required unless otherwise specified.
 
-| Key path                                                            | Type            | Default          | Description                                                                                                                                                      |
-| ------------------------------------------------------------------- | --------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data.type`                                                         | string          |                  | Must be `"tasks"`.                                                                                                                                               |
-| `data.attributes.name`                                              | string          | (previous value) | The name of the run task. Can include letters, numbers, `-`, and `_`.                                                                                            |
-| `data.attributes.url`                                               | string          | (previous value) | URL to send a run task payload.                                                                                                                                  |
-| `data.attributes.description`                                       | string          |                  | The description of the run task. Can be up to 300 characters long including spaces, letters, numbers, and special characters.                                    |
-| `data.attributes.category`                                          | string          | (previous value) | Must be `"task"`.                                                                                                                                                |
-| `data.attributes.hmac-key`                                          | string          | (previous value) | (Optional) HMAC key to verify run task.                                                                                                                          |
-| `data.attributes.enabled`                                           | bool            | (previous value) | (Optional) Whether the task will be run.                                                                                                                         |
-| `data.attributes.global-configuration.enabled` **(beta)**           | bool            | (previous value) | (Optional) Whether the task will be associated on all workspaces.                                                                                                |
-| `data.attributes.global-configuration.stages` **(beta)**            | array | (previous value) | (Optional) An array of strings representing the stages of the run lifecycle when the run task should begin. Must be one or more of `"pre_plan"`, `"post_plan"`, `"pre_apply"`, or `"post_apply"`. |
-| `data.attributes.global-configuration.enforcement-level` **(beta)** | string          | (previous value) | (Optional) The enforcement level of the workspace task. Must be `"advisory"` or `"mandatory"`.                                                                   |
+| Key path                                                 | Type            | Default          | Description                                                                                                                                                      |
+| -------------------------------------------------------- | --------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data.type`                                              | string          |                  | Must be `"tasks"`.                                                                                                                                               |
+| `data.attributes.name`                                   | string          | (previous value) | The name of the run task. Can include letters, numbers, `-`, and `_`.                                                                                            |
+| `data.attributes.url`                                    | string          | (previous value) | URL to send a run task payload.                                                                                                                                  |
+| `data.attributes.description`                            | string          |                  | The description of the run task. Can be up to 300 characters long including spaces, letters, numbers, and special characters.                                    |
+| `data.attributes.category`                               | string          | (previous value) | Must be `"task"`.                                                                                                                                                |
+| `data.attributes.hmac-key`                               | string          | (previous value) | (Optional) HMAC key to verify run task.                                                                                                                          |
+| `data.attributes.enabled`                                | bool            | (previous value) | (Optional) Whether the task will be run.                                                                                                                         |
+| `data.attributes.global-configuration.enabled`           | bool            | (previous value) | (Optional) Whether the task will be associated on all workspaces.                                                                                                |
+| `data.attributes.global-configuration.stages`            | array | (previous value) | (Optional) An array of strings representing the stages of the run lifecycle when the run task should begin. Must be one or more of `"pre_plan"`, `"post_plan"`, `"pre_apply"`, or `"post_apply"`. |
+| `data.attributes.global-configuration.enforcement-level` | string          | (previous value) | (Optional) The enforcement level of the workspace task. Must be `"advisory"` or `"mandatory"`.                                                                   |
 
 ### Sample Payload
 
@@ -474,13 +474,14 @@ This POST endpoint requires a JSON object with the following properties as a req
 
 Properties without a default value are required.
 
-| Key path                            | Type   | Default       | Description                                                                                                        |
-|-------------------------------------|--------|---------------|--------------------------------------------------------------------------------------------------------------------|
-| `data.type`                         | string |               | Must be `"workspace-tasks"`.                                                                                       |
-| `data.attributes.enforcement-level` | string |               | The enforcement level of the workspace task. Must be `"advisory"` or `"mandatory"`.                                |
-| `data.attributes.stage`             | string | `"post_plan"` | The stage in the run lifecycle when the run task should begin. Must be `"pre_plan"`, `"post_plan"`, `"pre_apply"`, or `"post_apply"`. |
-| `data.relationships.task.data.id`   | string |               | The ID of the run task.                                                                                            |
-| `data.relationships.task.data.type` | string |               | Must be `"tasks"`.                                                                                                 |
+| Key path                            | Type   | Default         | Description                                                                                                                                                                            |
+|-------------------------------------|--------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `data.type`                         | string |                 | Must be `"workspace-tasks"`.                                                                                                                                                           |
+| `data.attributes.enforcement-level` | string |                 | The enforcement level of the workspace task. Must be `"advisory"` or `"mandatory"`.                                                                                                    |
+| `data.attributes.stage`             | string | `"post_plan"`   | **DEPRECATED** Use `stages` instead. The stage in the run lifecycle when the run task should begin. Must be `"pre_plan"`, `"post_plan"`, `"pre_apply"`, or `"post_apply"`.             |
+| `data.attributes.stages`            | array  | `["post_plan"]` | An array of strings representing the stages of the run lifecycle when the run task should begin. Must be one or more of `"pre_plan"`, `"post_plan"`, `"pre_apply"`, or `"post_apply"`. |
+| `data.relationships.task.data.id`   | string |                 | The ID of the run task.                                                                                                                                                                |
+| `data.relationships.task.data.type` | string |                 | Must be `"tasks"`.                                                                                                                                                                     |
 
 ### Sample Payload
 
@@ -490,7 +491,7 @@ Properties without a default value are required.
     "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "advisory",
-        "stage": "post_plan"
+        "stages": ["post_plan"]
       },
       "relationships": {
         "task": {
@@ -524,7 +525,8 @@ curl \
       "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "advisory",
-        "stage": "post_plan"
+        "stage": "post_plan",
+        "stages": ["post_plan"]
       },
       "relationships": {
         "task": {
@@ -587,7 +589,8 @@ curl \
       "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "advisory",
-        "stage": "post_plan"
+        "stage": "post_plan",
+        "stages": ["post_plan"]
       },
       "relationships": {
         "task": {
@@ -659,7 +662,8 @@ curl --request GET \
       "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "advisory",
-        "stage": "post_plan"
+        "stage": "post_plan",
+        "stages": ["post_plan"]
       },
       "relationships": {
         "task": {
@@ -702,11 +706,12 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 
 Properties without a default value are required.
 
-| Key path                            | Type   | Default          | Description                                                                                           |
-|-------------------------------------|--------|------------------|-------------------------------------------------------------------------------------------------------|
-| `data.type`                         | string | (previous value) | Must be `"workspace-tasks"`.                                                                          |
-| `data.attributes.enforcement-level` | string | (previous value) | The enforcement level of the workspace run task. Must be `"advisory"` or `"mandatory"`.               |
-| `data.attributes.stage`             | string | (previous value) | The stage in the run lifecycle when the run task should begin. Must be `"pre_plan"` or `"post_plan"`. |
+| Key path                            | Type   | Default          | Description                                                                                                                                                                            |
+|-------------------------------------|--------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `data.type`                         | string | (previous value) | Must be `"workspace-tasks"`.                                                                                                                                                           |
+| `data.attributes.enforcement-level` | string | (previous value) | The enforcement level of the workspace run task. Must be `"advisory"` or `"mandatory"`.                                                                                                |
+| `data.attributes.stage`             | string | (previous value) | **DEPRECATED** Use `stages` instead. The stage in the run lifecycle when the run task should begin. Must be `"pre_plan"` or `"post_plan"`.                                             |
+| `data.attributes.stages`            | array  | (previous value) | An array of strings representing the stages of the run lifecycle when the run task should begin. Must be one or more of `"pre_plan"`, `"post_plan"`, `"pre_apply"`, or `"post_apply"`. |
 
 ### Sample Payload
 
@@ -756,7 +761,8 @@ curl \
       "type": "workspace-tasks",
       "attributes": {
         "enforcement-level": "mandatory",
-        "stage": "post_plan"
+        "stage": "post_plan",
+        "stages": ["post_plan"]
       },
       "relationships": {
         "task": {

--- a/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/run-tasks.mdx
@@ -48,7 +48,7 @@ To create a new run task:
 
 1. Click **Create run task**. The run task is now available within the organization, and you can associate it with one or more workspaces.
 
-### Global Run Tasks (Beta)
+### Global Run Tasks
 
 When you create a new run task you may choose to apply to all workspaces in the organization. This feature requires the **global-run-task** [entitlement][].
 


### PR DESCRIPTION
### What

This commit updates the run task documentation, indicating that the global run task feature is now no longer beta, but generally available.

### Why

Because it's not beta anymore

### Screenshots

N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
