### PR TITLE
Update API docs to consistently refer to user ID as the same thing

### DIFF
--- a/website/docs/cloud-docs/api-docs/team-members.mdx
+++ b/website/docs/cloud-docs/api-docs/team-members.mdx
@@ -67,7 +67,7 @@ Properties without a default value are required.
 | Key path      | Type   | Default | Description                      |
 | ------------- | ------ | ------- | -------------------------------- |
 | `data[].type` | string |         | Must be `"users"`.               |
-| `data[].id`   | string |         | The username of the user to add. |
+| `data[].id`   | string |         | The ID of the user you want to add to this team. |
 
 ### Sample Payload
 
@@ -165,7 +165,7 @@ Properties without a default value are required.
 | Key path      | Type   | Default | Description                         |
 | ------------- | ------ | ------- | ----------------------------------- |
 | `data[].type` | string |         | Must be `"users"`.                  |
-| `data[].id`   | string |         | The username of the user to remove. |
+| `data[].id`   | string |         | The ID of the user to remove from this team. |
 
 ### Sample Payload
 

--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -2792,7 +2792,7 @@ It is important to note that `type`, as well as one of `id` _or_ `attributes.nam
 | Key path                 | Type   | Default | Description                 |
 | ------------------------ | ------ | ------- | --------------------------- |
 | `data[].type`            | string |         | Must be `"tags"`.           |
-| `data[].id`              | string |         | The id of the tag to add.   |
+| `data[].id`              | string |         | The ID of the tag to add.   |
 | `data[].attributes.name` | string |         | The name of the tag to add. |
 
 ### Sample Payload
@@ -2860,7 +2860,7 @@ It is important to note that `type`, as well as one of `id` _or_ `attributes.nam
 | Key path                 | Type   | Default | Description                    |
 | ------------------------ | ------ | ------- | ------------------------------ |
 | `data[].type`            | string |         | Must be `"tags"`.              |
-| `data[].id`              | string |         | The id of the tag to remove.   |
+| `data[].id`              | string |         | The ID of the tag to remove.   |
 | `data[].attributes.name` | string |         | The name of the tag to remove. |
 
 ### Sample Payload


### PR DESCRIPTION
We had some inconsistencies in the descriptions of `user_id`'s, so this fixes everywhere I was able to find those inconsistencies! 

[🎟️ Jira ticket](https://hashicorp.atlassian.net/browse/IPE-786)