### PR TITLE
Clarify the behavior of updating the designated no-code version

### DIFF
--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -63,7 +63,7 @@ Start a new run in your workspace to update your existing infrastructure with yo
 
 ### Module Version Updates
 
-When you publish a new tag for a no-code module or change the module version made available to the end user, every workspace that is provisioned with the module is notified that an updated version is available on the workspace overview page. HCP Terraform does not automatically update the workspaces; instead the workspace owner must respond to the notification to update their workspace. HCP Terraform will prompt them to provide values for any new variables.
+When you [update the module version](/terraform/cloud-docs/no-code-provisioning/module-design#updating-a-module-s-version) that is designated for no-code provisioning, every workspace that is provisioned with the module is notified that an updated version is available on the workspace overview page. HCP Terraform does not automatically update the workspaces; instead the workspace owner must respond to the notification to update their workspace. HCP Terraform will prompt them to provide values for any new variables.
 
 To change the version of the module that users can deploy:
 

--- a/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
+++ b/website/docs/cloud-docs/no-code-provisioning/provisioning.mdx
@@ -63,7 +63,7 @@ Start a new run in your workspace to update your existing infrastructure with yo
 
 ### Module Version Updates
 
-When you [update the module version](/terraform/cloud-docs/no-code-provisioning/module-design#updating-a-module-s-version) that is designated for no-code provisioning, every workspace that is provisioned with the module is notified that an updated version is available on the workspace overview page. HCP Terraform does not automatically update the workspaces; instead the workspace owner must respond to the notification to update their workspace. HCP Terraform will prompt them to provide values for any new variables.
+When you [update the module version](/terraform/cloud-docs/no-code-provisioning/module-design#updating-a-module-s-version) designated for no-code provisioning, every workspace provisioned from the module is notified that an updated version is available on the workspace overview page. HCP Terraform does not automatically update workspaces. A workspace admin must respond to the update notification to upgrade the workspace, and HCP Terraform prompts for values for any new input variables.
 
 To change the version of the module that users can deploy:
 


### PR DESCRIPTION
### What
Clarified/corrected how no-code module version upgrades are initiated.

### Why
The docs incorrectly stated that pushing a new tag to the module would cause the no-code vesion to be updated. But only actively updating the designated/pinned version does this.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A)] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A)] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
