### PR TITLE
Updated the project name charater limit to 40 characters

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,9 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
+## 2024-04-25
+* Update [Projects API](/terraform/cloud-docs/api-docs/projects) documentation for creating and updating a project. Project name can now be up to 40 characters
+
 ## 2024-04-08
 * Add API documentation for new [team management permissions](/terraform/cloud-docs/users-teams-organizations/permissions#team-management-permissions).
 

--- a/website/docs/cloud-docs/api-docs/projects.mdx
+++ b/website/docs/cloud-docs/api-docs/projects.mdx
@@ -59,7 +59,7 @@ Properties without a default value are required.
 | Key path                      | Type   | Default   | Description                                                                                                                                                                                           |
 |-------------------------------|--------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `data.type`                   | string |           | Must be `"projects"`.                                                                                                                                                                                 |
-| `data.attributes.name`        | string |           | The name of the project. The name can contain letters, numbers, spaces, `-`, and `_`, but cannot start or end with spaces. It must be at least 3 characters long and no more than 36 characters long. |
+| `data.attributes.name`        | string |           | The name of the project. The name can contain letters, numbers, spaces, `-`, and `_`, but cannot start or end with spaces. It must be at least 3 characters long and no more than 40 characters long. |
 | `data.attributes.description` | string | (nothing) | **Optional.** The description of the project. It must be no more than 256 characters long.                                                                                                            |
 
 ### Sample Payload
@@ -125,7 +125,7 @@ Properties without a default value are required.
 | Key path                      | Type   | Default          | Description                                                                                                                                                                                              |
 |-------------------------------|--------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `data.type`                   | string |                  | Must be `"projects"`.                                                                                                                                                                                    |
-| `data.attributes.name`        | string | (previous value) | A new name for the project. The name can contain letters, numbers, spaces, `-`, and `_`, but cannot start or end with spaces. It must be at least 3 characters long and no more than 36 characters long. |
+| `data.attributes.name`        | string | (previous value) | A new name for the project. The name can contain letters, numbers, spaces, `-`, and `_`, but cannot start or end with spaces. It must be at least 3 characters long and no more than 40 characters long. |
 | `data.attributes.description` | string | (previous value) | The new description for the project. It must be no more than 256 characters long.                                                                                                                        |
 
 


### PR DESCRIPTION
### What

This PR updates the max Project name char limit for create/update project from 36 to 40

### Why
[Please see this Jira ticket for more info](https://hashicorp.atlassian.net/browse/TF-11739)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [X] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
