### PR TITLE
Correct configuration_version#create endpoint in example for tf test

### DIFF
--- a/website/docs/cloud-docs/api-docs/private-registry/tests.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/tests.mdx
@@ -241,8 +241,7 @@ curl \
   --header "Authorization: Bearer $TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
-  --data @payload.json \
-  https://app.terraform.io/api/v2/organizations/my-organization/tests/registry-modules/private/my-organization/registry-name/registry-provider/test-runs
+  https://app.terraform.io/api/v2/organizations/my-organization/tests/registry-modules/private/my-organization/registry-name/registry-provider/test-runs/configuration-versions
 ```
 
 ### Sample Response


### PR DESCRIPTION
### What
This PR corrects the uri in the config_version#create call for tf test as well as removes the unnecessary payload
### Why
The URI in the example block is incorrect and there is no payload.
### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).

#### Content
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
