### PR TITLE
Update run tasks docs and speculative plans to reflect present UI

### DIFF
--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -95,11 +95,9 @@ If a plan contains no changes, Terraform Cloud does not attempt to apply it. Ins
 
 ### Speculative Plans
 
-In addition to normal runs, Terraform Cloud can also run _speculative plans_, to test changes to a configuration during editing and code review. Speculative plans are plan-only runs. They show possible changes, and policies affected by those changes, but cannot apply any changes.
+In addition to normal runs, Terraform Cloud can run _speculative plans_ to test changes to a configuration during editing and code review. Speculative plans are plan-only runs. They show possible changes, and policies affected by those changes, but cannot apply any changes.
 
 Speculative plans can begin without waiting for other runs to finish because they don't affect real infrastructure. Terraform Cloud lists past speculative plan runs alongside a workspace's other runs.
-
-Speculative plans do not appear in a workspace's list of runs; viewing them requires a direct link, which is provided when the plan is initiated.
 
 There are three ways to run speculative plans:
 

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -95,9 +95,11 @@ If a plan contains no changes, Terraform Cloud does not attempt to apply it. Ins
 
 ### Speculative Plans
 
-In addition to normal runs, Terraform Cloud can also run _speculative plans,_ to test changes to a configuration during editing and code review.
+In addition to normal runs, Terraform Cloud can also run _speculative plans_, to test changes to a configuration during editing and code review. Speculative plans are plan-only runs. They show possible changes, and policies affected by those changes, but cannot apply any changes.
 
-Speculative plans are plan-only runs: they show a set of possible changes (and check them against Sentinel policies), but cannot apply those changes. They can begin at any time without waiting for other runs, since they don't affect real infrastructure. Speculative plans do not appear in a workspace's list of runs; viewing them requires a direct link, which is provided when the plan is initiated.
+Speculative plans can begin without waiting for other runs to finish because they don't affect real infrastructure. Terraform Cloud lists past speculative plan runs alongside a workspace's other runs.
+
+Speculative plans do not appear in a workspace's list of runs; viewing them requires a direct link, which is provided when the plan is initiated.
 
 There are three ways to run speculative plans:
 

--- a/website/docs/cloud-docs/run/states.mdx
+++ b/website/docs/cloud-docs/run/states.mdx
@@ -7,9 +7,9 @@ description: >-
 
 # Run States and Stages
 
-Each run passes through several stages of action (pending, plan, cost estimation, policy check, apply, and completion), and Terraform Cloud shows the progress through those stages as run states.
+Each plan and apply run passes through several stages of action: pending, plan, cost estimation, policy check, apply, and completion. Terraform Cloud shows a run's progress through each stage as a run state.
 
-In the list of workspaces on Terraform Cloud's main page, each workspace shows the state of the run it's currently processing. (Or, if no run is in progress, the state of the most recent completed run.)
+In the list of workspaces on Terraform Cloud's main page, each workspace shows the state of the run it's currently processing. If no run is in progress, Terraform Cloud displays the state of the most recently completed run.
 
 ## The Pending Stage
 


### PR DESCRIPTION
Fixing the speculative plan docs to reflect you can see speculative plan in runs list. Also, small tweak to the run states docs to reflect they apply to 'plan and apply' plans.