### PR TITLE
Adding Agent Pool associations to OAuth Client for Private VCS

### DIFF
--- a/website/docs/cloud-docs/api-docs/oauth-clients.mdx
+++ b/website/docs/cloud-docs/api-docs/oauth-clients.mdx
@@ -115,6 +115,14 @@ curl \
           "links": {
             "related": "/api/v2/oauth-tokens/ot-KaeqH4cy72VPXFQT"
           }
+        },
+        "agent-pool": {
+            "data": { 
+              "id": "apool-VsmjEMcYkShrckpK", "type": "agent-pools" 
+            },
+            "links": { 
+              "related": "/api/v2/agent-pools/apool-VsmjEMcYkShrckpK" 
+            }
         }
       }
     }
@@ -184,6 +192,14 @@ curl \
         "data": [],
         "links": {
           "related": "/api/v2/oauth-tokens/ot-KaeqH4cy72VPXFQT"
+        }
+      },
+      "agent-pool": {
+        "data": { 
+          "id": "apool-VsmjEMcYkShrckpK", "type": "agent-pools" 
+        },
+        "links": { 
+          "related": "/api/v2/agent-pools/apool-VsmjEMcYkShrckpK" 
         }
       }
     }

--- a/website/docs/cloud-docs/api-docs/oauth-clients.mdx
+++ b/website/docs/cloud-docs/api-docs/oauth-clients.mdx
@@ -118,7 +118,8 @@ curl \
         },
         "agent-pool": {
             "data": { 
-              "id": "apool-VsmjEMcYkShrckpK", "type": "agent-pools" 
+              "id": "apool-VsmjEMcYkShrckpK", 
+              "type": "agent-pools" 
             },
             "links": { 
               "related": "/api/v2/agent-pools/apool-VsmjEMcYkShrckpK" 
@@ -274,11 +275,10 @@ Properties without a default value are required.
         ]
       },
       "agent-pool": {
-        "data": 
-          { 
+        "data": { 
             "id": "apool-VsmjEMcYkShrckzzz",
             "type": "agent-pools"
-            } 
+        } 
       }
     }
   }
@@ -338,11 +338,10 @@ curl \
         }
       },
       "agent-pool": {
-        "data": 
-          { 
+        "data": { 
             "id": "apool-VsmjEMcYkShrckzzz",
             "type": "agent-pools"
-          }
+        }
       }
     }
   }
@@ -399,8 +398,10 @@ This PATCH endpoint requires a JSON object with the following properties as a re
         ]
       },
       "agent-pool": {
-        "data": 
-          { "id": "apool-VsmjEMcYkShrckzzz", "type": "agent-pools" } 
+        "data": { 
+            "id": "apool-VsmjEMcYkShrckzzz", 
+            "type": "agent-pools" 
+        } 
       }
     }
   }
@@ -460,8 +461,10 @@ curl \
         }
       },
       "agent-pool": {
-        "data": 
-          { "id": "apool-VsmjEMcYkShrckzzz", "type": "agent-pools" } 
+        "data": { 
+          "id": "apool-VsmjEMcYkShrckzzz", 
+          "type": "agent-pools" 
+        } 
       }
     }
   }

--- a/website/docs/cloud-docs/api-docs/oauth-clients.mdx
+++ b/website/docs/cloud-docs/api-docs/oauth-clients.mdx
@@ -251,6 +251,7 @@ Properties without a default value are required.
 | `data.attributes.rsa-public-key`     | string |         | **Required for Bitbucket Data Center in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your Bitbucket Data Center application link.   |
 | `data.attributes.organization-scoped` | boolean |         | Whether or not the OAuth client is scoped to all projects and workspaces in the organization. Defaults to `true`.
 | `data.relationships.projects.data[]` | array\[object] | `[]`      | A list of resource identifier objects that defines which projects are associated with the OAuth client. If `data.attributes.organization-scoped` is set to `false`, the OAuth client is only available to this list of projects. Each object in this list must contain a project `id` and use the `"projects"` type. For example, `{ "id": "prj-AwfuCJTkdai4xj9w", "type": "projects" }`. |
+| `data.relationships.agent-pool.data` | object | `{}`    | **For Private VCS** The Agent Pool associated to the VCS connection. This pool will be responsible for forwarding VCS Provider API calls and cloning VCS repositories.                         |
 
 ### Sample Payload
 
@@ -270,6 +271,10 @@ Properties without a default value are required.
         "data": [
           { "id": "prj-AwfuCJTkdai4xj9w", "type": "projects" }
         ]
+      },
+      "agent-pool": {
+        "data": 
+          { "id": "apool-VsmjEMcYkShrckzzz", "type": "agent-pools" } 
       }
     }
   }

--- a/website/docs/cloud-docs/api-docs/oauth-clients.mdx
+++ b/website/docs/cloud-docs/api-docs/oauth-clients.mdx
@@ -252,7 +252,7 @@ Properties without a default value are required.
 | `data.attributes.rsa-public-key`     | string |         | **Required for Bitbucket Data Center in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your Bitbucket Data Center application link.   |
 | `data.attributes.organization-scoped` | boolean |         | Whether or not the OAuth client is scoped to all projects and workspaces in the organization. Defaults to `true`.
 | `data.relationships.projects.data[]` | array\[object] | `[]`      | A list of resource identifier objects that defines which projects are associated with the OAuth client. If `data.attributes.organization-scoped` is set to `false`, the OAuth client is only available to this list of projects. Each object in this list must contain a project `id` and use the `"projects"` type. For example, `{ "id": "prj-AwfuCJTkdai4xj9w", "type": "projects" }`. |
-| `data.relationships.agent-pool.data` | object | `{}`    | **For Private VCS** The Agent Pool associated to the VCS connection. This pool will be responsible for forwarding VCS Provider API calls and cloning VCS repositories.                         |
+| `data.relationships.agent-pool.data` | object | `{}`    | The Agent Pool associated to the VCS connection. This pool will be responsible for forwarding VCS Provider API calls and cloning VCS repositories.                         |
 
 ### Sample Payload
 
@@ -378,7 +378,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 | `data.attributes.rsa-public-key` | string | (previous value) | **Required for Bitbucket Data Center in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your Bitbucket Data Center application link. |
 | `data.attributes.organization-scoped` | boolean | (previous value) | Whether or not the OAuth client is available to all projects and workspaces in the organization.                                                                      |
 | `data.relationships.projects`    | array\[object] | (previous value) | A list of resource identifier objects that defines which projects are associated with the OAuth client. If `data.attributes.organization-scoped` is set to `false`, the OAuth client is only available to this list of projects. Each object in this list must contain a project `id` and use the `"projects"` type. For example, `{ "id": "prj-AwfuCJTkdai4xj9w", "type": "projects" }`. Sending an empty array clears all project assignments.                                               |
-| `data.relationships.agent-pool.data` | object | `{}`    | **For Private VCS** The Agent Pool associated to the VCS connection. This pool will be responsible for forwarding VCS Provider API calls and cloning VCS repositories.                            |
+| `data.relationships.agent-pool.data` | object | `{}`    | The Agent Pool associated to the VCS connection. This pool will be responsible for forwarding VCS Provider API calls and cloning VCS repositories.                            |
 
 ### Sample Payload
 

--- a/website/docs/cloud-docs/api-docs/oauth-clients.mdx
+++ b/website/docs/cloud-docs/api-docs/oauth-clients.mdx
@@ -332,6 +332,10 @@ curl \
         "links": {
           "related": "/api/v2/oauth-tokens/ot-KaeqH4cy72VPXFQT"
         }
+      },
+      "agent-pool": {
+        "data": 
+          { "id": "apool-VsmjEMcYkShrckzzz", "type": "agent-pools" } 
       }
     }
   }
@@ -367,6 +371,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 | `data.attributes.rsa-public-key` | string | (previous value) | **Required for Bitbucket Data Center in conjunction with the `secret`. Not used for any other providers.** The text of the SSH public key associated with your Bitbucket Data Center application link. |
 | `data.attributes.organization-scoped` | boolean | (previous value) | Whether or not the OAuth client is available to all projects and workspaces in the organization.                                                                      |
 | `data.relationships.projects`    | array\[object] | (previous value) | A list of resource identifier objects that defines which projects are associated with the OAuth client. If `data.attributes.organization-scoped` is set to `false`, the OAuth client is only available to this list of projects. Each object in this list must contain a project `id` and use the `"projects"` type. For example, `{ "id": "prj-AwfuCJTkdai4xj9w", "type": "projects" }`. Sending an empty array clears all project assignments.                                               |
+| `data.relationships.agent-pool.data` | object | `{}`    | **For Private VCS** The Agent Pool associated to the VCS connection. This pool will be responsible for forwarding VCS Provider API calls and cloning VCS repositories.                            |
 
 ### Sample Payload
 
@@ -385,6 +390,10 @@ This PATCH endpoint requires a JSON object with the following properties as a re
         "data": [
           { "id": "prj-AwfuCJTkdai4xj9w", "type": "projects" }
         ]
+      },
+      "agent-pool": {
+        "data": 
+          { "id": "apool-VsmjEMcYkShrckzzz", "type": "agent-pools" } 
       }
     }
   }
@@ -442,6 +451,10 @@ curl \
         "links": {
           "related": "/api/v2/oauth-tokens/ot-KaeqH4cy72VPXFQT"
         }
+      },
+      "agent-pool": {
+        "data": 
+          { "id": "apool-VsmjEMcYkShrckzzz", "type": "agent-pools" } 
       }
     }
   }

--- a/website/docs/cloud-docs/api-docs/oauth-clients.mdx
+++ b/website/docs/cloud-docs/api-docs/oauth-clients.mdx
@@ -196,7 +196,8 @@ curl \
       },
       "agent-pool": {
         "data": { 
-          "id": "apool-VsmjEMcYkShrckpK", "type": "agent-pools" 
+          "id": "apool-VsmjEMcYkShrckpK",
+          "type": "agent-pools"
         },
         "links": { 
           "related": "/api/v2/agent-pools/apool-VsmjEMcYkShrckpK" 
@@ -274,7 +275,10 @@ Properties without a default value are required.
       },
       "agent-pool": {
         "data": 
-          { "id": "apool-VsmjEMcYkShrckzzz", "type": "agent-pools" } 
+          { 
+            "id": "apool-VsmjEMcYkShrckzzz",
+            "type": "agent-pools"
+            } 
       }
     }
   }
@@ -335,7 +339,10 @@ curl \
       },
       "agent-pool": {
         "data": 
-          { "id": "apool-VsmjEMcYkShrckzzz", "type": "agent-pools" } 
+          { 
+            "id": "apool-VsmjEMcYkShrckzzz",
+            "type": "agent-pools"
+          }
       }
     }
   }


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Private VCS allows us to associate an Agent Pool to an OAuth Client. This change documents the  API changes to support that.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
Users can now configure Private VCS connections via the API. The API also serves as the backend for `go-tfe` and `terraform-provider-tfe`. The provider [PR](https://github.com/hashicorp/terraform-provider-tfe/pull/1255) is already merged.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [X] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
