### PR TITLE
Add HCP `auth_method` attribute

### DIFF
--- a/website/docs/cloud-docs/api-docs/account.mdx
+++ b/website/docs/cloud-docs/api-docs/account.mdx
@@ -70,7 +70,7 @@ curl \
     "attributes": {
       "username": "admin",
       "is-service-account": false,
-      "auth-type": "tfc",
+      "auth-method": "tfc",
       "avatar-url": "https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm",
       "v2-only": false,
       "is-site-admin": true,
@@ -163,7 +163,7 @@ curl \
     "attributes": {
       "username": "admin",
       "is-service-account": false,
-      "auth-type": "hcp_username_password",
+      "auth-method": "hcp_username_password",
       "avatar-url": "https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm",
       "v2-only": false,
       "is-site-admin": true,
@@ -247,7 +247,7 @@ curl \
     "attributes": {
       "username": "admin",
       "is-service-account": false,
-      "auth-type": "hcp_github",
+      "auth-method": "hcp_github",
       "avatar-url": "https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm",
       "v2-only": false,
       "is-site-admin": true,

--- a/website/docs/cloud-docs/api-docs/account.mdx
+++ b/website/docs/cloud-docs/api-docs/account.mdx
@@ -70,6 +70,7 @@ curl \
     "attributes": {
       "username": "admin",
       "is-service-account": false,
+      "auth-type": "tfc",
       "avatar-url": "https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm",
       "v2-only": false,
       "is-site-admin": true,
@@ -162,6 +163,7 @@ curl \
     "attributes": {
       "username": "admin",
       "is-service-account": false,
+      "auth-type": "hcp_username_password",
       "avatar-url": "https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm",
       "v2-only": false,
       "is-site-admin": true,
@@ -245,6 +247,7 @@ curl \
     "attributes": {
       "username": "admin",
       "is-service-account": false,
+      "auth-type": "hcp_github",
       "avatar-url": "https://www.gravatar.com/avatar/9babb00091b97b9ce9538c45807fd35f?s=100&d=mm",
       "v2-only": false,
       "is-site-admin": true,

--- a/website/docs/cloud-docs/api-docs/organization-memberships.mdx
+++ b/website/docs/cloud-docs/api-docs/organization-memberships.mdx
@@ -149,7 +149,7 @@ $ curl \
       "attributes": {
         "username": null,
         "is-service-account": false,
-        "auth-type": "hcp_sso",
+        "auth-method": "hcp_sso",
         "avatar-url": "https://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=100&d=mm",
         "two-factor": {
           "enabled": false,

--- a/website/docs/cloud-docs/api-docs/organization-memberships.mdx
+++ b/website/docs/cloud-docs/api-docs/organization-memberships.mdx
@@ -149,6 +149,7 @@ $ curl \
       "attributes": {
         "username": null,
         "is-service-account": false,
+        "auth-type": "hcp_sso",
         "avatar-url": "https://www.gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?s=100&d=mm",
         "two-factor": {
           "enabled": false,

--- a/website/docs/cloud-docs/api-docs/users.mdx
+++ b/website/docs/cloud-docs/api-docs/users.mdx
@@ -78,7 +78,7 @@ curl \
     "attributes": {
       "username": "admin",
       "is-service-account": false,
-      "auth-type": "hcp_sso",
+      "auth-method": "hcp_sso",
       "avatar-url": "https://www.gravatar.com/avatar/fa1f0c9364253d351bf1c7f5c534cd40?s=100&d=mm",
       "v2-only": true,
       "permissions": {

--- a/website/docs/cloud-docs/api-docs/users.mdx
+++ b/website/docs/cloud-docs/api-docs/users.mdx
@@ -78,6 +78,7 @@ curl \
     "attributes": {
       "username": "admin",
       "is-service-account": false,
+      "auth-type": "hcp_sso",
       "avatar-url": "https://www.gravatar.com/avatar/fa1f0c9364253d351bf1c7f5c534cd40?s=100&d=mm",
       "v2-only": true,
       "permissions": {


### PR DESCRIPTION
[🎟️ Jira Ticket](https://hashicorp.atlassian.net/browse/IPE-653)

Since introducing linked accounts, we added a new field to `"users"`, so this PR updates API responses to match. 

"There should be an output for `auth_method` which describes the HCP account type that the user may be linked to. This is useful for a customer particularly who is looking to enforce all users link with the `hcp_sso` auth_method which is enabled for a customer domain in an approved allowlist."