### PR TITLE
Update health.mdx

### DIFF
--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -192,7 +192,7 @@ data "hcp_packer_artifact" "hashiapp_image" {
 }
 
 resource "aws_instance" "hashiapp" {
-  ami                         = data.hcp_packer_artifact.hashiapp_image.cloud_image_id
+  ami                         = data.hcp_packer_artifact.hashiapp_image.cloud_external_identifier
   instance_type               = var.instance_type
   associate_public_ip_address = true
   subnet_id                   = aws_subnet.hashiapp.id
@@ -212,8 +212,8 @@ check "ami_version_check" {
   }
 
   assert {
-    condition = aws_instance.hashiapp.ami == data.hcp_packer_artifact.hashiapp_image.cloud_image_id
-    error_message = "Must use the latest available AMI, ${data.hcp_packer_artifact.hashiapp_image.cloud_image_id}."
+    condition = aws_instance.hashiapp.ami == data.hcp_packer_artifact.hashiapp_image.cloud_external_identifier
+    error_message = "Must use the latest available AMI, ${data.hcp_packer_artifact.hashiapp_image.cloud_external_identifier}."
   }
 }
 ```

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -184,7 +184,7 @@ check "certificate_valid" {
 [HCP Packer](/hcp/docs/packer) stores metadata about your [Packer](https://www.packer.io/) images. The following example check fails when there is a newer AMI version available.
 
 ```hcl
-data "hcp_packer_image" "hashiapp_image" {
+data "hcp_packer_artifact" "hashiapp_image" {
   bucket_name     = "hashiapp"
   channel         = "latest"
   cloud_provider  = "aws"
@@ -192,7 +192,7 @@ data "hcp_packer_image" "hashiapp_image" {
 }
 
 resource "aws_instance" "hashiapp" {
-  ami                         = data.hcp_packer_image.hashiapp_image.cloud_image_id
+  ami                         = data.hcp_packer_artifact.hashiapp_image.cloud_image_id
   instance_type               = var.instance_type
   associate_public_ip_address = true
   subnet_id                   = aws_subnet.hashiapp.id
@@ -212,8 +212,8 @@ check "ami_version_check" {
   }
 
   assert {
-    condition = aws_instance.hashiapp.ami == data.hcp_packer_image.hashiapp_image.cloud_image_id
-    error_message = "Must use the latest available AMI, ${data.hcp_packer_image.hashiapp_image.cloud_image_id}."
+    condition = aws_instance.hashiapp.ami == data.hcp_packer_artifact.hashiapp_image.cloud_image_id
+    error_message = "Must use the latest available AMI, ${data.hcp_packer_artifact.hashiapp_image.cloud_image_id}."
   }
 }
 ```

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -185,14 +185,14 @@ check "certificate_valid" {
 
 ```hcl
 data "hcp_packer_artifact" "hashiapp_image" {
-  bucket_name     = "hashiapp"
-  channel         = "latest"
-  cloud_provider  = "aws"
-  region          = "us-west-2"
+  bucket_name  = "hashiapp"
+  channel_name = "latest"
+  platform     = "aws"
+  region       = "us-west-2"
 }
 
 resource "aws_instance" "hashiapp" {
-  ami                         = data.hcp_packer_artifact.hashiapp_image.cloud_external_identifier
+  ami                         = data.hcp_packer_artifact.hashiapp_image.external_identifier
   instance_type               = var.instance_type
   associate_public_ip_address = true
   subnet_id                   = aws_subnet.hashiapp.id
@@ -212,8 +212,8 @@ check "ami_version_check" {
   }
 
   assert {
-    condition = aws_instance.hashiapp.ami == data.hcp_packer_artifact.hashiapp_image.cloud_external_identifier
-    error_message = "Must use the latest available AMI, ${data.hcp_packer_artifact.hashiapp_image.cloud_external_identifier}."
+    condition = aws_instance.hashiapp.ami == data.hcp_packer_artifact.hashiapp_image.external_identifier
+    error_message = "Must use the latest available AMI, ${data.hcp_packer_artifact.hashiapp_image.external_identifier}."
   }
 }
 ```


### PR DESCRIPTION
update code examples to use hcp_packer_artifact (Data Source) no hcp_packer_image (Data Source) as removed from  https://github.com/hashicorp/terraform-provider-hcp/releases/tag/v0.84.0

### What
<!-- Explain what you changed and provide a list of changed page names. -->

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
