### PR TITLE
website/docs/cloud-docs/integrations/kubernetes: Update migration guide

### DIFF
--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -255,7 +255,7 @@ $ kubectl diff --filename workspaces_patch_a.yaml
 
 Patch the workspace CRD with **patch A**. This patch adds `app.terraform.io/v1alpha2` support, but excludes `.status.runStatus` because it has a different format in `app.terraform.io/v1alpha1` and causes JSON unmarshalling issues.
 
-~> **Warning** Once the patch is applied, Kubernetes will convert existing `app.terraform.io/v1alpha1` custom resources to `app.terraform.io/v1alpha2` according to the updated schema and v1 of the operator will no longer serve custom resources. You must update existing custom resources to satisfy the current schema. Refer to the tables above for a mapping of resource fields between v1 and v2 of the operator.
+!> **Upgrade warning**: Once you apply a patch, Kubernetes converts existing `app.terraform.io/v1alpha1` custom resources to `app.terraform.io/v1alpha2` according to the updated schema, meaning that v1 of the operator can no longer serve custom resources. Before patching, update your existing custom resources to satisfy the v2 schema requirements. [Learn more](#manifest-schema-migration).
 
 ```shell-session
 $ kubectl patch crd workspaces.app.terraform.io --patch-file workspaces_patch_a.yaml

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -51,39 +51,39 @@ Version 2 of the Terraform Cloud Kubernetes operator renames and moves many exis
 
 The table below lists the field mapping of the `Workspace` controller between v1 and v2 of the operator.
 
-| Version 1 | Version 2 | Notes |
+| Version 1 | Version 2 | Changes between versions |
 | --- | --- | --- |
 | `apiVersion: app.terraform.io/v1alpha1` | `apiVersion: app.terraform.io/v1alpha2` | The `apiVersion` is now `v1alpha2`. |
-| `kind: Workspace` | `kind: Workspace` |  |
-| `metadata` | `metadata` |  |
-| `spec.organization` | `spec.organization` |  |
+| `kind: Workspace` | `kind: Workspace` | None. |
+| `metadata` | `metadata` | None. |
+| `spec.organization` | `spec.organization` | None. |
 | `spec.secretsMountPath` | `spec.token.secretKeyRef` | In v2 the operator keeps the HCP Terraform access token in a Kubernetes Secret. |
-| `spec.vcs` | `spec.versionControl` | Renamed. Refer to the `versionControl` structure for details. |
-| `spec.vcs.token_id` | `spec.versionControl.oAuthTokenID` | Renamed. Refer to the `versionControl` structure for details. |
-| `spec.vcs.repo_identifier` | `spec.versionControl.repository` | Renamed. Refer to the `versionControl` structure for details. |
-| `spec.vcs.branch` | `spec.versionControl.branch` |  |
+| `spec.vcs` | `spec.versionControl` | Renamed the `vcs` field to `versionControl`. |
+| `spec.vcs.token_id` | `spec.versionControl.oAuthTokenID` | Renamed the `token_id` field to `oAuthTokenID`. |
+| `spec.vcs.repo_identifier` | `spec.versionControl.repository` | Renamed the `repo_identifier` field to `repository`. |
+| `spec.vcs.branch` | `spec.versionControl.branch` | None. |
 | `spec.vcs.ingress_submodules` | `spec.workingDirectory` | Moved. |
-| `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | We split variables into two possible places. In v1's CRD, if `spec.variables.environmentVariable` was `true`, migrate those variables to `spec.environmentVariables`. If `false`, migrate those variables to `spec.terraformVariables`. |
-| `spec.variables.[*]key` | `spec.environmentVariables.[*]name` OR `spec.terraformVariables.[*]name` | Renamed the `key` field as `name`. |
-| `spec.variables.[*]value` | `spec.environmentVariables.[*]value` OR `spec.terraformVariables.[*]value` |  |
-| `spec.variables.[*]valueFrom` | `spec.environmentVariables.[*]valueFrom` OR `spec.terraformVariables.[*]valueFrom` |  |
-| `spec.variables.[*]hcl` | `spec.environmentVariables.[*]hcl` OR `spec.terraformVariables.[*]hcl` |  |
-| `spec.variables.sensitive` |  `spec.environmentVariables.[*]sensitive` OR `spec.terraformVariables.[*]sensitive` |  |
+| `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | <a id="workspace-variables"></a>We split variables into two possible places. In v1's CRD, if `spec.variables.environmentVariable` was `true`, migrate those variables to `spec.environmentVariables`. If `false`, migrate those variables to `spec.terraformVariables`. |
+| `spec.variables.[*]key` | `spec.environmentVariables.[*]name` OR `spec.terraformVariables.[*]name` | Renamed the `key` field as `name`. [Learn more](#workspace-variables).|
+| `spec.variables.[*]value` | `spec.environmentVariables.[*]value` OR `spec.terraformVariables.[*]value` | [Learn more](#workspace-variables). |
+| `spec.variables.[*]valueFrom` | `spec.environmentVariables.[*]valueFrom` OR `spec.terraformVariables.[*]valueFrom` | [Learn more](#workspace-variables). |
+| `spec.variables.[*]hcl` | `spec.environmentVariables.[*]hcl` OR `spec.terraformVariables.[*]hcl` | [Learn more](#workspace-variables). |
+| `spec.variables.sensitive` |  `spec.environmentVariables.[*]sensitive` OR `spec.terraformVariables.[*]sensitive` | [Learn more](#workspace-variables). |
 | `spec.variables.environmentVariable` | N/A | Removed, variables are split between `spec.environmentVariables` and `spec.terraformVariables`. |
-| `spec.runTriggers.[*]` | `spec.runTriggers.[*]` |  Changes made to the `runTriggers` structure. |
+| `spec.runTriggers.[*]` | `spec.runTriggers.[*]` | None. |
 | `spec.runTriggers.[*].sourceableName` | `spec.runTriggers.[*].name` | The `sourceableName` field is now `name`. |
 | `spec.sshKeyID` | `spec.sshKey.id` | Moved the `sshKeyID` to `spec.sshKey.id`. |
 | `spec.outputs` | N/A | Removed. |
-| `spec.terraformVersion` | `spec.terraformVersion` |  |
-| `spec.notifications` | `spec.notifications` |  Changes made to the `notification` structure. |
-| `spec.notifications.type` | `spec.notifications.type` |  |
-| `spec.notifications.enabled` | `spec.notifications.enabled` |  |
-| `spec.notifications.name` | `spec.notifications.name` |  |
-| `spec.notifications.url` | `spec.notifications.url` |  |
-| `spec.notifications.token` | `spec.notifications.token` |  |
-| `spec.notifications.triggers.[*]` | `spec.notifications.triggers.[*]` |  |
-| `spec.notifications.recepients.[*]` | `spec.notifications.emailAddesses.[*]` | Renamed the `recepients` field to `emailAddesses`. |
-| `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | Renamed the `users` field to `emailUsers`. |
+| `spec.terraformVersion` | `spec.terraformVersion` | None. |
+| `spec.notifications.[*]` | `spec.notifications.[*]` | None. |
+| `spec.notifications.[*].type` | `spec.notifications.[*].type` | None. |
+| `spec.notifications.[*].enabled` | `spec.notifications.[*].enabled` | None. |
+| `spec.notifications.[*].name` | `spec.notifications.[*].name` | None. |
+| `spec.notifications.[*].url` | `spec.notifications.[*].url` | None. |
+| `spec.notifications.[*].token` | `spec.notifications.[*].token` | None. |
+| `spec.notifications.[*].triggers.[*]` | `spec.notifications.[*].triggers.[*]` | None. |
+| `spec.notifications.[*].recepients.[*]` | `spec.notifications.[*].emailAddesses.[*]` | Renamed the `recepients` field to `emailAddesses`. |
+| `spec.notifications.[*].users.[*]` | `spec.notifications.[*].emailUsers.[*]` | Renamed the `users` field to `emailUsers`. |
 | `spec.omitNamespacePrefix` | N/A | Removed. In v1 `spec.omitNamespacePrefix` is a boolean field that affects how the operator generates a workspace name. In v2, you must explicitly set workspace names in `spec.name`. |
 | `spec.agentPoolID` | `spec.agentPool.id` | Moved the `agentPoolID` field to `spec.agentPool.id`. |
 | `spec.agentPoolName` | `spec.agentPool.name` | Moved the `agentPoolName` field to `spec.agentPool.name`. |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -322,7 +322,7 @@ The `finalizer` exists to provide greater control over the migration process. Ve
 $ kubectl patch workspace migration --type=merge --patch '{"metadata": {"finalizers": ["workspace.app.terraform.io/finalizer"]}}'
 ```
 
-Review the operator logs once more and verify there are no error messages reported.
+Review the operator logs once more and verify there are no error messages.
 
 ```shell-session
 $ kubectl logs -f <POD_NAME>

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -166,7 +166,7 @@ The table below details the mapping between the `Workspace` controller in v1 of 
 | `spec.module.source` | `spec.module.source` | This supports all Terraform [module sources](https://developer.hashicorp.com/terraform/language/modules/sources). |
 | `spec.module.version` | `spec.module.version` | Refer to  [module sources](https://developer.hashicorp.com/terraform/language/modules/sources) for versioning information for each module source. |
 | `spec.variables.[*]` | `spec.variables.[*].name` | Variable names should be included in the module. This is a reference to variables in the Workspace where the module will be executed. |
-| `spec.outputs.[*].key` | `spec.outputs.[*].name` | Output names should be included in the module. This is a reference to the output variables produced by the module. |
+| `spec.outputs.[*].key` | `spec.outputs.[*].name` | You should include output names in the module. This is a reference to the output variables produced by the module. |
 | `status.workspaceID` OR `metadata.namespace-metadata.name` | `spec.workspace.id` OR `spec.workspace.name` | The workspace where the module is executed. The workspace must be in the same organization. |
 
 Below is an example migration of a `Module` between v1 and v2 of the operator:

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -45,94 +45,102 @@ $ kubectl get workspace --all-namespaces -o yaml > backup_tfc_operator_v1.yaml
 
 ## Manifest schema migration
 
+In v2 of the operator, many fields have been renamed or moved. You must update your specification with these changes when you migrate to v2 of the operator.
+
 ### Workspace controller
 
-In the table below you can find field mapping between v1 and v2.
+Below is the field mapping of the `Workspace` controller from v1 to v2 of the operator.
 
 | Version 1 | Version 2 | Notes |
 | --- | --- | --- |
-| `apiVersion: app.terraform.io/v1alpha1` | `apiVersion: app.terraform.io/v1alpha2` | CHANGED. In v2 the `apiVersion` changed from `v1alpha1` to `v1alpha2`. |
-| `kind: Workspace` | `kind: Workspace` | DID NOT CHANGE. |
-| `metadata` | `metadata` | DID NOT CHANGE. Entire `metadata` section remained unchanged. |
-| `spec.organization` | `spec.organization` | DID NOT CHANGE. |
-| `spec.secretsMountPath` | `spec.token.secretKeyRef` | CHANGED. In v2 the operator keeps HCP Terraform access token in a Kubernetes Secret. |
-| `spec.vcs` | `spec.versionControl` | CHANGED. This field got a new name. See below changes inside the `versionControl` structure. |
-| `spec.vcs.token_id` | `spec.versionControl.oAuthTokenID` | CHANGED. This field got a new name. |
-| `spec.vcs.repo_identifier` | `spec.versionControl.repository` | CHANGED. This field got a new name. |
-| `spec.vcs.branch` | `spec.versionControl.branch` | DID NOT CHANGE. |
-| `spec.vcs.ingress_submodules` | `spec.workingDirectory` | CHANGED. This moved to a different level. |
-| `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | CHANGED. Variables were split into two different paths. It depends on the bool value `spec.variables.environmentVariable` in v1 CRD:<br/> - If it is `true` then a variable should be migrated to `spec.environmentVariables`.<br/> - If it is `false` then a variable should be migrated to `spec.terraformVariables`. |
-| `spec.variables.[*]key` | `spec.environmentVariables.[*]name` OR `spec.terraformVariables.[*]name` | CHANGED. In v2 `key` renamed to `name`. |
-| `spec.variables.[*]value` | `spec.environmentVariables.[*]value` OR `spec.terraformVariables.[*]value` | DID NOT CHANGE. |
-| `spec.variables.[*]valueFrom` | `spec.environmentVariables.[*]valueFrom` OR `spec.terraformVariables.[*]valueFrom` | DID NOT CHANGE. |
-| `spec.variables.[*]hcl` | `spec.environmentVariables.[*]hcl` OR `spec.terraformVariables.[*]hcl` | DID NOT CHANGE. |
-| `spec.variables.sensitive` |  `spec.environmentVariables.[*]sensitive` OR `spec.terraformVariables.[*]sensitive` | DID NOT CHANGE. |
-| `spec.variables.environmentVariable` | N/A. | REMOVED. In v2 `environmentVariable` was removed and variables were split into two different paths. |
-| `spec.runTriggers.[*]` | `spec.runTriggers.[*]` | DID NOT CHANGE. Changes were made inside the `runTriggers` structure, see below. |
-| `spec.runTriggers.[*].sourceableName` | `spec.runTriggers.[*].name` | CHANGED. In v2 `sourceableName` was renamed to `name`. |
-| `spec.sshKeyID` | `spec.sshKey.id` | CHANGED. In v2 `sshKeyID` was moved to `spec.sshKey.id`. |
-| `spec.outputs` | N/A. | REMOVED. In v2 `spec.outputs` does not exist. |
-| `spec.terraformVersion` | `spec.terraformVersion` | DID NOT CHANGE. |
-| `spec.notifications` | `spec.notifications` | DID NOT CHANGE. Changes were made inside the `notification` structure, see below. |
-| `spec.notifications.type` | `spec.notifications.type` | DID NOT CHANGE. |
-| `spec.notifications.enabled` | `spec.notifications.enabled` | DID NOT CHANGE. |
-| `spec.notifications.name` | `spec.notifications.name` | DID NOT CHANGE. |
-| `spec.notifications.url` | `spec.notifications.url` | DID NOT CHANGE. |
-| `spec.notifications.token` | `spec.notifications.token` | DID NOT CHANGE. |
-| `spec.notifications.triggers.[*]` | `spec.notifications.triggers.[*]` | DID NOT CHANGE. |
-| `spec.notifications.recepients.[*]` | `spec.notifications.emailAddesses.[*]` | CHANGED. In v2 `recepients` was changed to `emailAddesses`. |
-| `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | CHANGED. In v2 `users`was changed to `emailUsers`. |
-| `spec.omitNamespacePrefix` | N/A. | REMOVED. In v1 `spec.omitNamespacePrefix` is a boolean field and affects a Workspace name:<br/> - If it is `true` then a Workspace name will be generated as `metadata.namespace-metadata.name`.<br/> - If it is `false` then a Workspace name will be generated as `metadata.name`.<br/> In v2 a Workspace name must be explicitly set in `spec.name`. |
-| `spec.agentPoolID` | `spec.agentPool.id` | CHANGED. In v2 `agentPoolID` was moved to `spec.agentPool.id`. |
-| `spec.agentPoolName` | `spec.agentPool.name` | CHANGED. In v2 `agentPoolName` was moved to `spec.agentPool.name`. |
-| `spec.module` | N/A. | REMOVED. In v2 Module is a separate controller with its own CRD. See below the migration mapping. |
+| `apiVersion: app.terraform.io/v1alpha1` | `apiVersion: app.terraform.io/v1alpha2` | The `apiVersion` changed from `v1alpha1` to `v1alpha2`. |
+| `kind: Workspace` | `kind: Workspace` |  |
+| `metadata` | `metadata` |  |
+| `spec.organization` | `spec.organization` |  |
+| `spec.secretsMountPath` | `spec.token.secretKeyRef` | In v2 the operator keeps HCP Terraform access token in a Kubernetes Secret. |
+| `spec.vcs` | `spec.versionControl` | Renamed. Refer to the `versionControl` structure for details. |
+| `spec.vcs.token_id` | `spec.versionControl.oAuthTokenID` | Renamed. Refer to the `versionControl` structure for details. |
+| `spec.vcs.repo_identifier` | `spec.versionControl.repository` | Renamed. Refer to the `versionControl` structure for details. |
+| `spec.vcs.branch` | `spec.versionControl.branch` |  |
+| `spec.vcs.ingress_submodules` | `spec.workingDirectory` | Moved. |
+| `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | Variables were split into two different paths. <br/>It depends on the bool value `spec.variables.environmentVariable` in v1 CRD:<br/> - If it is `true` then a variable should be migrated to `spec.environmentVariables`.<br/> - If it is `false` then a variable should be migrated to `spec.terraformVariables`. |
+| `spec.variables.[*]key` | `spec.environmentVariables.[*]name` OR `spec.terraformVariables.[*]name` | The `key` field is renamed to `name`. |
+| `spec.variables.[*]value` | `spec.environmentVariables.[*]value` OR `spec.terraformVariables.[*]value` |  |
+| `spec.variables.[*]valueFrom` | `spec.environmentVariables.[*]valueFrom` OR `spec.terraformVariables.[*]valueFrom` |  |
+| `spec.variables.[*]hcl` | `spec.environmentVariables.[*]hcl` OR `spec.terraformVariables.[*]hcl` |  |
+| `spec.variables.sensitive` |  `spec.environmentVariables.[*]sensitive` OR `spec.terraformVariables.[*]sensitive` |  |
+| `spec.variables.environmentVariable` | N/A | Removed, variables are split to `spec.environmentVariables` and `spec.terraformVariables`. |
+| `spec.runTriggers.[*]` | `spec.runTriggers.[*]` |  Changes made to the `runTriggers` structure. |
+| `spec.runTriggers.[*].sourceableName` | `spec.runTriggers.[*].name` | The `sourceableName` field is renamed to `name`. |
+| `spec.sshKeyID` | `spec.sshKey.id` | The `sshKeyID` is moved to `spec.sshKey.id`. |
+| `spec.outputs` | N/A | Removed. |
+| `spec.terraformVersion` | `spec.terraformVersion` |  |
+| `spec.notifications` | `spec.notifications` |  Changes made to the `notification` structure. |
+| `spec.notifications.type` | `spec.notifications.type` |  |
+| `spec.notifications.enabled` | `spec.notifications.enabled` |  |
+| `spec.notifications.name` | `spec.notifications.name` |  |
+| `spec.notifications.url` | `spec.notifications.url` |  |
+| `spec.notifications.token` | `spec.notifications.token` |  |
+| `spec.notifications.triggers.[*]` | `spec.notifications.triggers.[*]` |  |
+| `spec.notifications.recepients.[*]` | `spec.notifications.emailAddesses.[*]` | The `recepients` field is renamed to `emailAddesses`. |
+| `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | The `users` field is renamed to `emailUsers`. |
+| `spec.omitNamespacePrefix` | N/A | Removed. In v1 `spec.omitNamespacePrefix` is a boolean field and affects a Workspace name:<br/> - If it is `true` then a Workspace name will be generated as `metadata.namespace-metadata.name`.<br/> - If it is `false` then a Workspace name will be generated as `metadata.name`.<br/> In v2 a Workspace name must be explicitly set in `spec.name`. |
+| `spec.agentPoolID` | `spec.agentPool.id` | The `agentPoolID` field is moved to `spec.agentPool.id`. |
+| `spec.agentPoolName` | `spec.agentPool.name` | The `agentPoolName` field is moved to `spec.agentPool.name`. |
+| `spec.module` | N/A | Removed. Modules are now configured with a separate `Module` CRD. Refer to the below migration mapping for more information. |
 
-Here is an example of variables migration.
+Below is an example of the differences is how variables are configured between v1 and v2.
 
-- Version 1.
+<CodeBlockConfig filename="v1.yaml">
 
-  ```yaml
-  apiVersion: app.terraform.io/v1alpha1
-  kind: Workspace
-  metadata:
-    name: migration
-    spec:
-      variables:
-        - key: username
-          value: "user"
-          hcl: true
-          sensitive: false
-          environmentVariable: false
-        - key: SECRET_KEY
-          value: "s3cr3t"
-          hcl: false
-          sensitive: false
-          environmentVariable: true
-  ```
+```yaml
+apiVersion: app.terraform.io/v1alpha1
+kind: Workspace
+metadata:
+  name: migration
+  spec:
+    variables:
+      - key: username
+        value: "user"
+        hcl: true
+        sensitive: false
+        environmentVariable: false
+      - key: SECRET_KEY
+        value: "s3cr3t"
+        hcl: false
+        sensitive: false
+        environmentVariable: true
+```
 
-- Version 2.
+</CodeBlockConfig>
 
-  ```yaml
-  apiVersion: app.terraform.io/v1alpha2
-  kind: Workspace
-  metadata:
-    name: migration
-    spec:
-      terraformVariables:
-        - name: username
-          value: "user"
-          hcl: true
-          sensitive: false
-      environmentVariables:
-        - name: SECRET_KEY
-          value: "s3cr3t"
-          hcl: false
-          sensitive: false
-  ```
+In v2 of the operator, you must configure Terraform variables in `spec.terraformVariables` and environment variables `spec.environmentVariables`.
+
+<CodeBlockConfig filename="v2">
+
+```yaml
+apiVersion: app.terraform.io/v1alpha2
+kind: Workspace
+metadata:
+  name: migration
+  spec:
+    terraformVariables:
+      - name: username
+        value: "user"
+        hcl: true
+        sensitive: false
+    environmentVariables:
+      - name: SECRET_KEY
+        value: "s3cr3t"
+        hcl: false
+        sensitive: false
+```
+
+</CodeBlockConfig>
 
 ### Module controller
 
-Module controller is a new controller in v2 that aim to separate API-driven workflow from Workspace management. Below is a teamplate of a custom resource manifest:
+Terraform Cloud Kubernetes Operator v2 configures modules in a new `Module` controller separate from the `Workspace` controller. Below is a template of a custom resource manifest:
 
 ```yaml
 ---
@@ -149,45 +157,49 @@ spec:
   name: operator
 ```
 
-In the table below you can find field mapping between v1(Workspace controller) and v2(Module controller).
+The table below details the mapping between the `Workspace` controller in v1 of the operator and the `Module` controller in v2 of the operator.
 
-| Version 1 [Workspace CRD] | Version 2 [Module CRD] | Notes |
+| Version 1 (Workspace CRD) | Version 2 (Module CRD) | Notes |
 | --- | --- | --- |
-| `spec.module` | N/A. | In v2 Module is a separate controller with its own CRD. |
-| N/A. | `spec.name: operator` | In v1 name of the generated module is hardcoded to `opetator`. In v2 default name of the generated module is `this`, however, it can be changed. That decision was made intentionally to make the Module controller more flexible. This change can now be used to migrate existing API-driven workflows to the Operator. |
+| `spec.module` | N/A | In v2 of the operator a `Module` is a separate controller with its own CRD. |
+| N/A | `spec.name: operator` | In v1 of the operator, the name of the generated module is hardcoded to `operator`. In v2, the default name of the generated module is `this`, however it can be changed. |
 | `spec.module.source` | `spec.module.source` | This supports all Terraform [module sources](https://developer.hashicorp.com/terraform/language/modules/sources). |
-| `spec.module.version` | `spec.module.version` | The module version. It works in the same way as in any other Terraform [module sources](https://developer.hashicorp.com/terraform/language/modules/sources). |
+| `spec.module.version` | `spec.module.version` | Refer to  [module sources](https://developer.hashicorp.com/terraform/language/modules/sources) for versioning information for each module source. |
 | `spec.variables.[*]` | `spec.variables.[*].name` | Variable names should be included in the module. This is a reference to variables in the Workspace where the module will be executed. |
 | `spec.outputs.[*].key` | `spec.outputs.[*].name` | Output names should be included in the module. This is a reference to the output variables produced by the module. |
-| `status.workspaceID` OR `metadata.namespace-metadata.name` / `metadata.name` – depends on `spec.omitNamespacePrefix` | `spec.workspace.id` OR `spec.workspace.name` | Explicit reference to the Workspace where the module will be executed. It doesn’t have to be the one managed by the Operator. Reference is possible by Workspace ID or Name and must be within the same organization. |
+| `status.workspaceID` OR `metadata.namespace-metadata.name` | `spec.workspace.id` OR `spec.workspace.name` | The workspace where the module will be executed. The workspace must be within the same organization. |
 
-Here is an example of module migration.
+Below is an example migration of a `Module` between v1 and v2 of the operator:
 
-- Version 1.
+<CodeBlockConfig filename="v1.yaml">
 
-  ```yaml
-  apiVersion: app.terraform.io/v1alpha1
-  kind: Workspace
-  metadata:
-    name: migration
-  spec:
-    module:
-      source: app.terraform.io/org-name/module-name/provider
-      version: 0.0.42
-    variables:
-      - key: username
-        value: "user"
-        hcl: true
-        sensitive: false
-        environmentVariable: false
-      - key: SECRET_KEY
-        value: "s3cr3t"
-        hcl: false
-        sensitive: false
-        environmentVariable: true
-  ```
+```yaml
+apiVersion: app.terraform.io/v1alpha1
+kind: Workspace
+metadata:
+  name: migration
+spec:
+  module:
+    source: app.terraform.io/org-name/module-name/provider
+    version: 0.0.42
+  variables:
+    - key: username
+      value: "user"
+      hcl: true
+      sensitive: false
+      environmentVariable: false
+    - key: SECRET_KEY
+      value: "s3cr3t"
+      hcl: false
+      sensitive: false
+      environmentVariable: true
+```
 
-- Version 2.
+</CodeBlockConfig>
+
+In v2 of the operator, the workspace and module are manage by separate controllers.
+
+<CodeBlockConfig filename="workspace-v2.yaml">
 
   ```yaml
   apiVersion: app.terraform.io/v1alpha2
@@ -207,19 +219,25 @@ Here is an example of module migration.
           sensitive: false
   ```
 
-  ```yaml
-  apiVersion: app.terraform.io/v1alpha2
-  kind: Module
-  metadata:
+</CodeBlockConfig>
+
+<CodeBlockConfig filename="module-v2.yaml">
+
+```yaml
+apiVersion: app.terraform.io/v1alpha2
+kind: Module
+metadata:
+  name: migration
+spec:
+  name: operator
+  module:
+    source: app.terraform.io/org-name/module-name/provider
+    version: 0.0.42
+  workspace:
     name: migration
-  spec:
-    name: operator
-    module:
-      source: app.terraform.io/org-name/module-name/provider
-      version: 0.0.42
-    workspace:
-      name: migration
-  ```
+```
+
+</CodeBlockConfig>
 
 ## Upgrade the operator
 
@@ -237,7 +255,7 @@ $ kubectl diff --filename workspaces_patch_a.yaml
 
 Patch the workspace CRD with **patch A**. This patch adds `app.terraform.io/v1alpha2` support, but excludes `.status.runStatus` because it has a different format in `app.terraform.io/v1alpha1` and causes JSON unmarshalling issues.
 
-~> **Warning**<br/> Once the patch is applied, Kubernetes will convert existing `app.terraform.io/v1alpha1` CRs to `app.terraform.io/v1alpha2` according to the updated schema. Fields that are marked as CHANGED or REMOVED in the above migration table will be removed, and CRs will require an update to satisfy the current schema. The Operator v1 won't be able to serve CRs anymore.
+~> **Warning** Once the patch is applied, Kubernetes will convert existing `app.terraform.io/v1alpha1` custom resources to `app.terraform.io/v1alpha2` according to the updated schema and v1 of the operator will no longer serve custom resources. You must update existing custom resources to satisfy the current schema. Refer to the tables above for a mapping of resource fields between v1 and v2 of the operator.
 
 ```shell-session
 $ kubectl patch crd workspaces.app.terraform.io --patch-file workspaces_patch_a.yaml
@@ -262,13 +280,13 @@ Next, create a Kubernetes secret to store the HCP Terraform API token following 
 $ kubectl --namespace ${RELEASE_NAMESPACE} get secret terraformrc -o json | jq '.data.credentials' | tr -d '"' | base64 -d
 ```
 
-Update existing custom resources accoring to the migration table above and apply your changes:
+Update existing custom resources accoring to the migration table above and apply your changes.
 
 ```shell-session
 $ kubectl apply --filename <UPDATED_V2_WORKSPACE_MANIFEST.yaml>
 ```
 
-Download Workspace CRD patch B:
+Download Workspace CRD patch B.
 
 ```shell-session
 $ curl -sO https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_b.yaml
@@ -309,16 +327,15 @@ Review the operator logs once more and verify there are no error messages report
 ```shell-session
 $ kubectl logs -f <POD_NAME>
 ```
+The operator will reconcile resources during the next sync period. This interval is set by the `operator.syncPeriod` configuration of the operator and defaults to five minutes. 
 
-It might take up to `operator.syncPeriod` period before it reconciles resources.
-
-Apply migrated Module custom resources if you have any:
+If you have any migrated `Module` custom resources, apply them now.
 
 ```shell-session
 $ kubectl apply --filename <MIGRATED_V2_MODULE_MANIFEST.yaml>
 ```
 
-Finally, by default in the second version `applyMethod` is set to `manual`. In this case, a new run in a managed workspace will require manual approval. Run the following command for each Workspace resource to change it to `auto` approval.
+In v2 of the operator, `applyMethod` is set to `manual` by default. In this case, a new run in a managed workspace will require manual approval. Run the following command for each Workspace resource to change it to `auto` approval.
 
 ```shell-session
 kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"applyMethod": "auto"}}'

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -87,7 +87,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.omitNamespacePrefix` | N/A | Removed. In v1 `spec.omitNamespacePrefix` is a boolean field and affects a Workspace name:<br/> - If it is `true` then a Workspace name will be generated as `metadata.namespace-metadata.name`.<br/> - If it is `false` then a Workspace name will be generated as `metadata.name`.<br/> In v2 a Workspace name must be explicitly set in `spec.name`. |
 | `spec.agentPoolID` | `spec.agentPool.id` | The `agentPoolID` field is moved to `spec.agentPool.id`. |
 | `spec.agentPoolName` | `spec.agentPool.name` | The `agentPoolName` field is moved to `spec.agentPool.name`. |
-| `spec.module` | N/A | Removed. Modules are now configured with a separate `Module` CRD. Refer to the below migration mapping for more information. |
+| `spec.module` | N/A | Removed. You now configure modules with a separate `Module` CRD. [Learn more](#module-controller). |
 
 Below is an example of configuring a variable in v1 of the operator. 
 

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -85,7 +85,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.notifications.recepients.[*]` | `spec.notifications.emailAddesses.[*]` | The `recepients` field is renamed to `emailAddesses`. |
 | `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | Renamed the `users` field to `emailUsers`. |
 | `spec.omitNamespacePrefix` | N/A | Removed. In v1 `spec.omitNamespacePrefix` is a boolean field and affects a Workspace name:<br/> - If it is `true` then a Workspace name will be generated as `metadata.namespace-metadata.name`.<br/> - If it is `false` then a Workspace name will be generated as `metadata.name`.<br/> In v2 a Workspace name must be explicitly set in `spec.name`. |
-| `spec.agentPoolID` | `spec.agentPool.id` | The `agentPoolID` field is moved to `spec.agentPool.id`. |
+| `spec.agentPoolID` | `spec.agentPool.id` | Moved the `agentPoolID` field to `spec.agentPool.id`. |
 | `spec.agentPoolName` | `spec.agentPool.name` | Moved the `agentPoolName` field to `spec.agentPool.name`. |
 | `spec.module` | N/A | Removed. You now configure modules with a separate `Module` CRD. [Learn more](#module-controller). |
 

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -83,7 +83,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.notifications.token` | `spec.notifications.token` |  |
 | `spec.notifications.triggers.[*]` | `spec.notifications.triggers.[*]` |  |
 | `spec.notifications.recepients.[*]` | `spec.notifications.emailAddesses.[*]` | The `recepients` field is renamed to `emailAddesses`. |
-| `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | The `users` field is renamed to `emailUsers`. |
+| `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | Renamed the `users` field to `emailUsers`. |
 | `spec.omitNamespacePrefix` | N/A | Removed. In v1 `spec.omitNamespacePrefix` is a boolean field and affects a Workspace name:<br/> - If it is `true` then a Workspace name will be generated as `metadata.namespace-metadata.name`.<br/> - If it is `false` then a Workspace name will be generated as `metadata.name`.<br/> In v2 a Workspace name must be explicitly set in `spec.name`. |
 | `spec.agentPoolID` | `spec.agentPool.id` | The `agentPoolID` field is moved to `spec.agentPool.id`. |
 | `spec.agentPoolName` | `spec.agentPool.name` | Moved the `agentPoolName` field to `spec.agentPool.name`. |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -64,7 +64,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.vcs.branch` | `spec.versionControl.branch` |  |
 | `spec.vcs.ingress_submodules` | `spec.workingDirectory` | Moved. |
 | `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | We split variables into two possible places. In v1's CRD, if `spec.variables.environmentVariable` was `true`, migrate those variables to `spec.environmentVariables`. If `false`, migrate those variables to `spec.terraformVariables`. |
-| `spec.variables.[*]key` | `spec.environmentVariables.[*]name` OR `spec.terraformVariables.[*]name` | The `key` field is renamed to `name`. |
+| `spec.variables.[*]key` | `spec.environmentVariables.[*]name` OR `spec.terraformVariables.[*]name` | Renamed the `key` field as `name`. |
 | `spec.variables.[*]value` | `spec.environmentVariables.[*]value` OR `spec.terraformVariables.[*]value` |  |
 | `spec.variables.[*]valueFrom` | `spec.environmentVariables.[*]valueFrom` OR `spec.terraformVariables.[*]valueFrom` |  |
 | `spec.variables.[*]hcl` | `spec.environmentVariables.[*]hcl` OR `spec.terraformVariables.[*]hcl` |  |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -157,7 +157,7 @@ spec:
   name: operator
 ```
 
-The table below details the mapping between the `Workspace` controller in v1 of the operator and the `Module` controller in v2 of the operator.
+The table below describes the mapping between the `Workspace` controller from v1 and the `Module` controller in v2 of the operator.
 
 | Version 1 (Workspace CRD) | Version 2 (Module CRD) | Notes |
 | --- | --- | --- |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -53,7 +53,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 
 | Version 1 | Version 2 | Notes |
 | --- | --- | --- |
-| `apiVersion: app.terraform.io/v1alpha1` | `apiVersion: app.terraform.io/v1alpha2` | The `apiVersion` is changed from `v1alpha1` to `v1alpha2`. |
+| `apiVersion: app.terraform.io/v1alpha1` | `apiVersion: app.terraform.io/v1alpha2` | The `apiVersion` is now `v1alpha2`. |
 | `kind: Workspace` | `kind: Workspace` |  |
 | `metadata` | `metadata` |  |
 | `spec.organization` | `spec.organization` |  |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -297,7 +297,7 @@ View the changes that patch B applies to the workspace CRD.
 $ kubectl diff --filename workspaces_patch_b.yaml
 ```
 
-Patch workspace CRD with patch B. This patch adds `.status.runStatus` support, which was excluded in patch A.
+Patch the workspace CRD with patch B. This patch adds `.status.runStatus` support, which was excluded in patch A.
 
 ```shell-session
 $ kubectl patch crd workspaces.app.terraform.io --patch-file workspaces_patch_b.yaml

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -162,7 +162,7 @@ The table below details the mapping between the `Workspace` controller in v1 of 
 | Version 1 (Workspace CRD) | Version 2 (Module CRD) | Notes |
 | --- | --- | --- |
 | `spec.module` | N/A | In v2 of the operator a `Module` is a separate controller with its own CRD. |
-| N/A | `spec.name: operator` | In v1 of the operator, the name of the generated module is hardcoded to `operator`. In v2, the default name of the generated module is `this`, however it can be changed. |
+| N/A | `spec.name: operator` | In v1 of the operator, the name of the generated module is hardcoded to `operator`. In v2, the default name of the generated module is `this`, but you can rename it. |
 | `spec.module.source` | `spec.module.source` | This supports all Terraform [module sources](/terraform/language/modules/sources). |
 | `spec.module.version` | `spec.module.version` | Refer to  [module sources](/terraform/language/modules/sources) for versioning information for each module source. |
 | `spec.variables.[*]` | `spec.variables.[*].name` | You should include variable names in the module. This is a reference to variables in the workspace that is executing the module. |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -53,7 +53,7 @@ Below is the field mapping of the `Workspace` controller from v1 to v2 of the op
 
 | Version 1 | Version 2 | Notes |
 | --- | --- | --- |
-| `apiVersion: app.terraform.io/v1alpha1` | `apiVersion: app.terraform.io/v1alpha2` | The `apiVersion` changed from `v1alpha1` to `v1alpha2`. |
+| `apiVersion: app.terraform.io/v1alpha1` | `apiVersion: app.terraform.io/v1alpha2` | The `apiVersion` is changed from `v1alpha1` to `v1alpha2`. |
 | `kind: Workspace` | `kind: Workspace` |  |
 | `metadata` | `metadata` |  |
 | `spec.organization` | `spec.organization` |  |
@@ -63,7 +63,7 @@ Below is the field mapping of the `Workspace` controller from v1 to v2 of the op
 | `spec.vcs.repo_identifier` | `spec.versionControl.repository` | Renamed. Refer to the `versionControl` structure for details. |
 | `spec.vcs.branch` | `spec.versionControl.branch` |  |
 | `spec.vcs.ingress_submodules` | `spec.workingDirectory` | Moved. |
-| `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | Variables were split into two different paths. <br/>It depends on the bool value `spec.variables.environmentVariable` in v1 CRD:<br/> - If it is `true` then a variable should be migrated to `spec.environmentVariables`.<br/> - If it is `false` then a variable should be migrated to `spec.terraformVariables`. |
+| `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | Variables were split into two different paths. Depending on the variable's value of `spec.variables.environmentVariable` in v1 CRD:<br/> - If it is `true` then you must migrate the variable to `spec.environmentVariables`.<br/> - If it is `false` then you must migrate the variable to `spec.terraformVariables`. |
 | `spec.variables.[*]key` | `spec.environmentVariables.[*]name` OR `spec.terraformVariables.[*]name` | The `key` field is renamed to `name`. |
 | `spec.variables.[*]value` | `spec.environmentVariables.[*]value` OR `spec.terraformVariables.[*]value` |  |
 | `spec.variables.[*]valueFrom` | `spec.environmentVariables.[*]valueFrom` OR `spec.terraformVariables.[*]valueFrom` |  |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -335,7 +335,7 @@ If you have any migrated `Module` custom resources, apply them now.
 $ kubectl apply --filename <MIGRATED_V2_MODULE_MANIFEST.yaml>
 ```
 
-In v2 of the operator, `applyMethod` is set to `manual` by default. In this case, a new run in a managed workspace will require manual approval. Run the following command for each Workspace resource to change it to `auto` approval.
+In v2 of the operator, the `applyMethod` is set to `manual` by default. In this case, a new run in a managed workspace requires manual approval. Run the following command for each `Workspace` resource to change it to `auto` approval.
 
 ```shell-session
 kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"applyMethod": "auto"}}'

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -280,7 +280,7 @@ Next, create a Kubernetes secret to store the HCP Terraform API token following 
 $ kubectl --namespace ${RELEASE_NAMESPACE} get secret terraformrc -o json | jq '.data.credentials' | tr -d '"' | base64 -d
 ```
 
-Update existing custom resources accoring to the migration table above and apply your changes.
+Update existing custom resources [according to the schema migration guidance](#manifest-schema-migration) and apply your changes.
 
 ```shell-session
 $ kubectl apply --filename <UPDATED_V2_WORKSPACE_MANIFEST.yaml>

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -327,7 +327,7 @@ Review the operator logs once more and verify there are no error messages report
 ```shell-session
 $ kubectl logs -f <POD_NAME>
 ```
-The operator will reconcile resources during the next sync period. This interval is set by the `operator.syncPeriod` configuration of the operator and defaults to five minutes. 
+The operator reconciles resources during the next sync period. This interval is set by the `operator.syncPeriod` configuration of the operator and defaults to five minutes. 
 
 If you have any migrated `Module` custom resources, apply them now.
 

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -48,30 +48,197 @@ Finally, we suggest that you set the `applyMethod` of each HCP Terraform workspa
 ```shell-session
 kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"applyMethod": "manual"}}'
 ```
+
+## Manifest schema migration
+
+### Workspace controller
+
+In the table below you can find field mapping between v1 and v2.
+
+| Version 1 | Version 2 | Notes |
+| --- | --- | --- |
+| `apiVersion: app.terraform.io/v1alpha1` | `apiVersion: app.terraform.io/v1alpha2` | CHANGED. In v2 the `apiVersion` changed from `v1alpha1` to `v1alpha2`. |
+| `kind: Workspace` | `kind: Workspace` | DID NOT CHANGE. |
+| `metadata` | `metadata` | DID NOT CHANGE. Entire `metadata` section remained unchanged. |
+| `spec.organization` | `spec.organization` | DID NOT CHANGE. |
+| `spec.secretsMountPath` | `spec.token.secretKeyRef` | CHANGED. In v2 the operator keeps HCP Terraform access token in a Kubernetes Secret. |
+| `spec.vcs` | `spec.versionControl` | CHANGED. This field got a new name. See below changes inside the `versionControl` structure. |
+| `spec.vcs.token_id` | `spec.versionControl.oAuthTokenID` | CHANGED. This field got a new name. |
+| `spec.vcs.repo_identifier` | `spec.versionControl.repository` | CHANGED. This field got a new name. |
+| `spec.vcs.branch` | `spec.versionControl.branch` | DID NOT CHANGE. |
+| `spec.vcs.ingress_submodules` | `spec.workingDirectory` | CHANGED. This moved to a different level. |
+| `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | CHANGED. Variables were split into two different paths. It depends on the bool value `spec.variables.environmentVariable` in v1 CRD:<br/> - If it is `true` then a variable should be migrated to `spec.environmentVariables`.<br/> - If it is `false` then a variable should be migrated to `spec.terraformVariables`. |
+| `spec.variables.[*]key` | `spec.environmentVariables.[*]name` OR `spec.terraformVariables.[*]name` | CHANGED. In v2 `key` renamed to `name`. |
+| `spec.variables.[*]value` | `spec.environmentVariables.[*]value` OR `spec.terraformVariables.[*]value` | DID NOT CHANGE. |
+| `spec.variables.[*]valueFrom` | `spec.environmentVariables.[*]valueFrom` OR `spec.terraformVariables.[*]valueFrom` | DID NOT CHANGE. |
+| `spec.variables.[*]hcl` | `spec.environmentVariables.[*]hcl` OR `spec.terraformVariables.[*]hcl` | DID NOT CHANGE. |
+| `spec.variables.sensitive` |  `spec.environmentVariables.[*]sensitive` OR `spec.terraformVariables.[*]sensitive` | DID NOT CHANGE. |
+| `spec.variables.environmentVariable` | N/A. | REMOVED. In v2 `environmentVariable` was removed and variables were split into two different paths. |
+| `spec.runTriggers.[*]` | `spec.runTriggers.[*]` | DID NOT CHANGE. Changes were made inside the `runTriggers` structure, see below. |
+| `spec.runTriggers.[*].sourceableName` | `spec.runTriggers.[*].name` | CHANGED. In v2 `sourceableName` was renamed to `name`. |
+| `spec.sshKeyID` | `spec.sshKey.id` | CHANGED. In v2 `sshKeyID` was moved to `spec.sshKey.id`. |
+| `spec.outputs` | N/A. | REMOVED. In v2 `spec.outputs` does not exist. |
+| `spec.terraformVersion` | `spec.terraformVersion` | DID NOT CHANGE. |
+| `spec.notifications` | `spec.notifications` | DID NOT CHANGE. Changes were made inside the `notification` structure, see below. |
+| `spec.notifications.type` | `spec.notifications.type` | DID NOT CHANGE. |
+| `spec.notifications.enabled` | `spec.notifications.enabled` | DID NOT CHANGE. |
+| `spec.notifications.name` | `spec.notifications.name` | DID NOT CHANGE. |
+| `spec.notifications.url` | `spec.notifications.url` | DID NOT CHANGE. |
+| `spec.notifications.token` | `spec.notifications.token` | DID NOT CHANGE. |
+| `spec.notifications.triggers.[*]` | `spec.notifications.triggers.[*]` | DID NOT CHANGE. |
+| `spec.notifications.recepients.[*]` | `spec.notifications.emailAddesses.[*]` | CHANGED. In v2 `recepients` was changed to `emailAddesses`. |
+| `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | CHANGED. In v2 `users`was changed to `emailUsers`. |
+| `spec.omitNamespacePrefix` | N/A. | REMOVED. In v1 `spec.omitNamespacePrefix` is a boolean field and affects a Workspace name:<br/> - If it is `true` then a Workspace name will be generated as `metadata.namespace-metadata.name`.<br/> - If it is `false` then a Workspace name will be generated as `metadata.name`.<br/> In v2 a Workspace name must be explicitly set in `spec.name`. |
+| `spec.agentPoolID` | `spec.agentPool.id` | CHANGED. In v2 `agentPoolID` was moved to `spec.agentPool.id`. |
+| `spec.agentPoolName` | `spec.agentPool.name` | CHANGED. In v2 `agentPoolName` was moved to `spec.agentPool.name`. |
+| `spec.module` | N/A. | REMOVED. In v2 Module is a separate controller with its own CRD. See below the migration mapping. |
+
+Here is an example of variables migration.
+
+- Version 1.
+
+  ```yaml
+  apiVersion: app.terraform.io/v1alpha1
+  kind: Workspace
+  metadata:
+    name: migration
+    spec:
+      variables:
+        - key: username
+          value: "user"
+          hcl: true
+          sensitive: false
+          environmentVariable: false
+        - key: SECRET_KEY
+          value: "s3cr3t"
+          hcl: false
+          sensitive: false
+          environmentVariable: true
+  ```
+
+- Version 2.
+
+  ```yaml
+  apiVersion: app.terraform.io/v1alpha2
+  kind: Workspace
+  metadata:
+    name: migration
+    spec:
+      terraformVariables:
+        - name: username
+          value: "user"
+          hcl: true
+          sensitive: false
+      environmentVariables:
+        - name: SECRET_KEY
+          value: "s3cr3t"
+          hcl: false
+          sensitive: false
+  ```
+
+### Module controller
+
+Module controller is a new controller in v2 that aim to separate API-driven workflow from Workspace management. Below is a teamplate of a custom resource manifest:
+
+```yaml
+---
+apiVersion: app.terraform.io/v1alpha2
+kind: Module
+metadata:
+  name: <NAME>
+spec:
+  organization: <ORG-NAME>
+  token:
+    secretKeyRef:
+      name: <SECRET-NAME>
+      key: <KEY-NAME>
+  name: operator
+```
+
+In the table below you can find field mapping between v1(Workspace controller) and v2(Module controller).
+
+| Version 1 [Workspace CRD] | Version 2 [Module CRD] | Notes |
+| --- | --- | --- |
+| `spec.module` | N/A. | In v2 Module is a separate controller with its own CRD. |
+| N/A. | `spec.name: operator` | In v1 name of the generated module is hardcoded to `opetator`. In v2 default name of the generated module is `this`, however, it can be changed. That decision was made intentionally to make the Module controller more flexible. This change can now be used to migrate existing API-driven workflows to the Operator. |
+| `spec.module.source` | `spec.module.source` | This supports all Terraform [module sources](https://developer.hashicorp.com/terraform/language/modules/sources). |
+| `spec.module.version` | `spec.module.version` | The module version. It works in the same way as in any other Terraform [module sources](https://developer.hashicorp.com/terraform/language/modules/sources). |
+| `spec.variables.[*]` | `spec.variables.[*].name` | Variable names should be included in the module. This is a reference to variables in the Workspace where the module will be executed. |
+| `spec.outputs.[*].key` | `spec.outputs.[*].name` | Output names should be included in the module. This is a reference to the output variables produced by the module. |
+| `status.workspaceID` OR `metadata.namespace-metadata.name` / `metadata.name` – depends on `spec.omitNamespacePrefix` | `spec.workspace.id` OR `spec.workspace.name` | Explicit reference to the Workspace where the module will be executed. It doesn’t have to be the one managed by the Operator. Reference is possible by Workspace ID or Name and must be within the same organization. |
+
+Here is an example of module migration.
+
+- Version 1.
+
+  ```yaml
+  apiVersion: app.terraform.io/v1alpha1
+  kind: Workspace
+  metadata:
+    name: migration
+  spec:
+    module:
+      source: app.terraform.io/org-name/module-name/provider
+      version: 0.0.42
+    variables:
+      - key: username
+        value: "user"
+        hcl: true
+        sensitive: false
+        environmentVariable: false
+      - key: SECRET_KEY
+        value: "s3cr3t"
+        hcl: false
+        sensitive: false
+        environmentVariable: true
+  ```
+
+- Version 2.
+
+  ```yaml
+  apiVersion: app.terraform.io/v1alpha2
+  kind: Workspace
+  metadata:
+    name: migration
+    spec:
+      terraformVariables:
+        - name: username
+          value: "user"
+          hcl: true
+          sensitive: false
+      environmentVariables:
+        - name: SECRET_KEY
+          value: "s3cr3t"
+          hcl: false
+          sensitive: false
+  ```
+
+  ```yaml
+  apiVersion: app.terraform.io/v1alpha2
+  kind: Module
+  metadata:
+    name: migration
+  spec:
+    name: operator
+    module:
+      source: app.terraform.io/org-name/module-name/provider
+      version: 0.0.42
+    workspace:
+      name: migration
+  ```
+
 ## Upgrade the operator
-
-Clone the Terraform [Cloud Kubernetes Operator repository](https://github.com/hashicorp/terraform-cloud-operator).
-
-```shell-session
-$ git clone https://github.com/hashicorp/terraform-cloud-operator.git
-```
-
-Change to the migration directory.
-
-```shell-session
-$ cd terraform-cloud-operator/docs/migration/crds
-```
 
 View the changes that **patch A** will apply to the workspace CRD.
 
 ```shell-session
-$ kubectl diff -f workspaces_patch_a.yaml
+$ kubectl diff -f https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_a.yaml
 ```
 
 Patch the workspace CRD with **patch A**. This patch adds `app.terraform.io/v1alpha2` support, but excludes `.status.runStatus` because it has a different format in `app.terraform.io/v1alpha1` and causes JSON unmarshalling issues.
 
 ```shell-session
-$ kubectl patch crd workspaces.app.terraform.io --patch-file workspaces_patch_a.yaml
+$ kubectl patch crd workspaces.app.terraform.io --patch-file https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_a.yaml
 ```
 
 Install the Operator v2 Helm chart with the `helm install` command. Be sure to set the `operator.watchedNamespaces` value to the list of namespaces your Workspace resources are deployed to. If this value is not provided, the operator will watch all namespaces in the Kubernetes cluster.
@@ -79,7 +246,7 @@ Install the Operator v2 Helm chart with the `helm install` command. Be sure to s
 ```shell-session
 $ helm install \
   ${RELEASE_NAME} hashicorp/terraform-cloud-operator \
-  --version 2.0.0-beta7 \
+  --version 2.4.0 \
   --namespace ${RELEASE_NAMESPACE} \
   --set operator.syncPeriod=10m \
   --set 'operator.watchedNamespaces={white,blue,red}' \
@@ -97,7 +264,7 @@ $ kubectl --namespace ${RELEASE_NAMESPACE} get secret terraformrc -o json | jq '
 If v2 of the operator pod fails to start, ensure that each `workspace` object has the `spec.token` value set. To do this, patch each `workspace` object using following command for each Workspace resource.
 
 ```shell-session
-$ kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"terraformVersion": "1.4.6", "token": {"secretKeyRef": {"key": "token", "name": "tfc-operator"}}}}'
+$ kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"name": "NAME", "terraformVersion": "1.4.6", "token": {"secretKeyRef": {"key": "token", "name": "tfc-operator"}}}}'
 ```
 
 Review the logs and verify that there are no error messages reported. The logs will report when the operator begins and finishes reconciling each workspace.
@@ -112,13 +279,13 @@ INFO	Workspace Controller	{"workspace": {"name":"<WORKSPACE_NAME>","namespace":"
 View the changes that **patch B** will apply to the workspace CRD:
 
 ```shell-session
-$ kubectl diff -f workspaces_patch_b.yaml
+$ kubectl diff -f https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_b.yaml
 ```
 
 Patch workspace CRD with **patch B**. This patch adds `.status.runStatus` support that was excluded in Patch A.
 
 ```shell-session
-$ kubectl patch crd workspaces.app.terraform.io --patch-file workspaces_patch_b.yaml
+$ kubectl patch crd workspaces.app.terraform.io --patch-file https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_b.yaml
 ```
 
 The v2 operator will fail to proceed if a custom resource has the v1 finalizer `finalizer.workspace.app.terraform.io`. If you encounter an error, check the logs for more information.

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -84,7 +84,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.notifications.triggers.[*]` | `spec.notifications.triggers.[*]` |  |
 | `spec.notifications.recepients.[*]` | `spec.notifications.emailAddesses.[*]` | The `recepients` field is renamed to `emailAddesses`. |
 | `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | Renamed the `users` field to `emailUsers`. |
-| `spec.omitNamespacePrefix` | N/A | Removed. In v1 `spec.omitNamespacePrefix` is a boolean field and affects a Workspace name:<br/> - If it is `true` then a Workspace name will be generated as `metadata.namespace-metadata.name`.<br/> - If it is `false` then a Workspace name will be generated as `metadata.name`.<br/> In v2 a Workspace name must be explicitly set in `spec.name`. |
+| `spec.omitNamespacePrefix` | N/A | Removed. In v1 `spec.omitNamespacePrefix` is a boolean field that affects how the operator generates a workspace name. In v2, you must explicitly set workspace names in `spec.name`. |
 | `spec.agentPoolID` | `spec.agentPool.id` | Moved the `agentPoolID` field to `spec.agentPool.id`. |
 | `spec.agentPoolName` | `spec.agentPool.name` | Moved the `agentPoolName` field to `spec.agentPool.name`. |
 | `spec.module` | N/A | Removed. You now configure modules with a separate `Module` CRD. [Learn more](#module-controller). |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -165,7 +165,7 @@ The table below details the mapping between the `Workspace` controller in v1 of 
 | N/A | `spec.name: operator` | In v1 of the operator, the name of the generated module is hardcoded to `operator`. In v2, the default name of the generated module is `this`, however it can be changed. |
 | `spec.module.source` | `spec.module.source` | This supports all Terraform [module sources](https://developer.hashicorp.com/terraform/language/modules/sources). |
 | `spec.module.version` | `spec.module.version` | Refer to  [module sources](https://developer.hashicorp.com/terraform/language/modules/sources) for versioning information for each module source. |
-| `spec.variables.[*]` | `spec.variables.[*].name` | Variable names should be included in the module. This is a reference to variables in the Workspace where the module will be executed. |
+| `spec.variables.[*]` | `spec.variables.[*].name` | You should include variable names in the module. This is a reference to variables in the workspace that is executing the module. |
 | `spec.outputs.[*].key` | `spec.outputs.[*].name` | You should include output names in the module. This is a reference to the output variables produced by the module. |
 | `status.workspaceID` OR `metadata.namespace-metadata.name` | `spec.workspace.id` OR `spec.workspace.name` | The workspace where the module is executed. The workspace must be in the same organization. |
 

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -164,7 +164,7 @@ The table below details the mapping between the `Workspace` controller in v1 of 
 | `spec.module` | N/A | In v2 of the operator a `Module` is a separate controller with its own CRD. |
 | N/A | `spec.name: operator` | In v1 of the operator, the name of the generated module is hardcoded to `operator`. In v2, the default name of the generated module is `this`, however it can be changed. |
 | `spec.module.source` | `spec.module.source` | This supports all Terraform [module sources](https://developer.hashicorp.com/terraform/language/modules/sources). |
-| `spec.module.version` | `spec.module.version` | Refer to  [module sources](https://developer.hashicorp.com/terraform/language/modules/sources) for versioning information for each module source. |
+| `spec.module.version` | `spec.module.version` | Refer to  [module sources](/terraform/language/modules/sources) for versioning information for each module source. |
 | `spec.variables.[*]` | `spec.variables.[*].name` | You should include variable names in the module. This is a reference to variables in the workspace that is executing the module. |
 | `spec.outputs.[*].key` | `spec.outputs.[*].name` | You should include output names in the module. This is a reference to the output variables produced by the module. |
 | `status.workspaceID` OR `metadata.namespace-metadata.name` | `spec.workspace.id` OR `spec.workspace.name` | The workspace where the module is executed. The workspace must be in the same organization. |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -63,7 +63,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.vcs.repo_identifier` | `spec.versionControl.repository` | Renamed. Refer to the `versionControl` structure for details. |
 | `spec.vcs.branch` | `spec.versionControl.branch` |  |
 | `spec.vcs.ingress_submodules` | `spec.workingDirectory` | Moved. |
-| `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | Variables were split into two different paths. Depending on the variable's value of `spec.variables.environmentVariable` in v1 CRD:<br/> - If it is `true` then you must migrate the variable to `spec.environmentVariables`.<br/> - If it is `false` then you must migrate the variable to `spec.terraformVariables`. |
+| `spec.variables.[*]` | `spec.environmentVariables.[*]` OR `spec.terraformVariables.[*]` | We split variables into two possible places. In v1's CRD, if `spec.variables.environmentVariable` was `true`, migrate those variables to `spec.environmentVariables`. If `false`, migrate those variables to `spec.terraformVariables`. |
 | `spec.variables.[*]key` | `spec.environmentVariables.[*]name` OR `spec.terraformVariables.[*]name` | The `key` field is renamed to `name`. |
 | `spec.variables.[*]value` | `spec.environmentVariables.[*]value` OR `spec.terraformVariables.[*]value` |  |
 | `spec.variables.[*]valueFrom` | `spec.environmentVariables.[*]valueFrom` OR `spec.terraformVariables.[*]valueFrom` |  |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -57,7 +57,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `kind: Workspace` | `kind: Workspace` |  |
 | `metadata` | `metadata` |  |
 | `spec.organization` | `spec.organization` |  |
-| `spec.secretsMountPath` | `spec.token.secretKeyRef` | In v2 the operator keeps HCP Terraform access token in a Kubernetes Secret. |
+| `spec.secretsMountPath` | `spec.token.secretKeyRef` | In v2 the operator keeps the HCP Terraform access token in a Kubernetes Secret. |
 | `spec.vcs` | `spec.versionControl` | Renamed. Refer to the `versionControl` structure for details. |
 | `spec.vcs.token_id` | `spec.versionControl.oAuthTokenID` | Renamed. Refer to the `versionControl` structure for details. |
 | `spec.vcs.repo_identifier` | `spec.versionControl.repository` | Renamed. Refer to the `versionControl` structure for details. |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -337,5 +337,5 @@ $ kubectl apply --filename <MIGRATED_V2_MODULE_MANIFEST.yaml>
 In v2 of the operator, the `applyMethod` is set to `manual` by default. In this case, a new run in a managed workspace requires manual approval. Run the following command for each `Workspace` resource to change it to `auto` approval.
 
 ```shell-session
-kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"applyMethod": "auto"}}'
+$ kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"applyMethod": "auto"}}'
 ```

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -292,7 +292,7 @@ Download Workspace CRD patch B.
 $ curl -sO https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_b.yaml
 ```
 
-View the changes that **patch B** will apply to the workspace CRD.
+View the changes that patch B applies to the workspace CRD.
 
 ```shell-session
 $ kubectl diff --filename workspaces_patch_b.yaml

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -253,7 +253,7 @@ View the changes that **patch A** will apply to the workspace CRD.
 $ kubectl diff --filename workspaces_patch_a.yaml
 ```
 
-Patch the workspace CRD with **patch A**. This patch adds `app.terraform.io/v1alpha2` support, but excludes `.status.runStatus` because it has a different format in `app.terraform.io/v1alpha1` and causes JSON unmarshalling issues.
+Patch the workspace CRD with patch A. This patch adds `app.terraform.io/v1alpha2` support, but excludes `.status.runStatus` because it has a different format in `app.terraform.io/v1alpha1` and causes JSON un-marshalling issues.
 
 !> **Upgrade warning**: Once you apply a patch, Kubernetes converts existing `app.terraform.io/v1alpha1` custom resources to `app.terraform.io/v1alpha2` according to the updated schema, meaning that v1 of the operator can no longer serve custom resources. Before patching, update your existing custom resources to satisfy the v2 schema requirements. [Learn more](#manifest-schema-migration).
 

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -167,7 +167,7 @@ The table below details the mapping between the `Workspace` controller in v1 of 
 | `spec.module.version` | `spec.module.version` | Refer to  [module sources](https://developer.hashicorp.com/terraform/language/modules/sources) for versioning information for each module source. |
 | `spec.variables.[*]` | `spec.variables.[*].name` | Variable names should be included in the module. This is a reference to variables in the Workspace where the module will be executed. |
 | `spec.outputs.[*].key` | `spec.outputs.[*].name` | Output names should be included in the module. This is a reference to the output variables produced by the module. |
-| `status.workspaceID` OR `metadata.namespace-metadata.name` | `spec.workspace.id` OR `spec.workspace.name` | The workspace where the module will be executed. The workspace must be within the same organization. |
+| `status.workspaceID` OR `metadata.namespace-metadata.name` | `spec.workspace.id` OR `spec.workspace.name` | The workspace where the module is executed. The workspace must be in the same organization. |
 
 Below is an example migration of a `Module` between v1 and v2 of the operator:
 

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -247,7 +247,7 @@ Download Workspace CRD patch A:
 $ curl -sO https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_a.yaml
 ```
 
-View the changes that **patch A** will apply to the workspace CRD.
+View the changes that patch A applies to the workspace CRD.
 
 ```shell-session
 $ kubectl diff --filename workspaces_patch_a.yaml

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -143,7 +143,6 @@ metadata:
 Terraform Cloud Kubernetes Operator v2 configures modules in a new `Module` controller separate from the `Workspace` controller. Below is a template of a custom resource manifest:
 
 ```yaml
----
 apiVersion: app.terraform.io/v1alpha2
 kind: Module
 metadata:

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -197,7 +197,7 @@ spec:
 
 </CodeBlockConfig>
 
-In v2 of the operator, the workspace and module are manage by separate controllers.
+In v2 of the operator, separate controllers manage workspace and modules.
 
 <CodeBlockConfig filename="workspace-v2.yaml">
 

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -82,7 +82,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.notifications.url` | `spec.notifications.url` |  |
 | `spec.notifications.token` | `spec.notifications.token` |  |
 | `spec.notifications.triggers.[*]` | `spec.notifications.triggers.[*]` |  |
-| `spec.notifications.recepients.[*]` | `spec.notifications.emailAddesses.[*]` | The `recepients` field is renamed to `emailAddesses`. |
+| `spec.notifications.recepients.[*]` | `spec.notifications.emailAddesses.[*]` | Renamed the `recepients` field to `emailAddesses`. |
 | `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | Renamed the `users` field to `emailUsers`. |
 | `spec.omitNamespacePrefix` | N/A | Removed. In v1 `spec.omitNamespacePrefix` is a boolean field that affects how the operator generates a workspace name. In v2, you must explicitly set workspace names in `spec.name`. |
 | `spec.agentPoolID` | `spec.agentPool.id` | Moved the `agentPoolID` field to `spec.agentPool.id`. |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -72,7 +72,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.variables.environmentVariable` | N/A | Removed, variables are split between `spec.environmentVariables` and `spec.terraformVariables`. |
 | `spec.runTriggers.[*]` | `spec.runTriggers.[*]` |  Changes made to the `runTriggers` structure. |
 | `spec.runTriggers.[*].sourceableName` | `spec.runTriggers.[*].name` | The `sourceableName` field is renamed to `name`. |
-| `spec.sshKeyID` | `spec.sshKey.id` | The `sshKeyID` is moved to `spec.sshKey.id`. |
+| `spec.sshKeyID` | `spec.sshKey.id` | Moved the `sshKeyID` to `spec.sshKey.id`. |
 | `spec.outputs` | N/A | Removed. |
 | `spec.terraformVersion` | `spec.terraformVersion` |  |
 | `spec.notifications` | `spec.notifications` |  Changes made to the `notification` structure. |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -71,7 +71,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.variables.sensitive` |  `spec.environmentVariables.[*]sensitive` OR `spec.terraformVariables.[*]sensitive` |  |
 | `spec.variables.environmentVariable` | N/A | Removed, variables are split between `spec.environmentVariables` and `spec.terraformVariables`. |
 | `spec.runTriggers.[*]` | `spec.runTriggers.[*]` |  Changes made to the `runTriggers` structure. |
-| `spec.runTriggers.[*].sourceableName` | `spec.runTriggers.[*].name` | The `sourceableName` field is renamed to `name`. |
+| `spec.runTriggers.[*].sourceableName` | `spec.runTriggers.[*].name` | The `sourceableName` field is now `name`. |
 | `spec.sshKeyID` | `spec.sshKey.id` | Moved the `sshKeyID` to `spec.sshKey.id`. |
 | `spec.outputs` | N/A | Removed. |
 | `spec.terraformVersion` | `spec.terraformVersion` |  |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -69,7 +69,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.variables.[*]valueFrom` | `spec.environmentVariables.[*]valueFrom` OR `spec.terraformVariables.[*]valueFrom` |  |
 | `spec.variables.[*]hcl` | `spec.environmentVariables.[*]hcl` OR `spec.terraformVariables.[*]hcl` |  |
 | `spec.variables.sensitive` |  `spec.environmentVariables.[*]sensitive` OR `spec.terraformVariables.[*]sensitive` |  |
-| `spec.variables.environmentVariable` | N/A | Removed, variables are split to `spec.environmentVariables` and `spec.terraformVariables`. |
+| `spec.variables.environmentVariable` | N/A | Removed, variables are split between `spec.environmentVariables` and `spec.terraformVariables`. |
 | `spec.runTriggers.[*]` | `spec.runTriggers.[*]` |  Changes made to the `runTriggers` structure. |
 | `spec.runTriggers.[*].sourceableName` | `spec.runTriggers.[*].name` | The `sourceableName` field is renamed to `name`. |
 | `spec.sshKeyID` | `spec.sshKey.id` | The `sshKeyID` is moved to `spec.sshKey.id`. |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -86,7 +86,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.notifications.users.[*]` | `spec.notifications.emailUsers.[*]` | The `users` field is renamed to `emailUsers`. |
 | `spec.omitNamespacePrefix` | N/A | Removed. In v1 `spec.omitNamespacePrefix` is a boolean field and affects a Workspace name:<br/> - If it is `true` then a Workspace name will be generated as `metadata.namespace-metadata.name`.<br/> - If it is `false` then a Workspace name will be generated as `metadata.name`.<br/> In v2 a Workspace name must be explicitly set in `spec.name`. |
 | `spec.agentPoolID` | `spec.agentPool.id` | The `agentPoolID` field is moved to `spec.agentPool.id`. |
-| `spec.agentPoolName` | `spec.agentPool.name` | The `agentPoolName` field is moved to `spec.agentPool.name`. |
+| `spec.agentPoolName` | `spec.agentPool.name` | Moved the `agentPoolName` field to `spec.agentPool.name`. |
 | `spec.module` | N/A | Removed. You now configure modules with a separate `Module` CRD. [Learn more](#module-controller). |
 
 Below is an example of configuring a variable in v1 of the operator. 

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -89,7 +89,7 @@ The table below lists the field mapping of the `Workspace` controller between v1
 | `spec.agentPoolName` | `spec.agentPool.name` | The `agentPoolName` field is moved to `spec.agentPool.name`. |
 | `spec.module` | N/A | Removed. Modules are now configured with a separate `Module` CRD. Refer to the below migration mapping for more information. |
 
-Below is an example of the differences is how variables are configured between v1 and v2.
+Below is an example of configuring a variable in v1 of the operator. 
 
 <CodeBlockConfig filename="v1.yaml">
 

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -49,7 +49,7 @@ Version 2 of the Terraform Cloud Kubernetes operator renames and moves many exis
 
 ### Workspace controller
 
-Below is the field mapping of the `Workspace` controller from v1 to v2 of the operator.
+The table below lists the field mapping of the `Workspace` controller between v1 and v2 of the operator.
 
 | Version 1 | Version 2 | Notes |
 | --- | --- | --- |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -163,7 +163,7 @@ The table below details the mapping between the `Workspace` controller in v1 of 
 | --- | --- | --- |
 | `spec.module` | N/A | In v2 of the operator a `Module` is a separate controller with its own CRD. |
 | N/A | `spec.name: operator` | In v1 of the operator, the name of the generated module is hardcoded to `operator`. In v2, the default name of the generated module is `this`, however it can be changed. |
-| `spec.module.source` | `spec.module.source` | This supports all Terraform [module sources](https://developer.hashicorp.com/terraform/language/modules/sources). |
+| `spec.module.source` | `spec.module.source` | This supports all Terraform [module sources](/terraform/language/modules/sources). |
 | `spec.module.version` | `spec.module.version` | Refer to  [module sources](/terraform/language/modules/sources) for versioning information for each module source. |
 | `spec.variables.[*]` | `spec.variables.[*].name` | You should include variable names in the module. This is a reference to variables in the workspace that is executing the module. |
 | `spec.outputs.[*].key` | `spec.outputs.[*].name` | You should include output names in the module. This is a reference to the output variables produced by the module. |

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -116,7 +116,7 @@ metadata:
 
 In v2 of the operator, you must configure Terraform variables in `spec.terraformVariables` and environment variables `spec.environmentVariables`.
 
-<CodeBlockConfig filename="v2">
+<CodeBlockConfig filename="v2.yaml">
 
 ```yaml
 apiVersion: app.terraform.io/v1alpha2

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -298,7 +298,7 @@ View the changes that **patch B** will apply to the workspace CRD.
 $ kubectl diff --filename workspaces_patch_b.yaml
 ```
 
-Patch workspace CRD with **patch B**. This patch adds `.status.runStatus` support that was excluded in patch A.
+Patch workspace CRD with patch B. This patch adds `.status.runStatus` support, which was excluded in patch A.
 
 ```shell-session
 $ kubectl patch crd workspaces.app.terraform.io --patch-file workspaces_patch_b.yaml

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -43,12 +43,6 @@ Next, backup the workspace resources.
 $ kubectl get workspace --all-namespaces -o yaml > backup_tfc_operator_v1.yaml
 ```
 
-Finally, we suggest that you set the `applyMethod` of each HCP Terraform workspace to `manual`. In version 2 of the Terraform Cloud Kubernetes Operator this is the default value, however explicitly configuring it with the value provides extra protection from unintended automatic applies during the upgrade process. Run the following command for each Workspace resource.
-
-```shell-session
-kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"applyMethod": "manual"}}'
-```
-
 ## Manifest schema migration
 
 ### Workspace controller
@@ -229,16 +223,24 @@ Here is an example of module migration.
 
 ## Upgrade the operator
 
+Download Workspace CRD patch A:
+
+```shell-session
+$ curl -sO https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_a.yaml
+```
+
 View the changes that **patch A** will apply to the workspace CRD.
 
 ```shell-session
-$ kubectl diff -f https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_a.yaml
+$ kubectl diff --filename workspaces_patch_a.yaml
 ```
 
 Patch the workspace CRD with **patch A**. This patch adds `app.terraform.io/v1alpha2` support, but excludes `.status.runStatus` because it has a different format in `app.terraform.io/v1alpha1` and causes JSON unmarshalling issues.
 
+~> **Warning**<br/> Once the patch is applied, Kubernetes will convert existing `app.terraform.io/v1alpha1` CRs to `app.terraform.io/v1alpha2` according to the updated schema. Fields that are marked as CHANGED or REMOVED in the above migration table will be removed, and CRs will require an update to satisfy the current schema. The Operator v1 won't be able to serve CRs anymore.
+
 ```shell-session
-$ kubectl patch crd workspaces.app.terraform.io --patch-file https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_a.yaml
+$ kubectl patch crd workspaces.app.terraform.io --patch-file workspaces_patch_a.yaml
 ```
 
 Install the Operator v2 Helm chart with the `helm install` command. Be sure to set the `operator.watchedNamespaces` value to the list of namespaces your Workspace resources are deployed to. If this value is not provided, the operator will watch all namespaces in the Kubernetes cluster.
@@ -248,7 +250,6 @@ $ helm install \
   ${RELEASE_NAME} hashicorp/terraform-cloud-operator \
   --version 2.4.0 \
   --namespace ${RELEASE_NAMESPACE} \
-  --set operator.syncPeriod=10m \
   --set 'operator.watchedNamespaces={white,blue,red}' \
   --set controllers.agentPool.workers=5 \
   --set controllers.module.workers=5 \
@@ -261,31 +262,28 @@ Next, create a Kubernetes secret to store the HCP Terraform API token following 
 $ kubectl --namespace ${RELEASE_NAMESPACE} get secret terraformrc -o json | jq '.data.credentials' | tr -d '"' | base64 -d
 ```
 
-If v2 of the operator pod fails to start, ensure that each `workspace` object has the `spec.token` value set. To do this, patch each `workspace` object using following command for each Workspace resource.
+Update existing custom resources accoring to the migration table above and apply your changes:
 
 ```shell-session
-$ kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"name": "NAME", "terraformVersion": "1.4.6", "token": {"secretKeyRef": {"key": "token", "name": "tfc-operator"}}}}'
+$ kubectl apply --filename <UPDATED_V2_WORKSPACE_MANIFEST.yaml>
 ```
 
-Review the logs and verify that there are no error messages reported. The logs will report when the operator begins and finishes reconciling each workspace.
+Download Workspace CRD patch B:
 
 ```shell-session
-$ kubectl logs -f <POD_NAME>
-INFO	Workspace Controller	{"workspace": {"name":"<WORKSPACE_NAME>","namespace":"<NAMESPACE>"}, "msg": "new reconciliation event"}
-##...
-INFO	Workspace Controller	{"workspace": {"name":"<WORKSPACE_NAME>","namespace":"<NAMESPACE>"}, "msg": "successfully reconciled workspace"}
+$ curl -sO https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_b.yaml
 ```
 
-View the changes that **patch B** will apply to the workspace CRD:
+View the changes that **patch B** will apply to the workspace CRD.
 
 ```shell-session
-$ kubectl diff -f https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_b.yaml
+$ kubectl diff --filename workspaces_patch_b.yaml
 ```
 
-Patch workspace CRD with **patch B**. This patch adds `.status.runStatus` support that was excluded in Patch A.
+Patch workspace CRD with **patch B**. This patch adds `.status.runStatus` support that was excluded in patch A.
 
 ```shell-session
-$ kubectl patch crd workspaces.app.terraform.io --patch-file https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/main/docs/migration/crds/workspaces_patch_b.yaml
+$ kubectl patch crd workspaces.app.terraform.io --patch-file workspaces_patch_b.yaml
 ```
 
 The v2 operator will fail to proceed if a custom resource has the v1 finalizer `finalizer.workspace.app.terraform.io`. If you encounter an error, check the logs for more information.
@@ -299,14 +297,29 @@ Specifically, look for an error message such as the following.
 ```
 ERROR	Migration	{"workspace": "default/<WORKSPACE_NAME>", "msg": "spec contains old finalizer finalizer.workspace.app.terraform.io"}
 ```
+
 The `finalizer` exists to provide greater control over the migration process. Verify the custom resource, and when you’re ready to migrate it, use the `kubectl patch` command to update the `finalizer` value.
 
 ```shell-session
 $ kubectl patch workspace migration --type=merge --patch '{"metadata": {"finalizers": ["workspace.app.terraform.io/finalizer"]}}'
 ```
 
-Finally, review the operator logs once more and verify there are no error messages reported.
+Review the operator logs once more and verify there are no error messages reported.
 
 ```shell-session
 $ kubectl logs -f <POD_NAME>
+```
+
+It might take up to `operator.syncPeriod` period before it reconciles resources.
+
+Apply migrated Module custom resources if you have any:
+
+```shell-session
+$ kubectl apply --filename <MIGRATED_V2_MODULE_MANIFEST.yaml>
+```
+
+Finally, by default in the second version `applyMethod` is set to `manual`. In this case, a new run in a managed workspace will require manual approval. Run the following command for each Workspace resource to change it to `auto` approval.
+
+```shell-session
+kubectl patch workspace <WORKSPACE_NAME> --type=merge --patch '{"spec": {"applyMethod": "auto"}}'
 ```

--- a/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/ops-v2-migration.mdx
@@ -45,7 +45,7 @@ $ kubectl get workspace --all-namespaces -o yaml > backup_tfc_operator_v1.yaml
 
 ## Manifest schema migration
 
-In v2 of the operator, many fields have been renamed or moved. You must update your specification with these changes when you migrate to v2 of the operator.
+Version 2 of the Terraform Cloud Kubernetes operator renames and moves many existing fields. When you migrate, you must update your specification to match version 2's field names.
 
 ### Workspace controller
 


### PR DESCRIPTION
### What

Update the HCP Terraform Operator migration guide with the CRD migration table, change the order of some steps, and update them whenever necessary.

### Why

https://hashicorp.atlassian.net/browse/TFECO-6425

### Screenshots

N/A.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
