### PR TITLE
API Docs: Variable Sets searchable

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,9 @@ description: >-
 
 Keep track of changes to the API for Terraform Cloud and Terraform Enterprise.
 
+## 2024-3-26
+* Add API documentation searching [Variable Sets](/terraform/cloud-docs/api-docs/variable-sets#list-variable-sets) by name.
+
 ## 2024-3-14
 * Add documentation for creating runs with debugging mode enabled.
 

--- a/website/docs/cloud-docs/api-docs/variable-sets.mdx
+++ b/website/docs/cloud-docs/api-docs/variable-sets.mdx
@@ -400,12 +400,13 @@ attached to the project this workspace is contained within.
 
 ### Query Parameters
 
-All of the list endpoints support pagination [with standard URL query parameters](/terraform/cloud-docs/api-docs#query-parameters). Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+All of the list endpoints support pagination [with standard URL query parameters](/terraform/cloud-docs/api-docs#query-parameters) and search through the `q` parameter. Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
 
 | Parameter      | Description                                                         |
 |----------------|---------------------------------------------------------------------|
 | `page[number]` | **Optional.** If omitted, the endpoint returns the first page.      |
 | `page[size]`   | **Optional.** If omitted, the endpoint returns 20 varsets per page. |
+| `q`            | **Optional.** A search query string. Variable sets are searchable by name. |
 
 ### Sample Response
 


### PR DESCRIPTION
### What
I noticed that we are missing API docs for searching Variable Sets by name in our API docs.

The `q` parameter is available for listing variable sets on organizations, workspaces, and projects.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
