### PR TITLE
Docs/update migrate state instructions

### DIFF
--- a/website/docs/cloud-docs/migrate/index.mdx
+++ b/website/docs/cloud-docs/migrate/index.mdx
@@ -1,17 +1,17 @@
 ---
 page_title: Migrating to HCP Terraform or Terraform Enterprise - HCP Terraform
 description: >-
-  Migrate state to HCP Terraform or Terraform Enterprise to continue managing
+  Learn how to migrate existing Terraform state files to HCP Terraform or Terraform Enterprise so that you can manage
   existing infrastructure without de-provisioning.
 ---
 
-# Migrating to HCP Terraform or Terraform Enterprise
+# Migrate Terraform state to HCP Terraform or Terraform Enterprise
 
-This topic describes how to migrate Terraform state files to HCP Terraform and Terraform Enterprise. Refer to [State](/terraform/language/state) in the Terraform configuration language reference for additional information about state. 
+This topic describes how to migrate existing Terraform state files to HCP Terraform or Terraform Enterprise without first de-provisioning them. Refer to [State](/terraform/language/state) in the Terraform configuration language reference for additional information about Terraform state. 
 
 ## Overview
 
-Perform the following actions to migrate existing resources to one or more workspaces in HCP Terraform or Terraform Enterprise without de-provisioning them:
+Perform the following actions to migrate existing resources to one or more workspaces in HCP Terraform or Terraform Enterprise:
 
 1. Stop all Terraform operations associated with the state files. 
 1. Migrate Terraform state files using either the Terraform CLI or the HCP Terraform or Terraform Enterprise API.

--- a/website/docs/cloud-docs/migrate/index.mdx
+++ b/website/docs/cloud-docs/migrate/index.mdx
@@ -75,5 +75,5 @@ Stop all Terraform operations associated with the state files. This may require 
    - [Create a state version](/terraform/enterprise/api-docs/state-versions#create-a-state-version) in the Terraform Enterprise API reference documentation.
 1. Send a `POST` request to the `/workspaces/:workspace_id/actions/unlock` endpoint to unlock the workspace. 
 
-Refer to the following external article for an example how to create a script in Python to automate multiple state files:
+Refer to the following external article for an example of how to create a script in Python to automate multiple state files:
 [Migrating A Lot of State with Python and the HCP Terraform (previously Terraform Cloud) API](https://medium.com/hashicorp-engineering/migrating-a-lot-of-state-with-python-and-the-terraform-cloud-api-997ec798cd11). The example uses the [Workspaces API](/terraform/cloud-docs/api-docs/workspaces#create-a-workspace) to create the necessary workspaces in HCP Terraform and the [State Versions API](/terraform/cloud-docs/api-docs/state-versions) to migrate the state files to those workspaces.

--- a/website/docs/cloud-docs/migrate/index.mdx
+++ b/website/docs/cloud-docs/migrate/index.mdx
@@ -34,9 +34,9 @@ Stop all Terraform operations associated with the state files. This may require 
 1. Add the `cloud` block to your Terraform configuration and specify the following fields:
    1. `hostname` field: Specify either `app.terraform.io` for HCP Terraform or the hostname of your Terraform Enterprise deployment. 
    1. `organization` field: Specify your HCP Terraform or Terraform Enterprise organization. 
-   1. `workspaces` block: Add the `tags` field and specify one or more destination workspaces as a list of strings. 
+   1. `workspaces` block: Add a `tags` or `name` field and specify one or more destination workspaces as a list of strings. 
 
-   The following example below shows how you can map your CLI workspaces to HCP Terraform workspaces that have a specific tag.
+   Refer to [The `cloud` Block](/terraform/cli/cloud/settings#the-cloud-block) in the Terraform CLI documentation for additional information. The following example migrates the state associated with the configuration to the `networking` workspace on HCP Terraform:
 
   ```
   terraform {
@@ -58,7 +58,7 @@ Stop all Terraform operations associated with the state files. This may require 
 1. Encode your state files as a base64 string and generate an MD5 hash. The following example generates the string and hash file for a single `terraform.tfstate` file:
 
    ```shell-session
-    $ echo terraform.tfstate | base64
+    $ cat terraform.tfstate | base64
     dGVycmFmb3JtLnRmc3RhdGUK
     $ md5sum terraform.tfstate
     690a3f8ae079c629494a52c68757d585  terraform.tfstate

--- a/website/docs/cloud-docs/migrate/index.mdx
+++ b/website/docs/cloud-docs/migrate/index.mdx
@@ -7,37 +7,73 @@ description: >-
 
 # Migrating to HCP Terraform or Terraform Enterprise
 
-You can begin using HCP Terraform to manage existing resources without de-provisioning them. This requires migrating the Terraform [state files](/terraform/language/state) for those resources to one or more HCP Terraform workspaces. You can perform this migration with either the Terraform CLI or the HCP Terraform API.
+This topic describes how to migrate Terraform state files to HCP Terraform and Terraform Enterprise. Refer to [State](/terraform/language/state) in the Terraform configuration language reference for additional information about state. 
 
-> **Hands-on:** Try the [Migrate State to HCP Terraform](/terraform/tutorials/state/cloud-migrate) tutorial to practice using the CLI method.
+## Overview
+
+Perform the following actions to migrate existing resources to one or more workspaces in HCP Terraform or Terraform Enterprise without de-provisioning them:
+
+1. Stop all Terraform operations associated with the state files. 
+1. Migrate Terraform state files using either the Terraform CLI or the HCP Terraform or Terraform Enterprise API.
+
+> **Hands-on:** Complete the [Migrate State to HCP Terraform](/terraform/tutorials/state/cloud-migrate) tutorial for additional guidance on how to migrate Terraform state using the CLI.
 
 ## Requirements
 
-Stop all Terraform operations involving the state files before migrating them. This may involve locking or deleting CI jobs, restricting access to the state backend, or communicating with other teams. You should also only migrate state files into HCP Terraform workspaces that have never performed a run.
+- Terraform v1.1 and later is required to configure the `cloud` block. For Terraform v1.0 and older, use the [`remote` backend](/terraform/language/settings/backends/remote) instead.
+- You must present a token linked to appropriate permissions to use the API. Refer to the following topics for additional information:
+  - [HCP Terraform API overview](/terraform/cloud-docs/api-docs)
+  - [Terraform Enterprise API overview](/terraform/enterprise/api-docs)
 
-## CLI Migration
+## Stop Terraform operations
 
-To migrate with the Terraform CLI, add the `cloud` block to your configuration, specify one or more HCP Terraform workspaces for the state files, and run `terraform init`. If the workspaces you choose do not yet exist, HCP Terraform creates them automatically in the specified organization.
+Stop all Terraform operations associated with the state files. This may require locking or deleting CI jobs, restricting access to the state backend, and communicating with other teams. You should also only migrate state files into HCP Terraform or Terraform Enterprise workspaces that have never performed a run.
 
-The example below shows how you can map your CLI workspaces to HCP Terraform workspaces that have a specific tag.
+## Migrate state using the CLI
 
-```
-terraform {
-  cloud {
-    organization = "my-org"
-    workspaces {
-      tags = ["networking"]
+1. Add the `cloud` block to your Terraform configuration and specify the following fields:
+   1. `hostname` field: Specify either `app.terraform.io` for HCP Terraform or the hostname of your Terraform Enterprise deployment. 
+   1. `organization` field: Specify your HCP Terraform or Terraform Enterprise organization. 
+   1. `workspaces` block: Add the `tags` field and specify one or more destination workspaces as a list of strings. 
+
+   The following example below shows how you can map your CLI workspaces to HCP Terraform workspaces that have a specific tag.
+
+  ```
+  terraform {
+    cloud {
+      hostname = "app.terraform.io"
+      organization = "my-org"
+      workspaces {
+        tags = ["networking"]
+      }
     }
   }
-}
-```
+  ```
 
-Refer to [Using HCP Terraform](/terraform/cli/cloud) in the Terraform CLI documentation for details about how to configure the `cloud` block and migrate state to one or more HCP Terraform workspaces.
+1. Run `terraform init`. Terraform creates any workspaces specified in the configuration if they do not already exist in the organization.
 
--> **Note:** The `cloud` block is available in Terraform v1.1 and later. Previous versions can use the [`remote` backend](/terraform/language/settings/backends/remote) to configure the CLI workflow and migrate state.
 
-## API Migration
+## Migrate state using the API
 
-You can use the HCP Terraform API to automate migrating many state files at once.
+1. Encode your state files as a base64 string and generate an MD5 hash. The following example generates the string and hash file for a single `terraform.tfstate` file:
 
-This blog post contains an example of how to automate state migration with the API: [Migrating A Lot of State with Python and the HCP Terraform (previously Terraform Cloud) API](https://medium.com/hashicorp-engineering/migrating-a-lot-of-state-with-python-and-the-terraform-cloud-api-997ec798cd11). The example uses the [Workspaces API](/terraform/cloud-docs/api-docs/workspaces#create-a-workspace) to create the necessary workspaces in HCP Terraform and the [State Versions API](/terraform/cloud-docs/api-docs/state-versions) to migrate the state files to those workspaces.
+   ```shell-session
+    $ echo terraform.tfstate | base64
+    dGVycmFmb3JtLnRmc3RhdGUK
+    $ md5sum terraform.tfstate
+    690a3f8ae079c629494a52c68757d585  terraform.tfstate
+    ```
+   
+1. If the workspace does not yet exist in your organization, send a `POST` request to the `/organizations/:organization_name/workspaces` endpoint to create it. Otherwise, proceed to the next step. Refer to the following topics for details:
+   - [Create a workspace](/terraform/cloud-docs/api-docs/workspaces#create-a-workspace) in the HCP Terraform API reference documentation. 
+   - [Create a workspace](/terraform/enterprise/api-docs/workspaces#create-a-workspace) in the Terraform Enterprise API reference documentation.
+1. Send a `POST` request to the `/workspaces/:workspace_id/actions/lock` endpoint to lock the workspace. Refer to the following topics for details:
+   - [Lock a workspace](/terraform/cloud-docs/api-docs/workspaces#lock-a-workspace) in the HCP Terraform API reference documentation. 
+   - [Lock a workspace](/terraform/enterprise/api-docs/workspaces#lock-a-workspace) in the Terraform Enterprise API reference documentation. 
+1. To upload your state files to the workspace, send a `POST` request to the `/workspaces/:workspace_id/state-versions` endpoint. Specify the MD5 string in the `data.attributes.md5` field and encoded state file in the `data.attributes.state` field of the request body.  Refer to the following topics for details:
+   - [Create a state version](/terraform/cloud-docs/api-docs/state-versions#create-a-state-version) in the HCP Terraform API reference documentation. 
+   - [Create a state version](/terraform/enterprise/api-docs/state-versions#create-a-state-version) in the Terraform Enterprise API reference documentation.
+1. Send a `POST` request to the `/workspaces/:workspace_id/actions/unlock` endpoint to unlock the workspace. 
+
+Refer to the following external article for an example how to create a script in Python to automate multiple state files:
+[Migrating A Lot of State with Python and the HCP Terraform (previously Terraform Cloud) API](https://medium.com/hashicorp-engineering/migrating-a-lot-of-state-with-python-and-the-terraform-cloud-api-997ec798cd11). The example uses the [Workspaces API](/terraform/cloud-docs/api-docs/workspaces#create-a-workspace) to create the necessary workspaces in HCP Terraform and the [State Versions API](/terraform/cloud-docs/api-docs/state-versions) to migrate the state files to those workspaces.


### PR DESCRIPTION
### What
This PR updates the instructions for migrating existing TF state files to the cloud platforms. The original request identified a missing field in the configuration and that the content was oriented toward HCP TF only. 
As part of the update, I refactored the information so that it aligns better with our usage content type format. I also provided minimal instructions for using the API to complete the action. In the future, we should provide more complete instructions, including example request calls and request body configurations. Although it is inconsistent with our documentation guidelines, I left the link to the external example for now.   

[Preview](https://terraform-docs-common-git-docs-update-migrate-62747d-hashicorp.vercel.app/terraform/cloud-docs/migrate)

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [X] Description links to related pull requests or issues, if any.

#### Content
- [X] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
