### PR TITLE
Add documentation for audit trails token

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -46,6 +46,10 @@
       { "title": "Agent Tokens", "path": "api-docs/agent-tokens" },
       { "title": "Applies", "path": "api-docs/applies" },
       { "title": "Audit Trails", "path": "api-docs/audit-trails" },
+      {
+        "title": "Audit Trails Tokens",
+        "path": "api-docs/audit-trails-tokens"
+      },
       { "title": "Assessment Results", "path": "api-docs/assessment-results" },
       {
         "title": "Comments",

--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -119,7 +119,7 @@ curl \
 }
 ```
 
-## Delete the audit trails token
+## Delete a token
 
 `DELETE /organizations/:organization/authentication-token?token=audit-trails`
 

--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -1,0 +1,147 @@
+---
+page_title: Audit Trails Tokens - API Docs - HCP Terraform
+description: >-
+  Use the `/authentication-token` endpoint with the `token` query param to manage audit trails API tokens. Generate and delete audit trails tokens using the HTTP API.
+---
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+
+[JSON API document]: /terraform/cloud-docs/api-docs#json-api-documents
+
+[JSON API error object]: https://jsonapi.org/format/#error-objects
+
+# Audit Trails Token API
+
+## Generate a new audit trails token
+
+`POST /organizations/:organization_name/authentication-token?token=audit-trails`
+
+| Parameter            | Description                                           |
+| -------------------- | ----------------------------------------------------- |
+| `:organization_name` | The name of the organization to generate a token for. |
+
+Generates a new [audit trails API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#audit-trails-api-tokens), replacing any existing token.
+
+Only members of the owners team, the owners [team API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens), and the [organization API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens) can access this endpoint.
+
+This endpoint returns the secret text of the new authentication token. You can only access this token when you create it and can not recover it later.
+
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
+
+| Status  | Response                                                | Reason              |
+| ------- | ------------------------------------------------------- | ------------------- |
+| [201][] | [JSON API document][] (`type: "authentication-tokens"`) | Success             |
+| [404][] | [JSON API error object][]                               | User not authorized |
+
+### Request Body
+
+This POST endpoint requires a JSON object with the following properties as a request payload.
+
+
+| Key path                      | Type   | Default | Description                                                                                                             |
+| ----------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `data.type`                   | string |         | Must be `"authentication-token"`.                                                                                       |
+| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the Audit Trails Token will expire, in ISO 8601 format. If omitted or set to `null` the token will never expire. |
+
+### Sample Payload
+
+```json
+{
+  "data": {
+    "type": "authentication-token",
+    "attributes": {
+      "expired-at": "2023-04-06T12:00:00.000Z"
+    }
+  }
+}
+```
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request POST \
+  --data @payload.json \
+  https://app.terraform.io/api/v2/organizations/my-organization/authentication-token?token=audit-trails
+```
+
+### Sample Response
+
+```json
+{
+  "data": {
+    "id": "4111756",
+    "type": "authentication-tokens",
+    "attributes": {
+      "created-at": "2017-11-29T19:11:28.075Z",
+      "last-used-at": null,
+      "description": null,
+      "token": "ZgqYdzuvlv8Iyg.atlasv1.6nV7t1OyFls341jo1xdZTP72fN0uu9VL55ozqzekfmToGFbhoFvvygIRy2mwVAXomOE",
+      "expired-at": "2023-04-06T12:00:00.000Z"
+    },
+    "relationships": {
+      "created-by": {
+        "data": {
+          "id": "user-62goNpx1ThQf689e",
+          "type": "users"
+        }
+      }
+    }
+  }
+}
+```
+
+## Delete the audit trails token
+
+`DELETE /organizations/:organization/authentication-token?token=audit-trails`
+
+| Parameter            | Description                                   |
+| -------------------- | --------------------------------------------- |
+| `:organization_name` | Which organization's token should be deleted. |
+
+Only members of the owners team, the owners [team API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens), and the [organization API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens) can access this endpoint.
+
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
+
+| Status  | Response                  | Reason              |
+| ------- | ------------------------- | ------------------- |
+| [204][] | No Content                | Success             |
+| [404][] | [JSON API error object][] | User not authorized |
+
+### Sample Request
+
+```shell
+curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request DELETE \
+  https://app.terraform.io/api/v2/organizations/my-organization/authentication-token?token=audit-trails
+```

--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -67,7 +67,7 @@ This POST endpoint requires a JSON object with the following properties as a req
 | Key path                      | Type   | Default | Description                                                                                                             |
 | ----------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `data.type`                   | string |         | Must be `"authentication-token"`.                                                                                       |
-| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the Audit Trails Token will expire, in ISO 8601 format. If omitted or set to `null` the token will never expire. |
+| `data.attributes.expired-at`  | string | `null`  | The UTC date and time that the audit trails token expires, in ISO 8601 format. If omitted or set to `null` the token will never expire. |
 
 ### Sample Payload
 

--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: Audit Trails Tokens - API Docs - HCP Terraform
+page_title: Audit Trail Tokens - API Docs - HCP Terraform
 description: >-
   Use the `/authentication-token` endpoint with the `token` query param to manage audit trails API tokens. Generate and delete audit trails tokens using the HTTP API.
 ---

--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -38,6 +38,8 @@ description: >-
 
 # Audit Trail Tokens API
 
+Audit trail tokens are used to authenticate integrations pulling audit trail data, for example, using the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
+
 ## Generate a new token
 
 `POST /organizations/:organization_name/authentication-token?token=audit-trails`

--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -36,7 +36,7 @@ description: >-
 
 [JSON API error object]: https://jsonapi.org/format/#error-objects
 
-# Audit Trails Token API
+# Audit Trail Tokens API
 
 ## Generate a new token
 

--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -46,7 +46,7 @@ description: >-
 | -------------------- | ----------------------------------------------------- |
 | `:organization_name` | The name of the organization to generate a token for. |
 
-Generates a new [audit trails API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#audit-trails-api-tokens), replacing any existing token.
+Generates a new [audit trails token](/terraform/cloud-docs/users-teams-organizations/api-tokens#audit-trails-tokens), replacing any existing token.
 
 Only members of the owners team, the owners [team API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens), and the [organization API token](/terraform/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens) can access this endpoint.
 

--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -38,7 +38,7 @@ description: >-
 
 # Audit Trails Token API
 
-## Generate a new audit trails token
+## Generate a new token
 
 `POST /organizations/:organization_name/authentication-token?token=audit-trails`
 

--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: Audit Trail Tokens - API Docs - HCP Terraform
 description: >-
-  Use the `/authentication-token` endpoint with the `token` query param to manage audit trails API tokens. Generate and delete audit trails tokens using the HTTP API.
+  Use the `/authentication-token` endpoint with the `token` query param to manage audit trails API tokens. Generate and delete audit trail tokens using the HTTP API.
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,9 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
+## 2024-05-29
+* Add API documentation for the new [audit trails tokens](/terraform/cloud-docs/api-docs/audit-trails-tokens).
+
 ## 2024-05-23
 * Update the [registry modules API](/terraform/cloud-docs/api-docs/private-registry/modules#create-a-module-version) for publishing new versions of branch based modules.
 

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -10,7 +10,7 @@ description: >-
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
 ## 2024-05-29
-* Add API documentation for the new [audit trails tokens](/terraform/cloud-docs/api-docs/audit-trails-tokens).
+* Add API documentation for the new [audit trails token](/terraform/cloud-docs/api-docs/audit-trails-tokens).
 
 ## 2024-05-23
 * Update the [registry modules API](/terraform/cloud-docs/api-docs/private-registry/modules#create-a-module-version) for publishing new versions of branch based modules.

--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -48,11 +48,12 @@ HashiCorp provides a [stability policy](/terraform/cloud-docs/api-docs/stability
 
 All requests must be authenticated with a bearer token. Use the HTTP header `Authorization` with the value `Bearer <token>`. If the token is absent or invalid, HCP Terraform responds with [HTTP status 401][401] and a [JSON API error object][]. The 401 status code is reserved for problems with the authentication token; forbidden requests with a valid token result in a 404.
 
-There are three kinds of tokens available:
+There are four kinds of tokens available:
 
 - [User tokens](/terraform/cloud-docs/users-teams-organizations/users#api-tokens) — each HCP Terraform user can have any number of API tokens, which can make requests on their behalf.
 - [Team tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens) — each team can have one API token at a time. This is intended for performing plans and applies via a CI/CD pipeline.
 - [Organization tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens) — each organization can have one API token at a time. This is intended for automating the management of teams, team membership, and workspaces. The organization token cannot perform plans and applies.
+- [Audit trails tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens#audit-trails-tokens) - each organization can have one audit trails token at a time. This token provides real-only access to an organization's audit trails, and is intended to be used in the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
 
 ### Blob Storage Authentication
 

--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -53,7 +53,7 @@ There are four kinds of tokens available:
 - [User tokens](/terraform/cloud-docs/users-teams-organizations/users#api-tokens) — each HCP Terraform user can have any number of API tokens, which can make requests on their behalf.
 - [Team tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens) — each team can have one API token at a time. This is intended for performing plans and applies via a CI/CD pipeline.
 - [Organization tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens) — each organization can have one API token at a time. This is intended for automating the management of teams, team membership, and workspaces. The organization token cannot perform plans and applies.
-- [Audit trails tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens#audit-trails-tokens) - each organization can have one audit trails token at a time. This token provides real-only access to an organization's audit trails, and is intended to be used in the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
+- [Audit trails token](/terraform/cloud-docs/users-teams-organizations/api-tokens#audit-trails-tokens) - each organization can have a single token that can read that organization's audit trails. Use this token type to authenticate integrations pulling audit trail data, for example, using the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
 
 ### Blob Storage Authentication
 

--- a/website/docs/cloud-docs/integrations/splunk/index.mdx
+++ b/website/docs/cloud-docs/integrations/splunk/index.mdx
@@ -46,7 +46,7 @@ The current release of the HCP Terraform for Splunk app supports the following v
 * Install the [HCP Terraform for Splunk app via Splunkbase](https://splunkbase.splunk.com/app/5141/)
   * Splunk Cloud users should consult the latest instructions on how to [use IDM with cloud-based add-ons](https://docs.splunk.com/Documentation/SplunkCloud/8.0.2007/Admin/IntroGDI#Use_IDM_with_cloud-based_add-ons) within the Splunk documentation.
 * Click "Configure the application"
-* Generate an [Organization token](/terraform/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens) within HCP Terraform
+* Generate an [Audit trails token](/terraform/cloud-docs/users-teams-organizations/api-tokens#audit-trails-tokens) within HCP Terraform
 * Click "complete setup"
 
 Once configured, you’ll be redirected to the Splunk search interface with the pre-configured HCP Terraform dashboards. Splunk will begin importing and indexing the last 14 days of audit log information and populating the dashboards. This process may take a few minutes to complete.

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -53,7 +53,7 @@ Organization API tokens have permissions across the entire organization. They ca
 
 You can generate an audit trails token to read an organization's [audit trails](/terraform/cloud-docs/api-docs/audit-trails). Use this token type to authenticate integrations pulling audit trail data, for example, using the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
 
-To manage the token for reading audit trails for a specific organization, go to **Organization settings > API Token** and use the controls under the "Audit Token" header.
+To manage an organization's audit trails token, go to **Organization settings > API Token** and use the settings under the "Audit Token" header.
 
 Each organization can have **one** valid audit trails token at a time. Only [organization owners](/terraform/cloud-docs/users-teams-organizations/teams#the-owners-team) can generate or revoke an organization's audit trails token.
 

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # API Tokens
 
-HCP Terraform supports three distinct types of API tokens with varying levels of access: user, team, and organization. There are differences in access levels and generation workflows for each of these token types, which are outlined below.
+HCP Terraform supports four distinct types of API tokens with varying levels of access: user, team, organization, and audit trails. There are differences in access levels and generation workflows for each of these token types, which are outlined below.
 
 API tokens are displayed only once when they are created, and are obfuscated thereafter. If the token is lost, it must be regenerated.
 
@@ -48,6 +48,16 @@ Organization API tokens are designed for creating and configuring workspaces and
 Organization API tokens have permissions across the entire organization. They can perform all CRUD operations on most resources, but have some limitations; most importantly, they cannot start runs or create configuration versions. Any API endpoints that can't be used with an organization API token include a note like the following:
 
 -> **Note:** This endpoint cannot be accessed with [organization tokens](#organization-api-tokens). You must access it with a [user token](/terraform/cloud-docs/users-teams-organizations/users#api-tokens) or [team token](#team-api-tokens).
+
+## Audit Trails Tokens
+
+Tokens may be generated for reading organization audit trails. They are intended to be used in the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
+
+To manage the token for reading audit trails for a specific organization, go to **Organization settings > API Token** and use the controls under the "Audit Token" header.
+
+Each organization can have **one** valid audit trails token at a time. Only [organization owners](/terraform/cloud-docs/users-teams-organizations/teams#the-owners-team) can generate or revoke an organization's audit trails token.
+
+[permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 ## Agent API Tokens
 

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # API Tokens
 
-HCP Terraform supports four distinct types of API tokens with varying levels of access: user, team, organization, and audit trails. There are differences in access levels and generation workflows for each of these token types, which are outlined below.
+HCP Terraform supports many distinct types of API tokens with varying levels of access: user, team, organization, and audit trails. There are differences in access levels and generation workflows for each of these token types, which are outlined below.
 
 API tokens are displayed only once when they are created, and are obfuscated thereafter. If the token is lost, it must be regenerated.
 

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -51,7 +51,7 @@ Organization API tokens have permissions across the entire organization. They ca
 
 ## Audit Trails Tokens
 
-Tokens may be generated for reading organization audit trails. They are intended to be used in the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
+You can generate an audit trails token to read an organization's [audit trails](/terraform/cloud-docs/api-docs/audit-trails). Use this token type to authenticate integrations pulling audit trail data, for example, using the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
 
 To manage the token for reading audit trails for a specific organization, go to **Organization settings > API Token** and use the controls under the "Audit Token" header.
 

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -55,7 +55,7 @@ You can generate an audit trails token to read an organization's [audit trails](
 
 To manage an organization's audit trails token, go to **Organization settings > API Token** and use the settings under the "Audit Token" header.
 
-Each organization can have **one** valid audit trails token at a time. Only [organization owners](/terraform/cloud-docs/users-teams-organizations/teams#the-owners-team) can generate or revoke an organization's audit trails token.
+Each organization can only have a _single_ valid audit trails token. Only [organization owners](/terraform/cloud-docs/users-teams-organizations/teams#the-owners-team) can generate or revoke an organization's audit trails token.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -49,7 +49,7 @@ Organization API tokens have permissions across the entire organization. They ca
 
 -> **Note:** This endpoint cannot be accessed with [organization tokens](#organization-api-tokens). You must access it with a [user token](/terraform/cloud-docs/users-teams-organizations/users#api-tokens) or [team token](#team-api-tokens).
 
-## Audit Trails Tokens
+## Audit trail tokens
 
 You can generate an audit trails token to read an organization's [audit trails](/terraform/cloud-docs/api-docs/audit-trails). Use this token type to authenticate integrations pulling audit trail data, for example, using the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
 


### PR DESCRIPTION
### What
Adds documentation for the [newly added audit trails token type](https://hermes.hashicorp.services/document/13tDFupiVXekgj0xWJ0njU-13vLVYJO3_6JHpw9Ug_4Y).

### Why
To document the new and more secure method of generating audit trails token to use in the TFC Splunk app (rather than using organization tokens, as was the previously recommended practice)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages. **N/A**
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. **N/A**
- [X] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [X] UI elements (button names, page names, etc.) are bolded. **N/A**
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
