### PR TITLE
IPL-5982: Clarify that notifications won't be sent for speculative plans

### DIFF
--- a/website/docs/cloud-docs/api-docs/notification-configurations.mdx
+++ b/website/docs/cloud-docs/api-docs/notification-configurations.mdx
@@ -42,6 +42,8 @@ HCP Terraform can send notifications for run state transitions and workspace eve
 
 Interacting with notification configurations requires admin access to the relevant workspace. ([More about permissions](/terraform/cloud-docs/users-teams-organizations/permissions).)
 
+-> **Note:** [Speculative plans](/terraform/cloud-docs/run/modes-and-options#plan-only-speculative-plan) and workspaces configured with `Local` [execution mode](/terraform/cloud-docs/workspaces/settings#execution-mode) do not support notifications.
+
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
 ## Notification Triggers

--- a/website/docs/cloud-docs/workspaces/settings/notifications.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/notifications.mdx
@@ -8,7 +8,7 @@ description: >-
 
 HCP Terraform can use webhooks to notify external systems about run progress and other events. Each workspace has its own notification settings and can notify up to 20 destinations.
 
--> **Note:** Workspaces configured with `Local` [execution mode](/terraform/cloud-docs/workspaces/settings#execution-mode) do not support notifications.
+-> **Note:** [Speculative plans](/terraform/cloud-docs/run/modes-and-options#plan-only-speculative-plan) and workspaces configured with `Local` [execution mode](/terraform/cloud-docs/workspaces/settings#execution-mode) do not support notifications.
 
 Configuring notifications requires admin access to the workspace. Refer to [Permissions](/terraform/cloud-docs/users-teams-organizations/permissions) for details.
 


### PR DESCRIPTION
### What
Specify that Speculative Plans will not trigger notifications

* https://terraform-docs-common-git-paul-ipl-5982-hashicorp.vercel.app/terraform/cloud-docs/workspaces/settings/notifications
* https://terraform-docs-common-git-paul-ipl-5982-hashicorp.vercel.app/terraform/cloud-docs/api-docs/notification-configurations

### Why
This is a common source of confusion given that users expect for notifications to be sent for speculative plans. This isn't currently supported.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

![image](https://github.com/hashicorp/terraform-docs-common/assets/155981/412c120e-66fe-4103-ac9c-9e57b45f7d37)

![image](https://github.com/hashicorp/terraform-docs-common/assets/155981/c8694576-9827-4591-a9f1-15e44c46734d)


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
