### PR TITLE
TF-13302: Adds Runs to Organization Settings

### DIFF
--- a/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
@@ -153,7 +153,7 @@ HCP Terraform can perform automatic health assessments in a workspace to assess 
 You can enforce health assessments for all eligible workspaces or let each workspace opt in to health assessments through workspace settings. Refer to [Health](/terraform/cloud-docs/workspaces/health) in the workspaces documentation for more details.
 
 #### Runs
-From the Workspaces page, click **Settings** in the sidebar, then **Runs**  to view current runs in all workspaces. You can perform the following actions:
+From the Workspaces page, click **Settings** in the sidebar, then **Runs** to view current runs in all workspaces. You can perform the following actions:
 
 - Click **Needs Attention** to filter runs that requires user input, such as approving the plan or overriding a policy, to continue. 
 - Click **Running** to filter for runs that are in progress. 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
@@ -153,9 +153,14 @@ HCP Terraform can perform automatic health assessments in a workspace to assess 
 You can enforce health assessments for all eligible workspaces or let each workspace opt in to health assessments through workspace settings. Refer to [Health](/terraform/cloud-docs/workspaces/health) in the workspaces documentation for more details.
 
 #### Runs
-View all the current runs from your workspaces in HCP Terraform.
-From this page, you can delete a current run from different workspaces, filtering by `Needs Attention`, `Running` or `On Hold`.
-All the runs can also be sorted by `Latest change` or alphabetically by `Workspace/Project`.
+From the Workspaces page, click **Settings** in the sidebar, then **Runs**  to view current runs in all workspaces. You can perform the following actions:
+
+- Click **Needs Attention** to filter runs that requires user input, such as approving the plan or overriding a policy, to continue. 
+- Click **Running** to filter for runs that are in progress. 
+- Click **On Hold** to filter runs that have paused. 
+- Click on a column header to display runs in alphanumeric order according to the most recent change or workspace name.  
+
+Refer to [Run States and Stages](/terraform/cloud-docs/run/states) for additional information about understanding run states.
 
 ### Integrations
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
@@ -152,6 +152,10 @@ HCP Terraform can perform automatic health assessments in a workspace to assess 
 
 You can enforce health assessments for all eligible workspaces or let each workspace opt in to health assessments through workspace settings. Refer to [Health](/terraform/cloud-docs/workspaces/health) in the workspaces documentation for more details.
 
+#### Runs
+View all the current runs from your workspaces in HCP Terraform.
+From this page, you can delete a current run from different workspaces, filtering by `Needs Attention`, `Running` or `On Hold`.
+All the runs can also be sorted by `Latest change` or alphabetically by `Workspace/Project`.
 
 ### Integrations
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
`/terraform/cloud-docs/users-teams-organizations/organizations` now will have Runs menu, where the new functionality is explained

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
Since we recently added a new feature for Organization Settings, we are updating the docs to reflect this new state.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->
![image](https://github.com/hashicorp/terraform-docs-common/assets/7681028/1dfcc8bf-6e1c-4d91-9cd2-5e287e92e9aa)

This documentation reflects this functionality:
![image](https://github.com/hashicorp/terraform-docs-common/assets/7681028/11ef776f-029d-4050-ae99-a52e89455218)



----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [n/a] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [n/a] API documentation and the API Changelog have been updated. 
- [n/a] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [n/a] Pages with related content are updated and link to this content when appropriate.
- [n/a] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [n/a] New pages have metadata (page name and description) at the top.
- [n/a] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [n/a] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
