### PR TITLE
Correcting the documentation regarding permissions needed for managing modules.

### DIFF
--- a/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
@@ -238,7 +238,7 @@ curl \
 
 | Parameter            | Description                                                                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to the "owners" team or a member of the "owners" team. |
+| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must have the "**Manage modules**" permission. |
 
 Publishes a new registry private module from a VCS repository, with module versions managed automatically by the repository's tags. The publishing process will fetch all tags in the source repository that look like [SemVer](https://semver.org/) versions with optional 'v' prefix. For each version, the tag is cloned and the config parsed to populate module details (input and output variables, readme, submodules, etc.). The [Module Registry Requirements](/terraform/registry/modules/publish#requirements) define additional requirements on naming, standard module structure and tags for releases.
 
@@ -349,7 +349,7 @@ curl \
 
 | Parameter            | Description                                                                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to the "owners" team or a member of the "owners" team. |
+| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must have the "**Manage modules**" permission. |
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
@@ -511,7 +511,7 @@ curl \
 
 | Parameter            | Description                                                                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to the "owners" team or a member of the "owners" team. |
+| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must have the "**Manage modules**" permission. |
 | `:namespace`         | The namespace of the module for which the version is being created. For private modules this is the same as the `:organization_name` parameter                                                           |
 | `:name`              | The name of the module for which the version is being created.                                                                                                                                           |
 | `:provider`          | The name of the provider for which the version is being created.                                                                                                                                         |

--- a/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
@@ -238,7 +238,7 @@ curl \
 
 | Parameter            | Description                                                                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must have the "**Manage modules**" permission. |
+| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to a team or member of this team with the "**Manage modules**" permission. |
 
 Publishes a new registry private module from a VCS repository, with module versions managed automatically by the repository's tags. The publishing process will fetch all tags in the source repository that look like [SemVer](https://semver.org/) versions with optional 'v' prefix. For each version, the tag is cloned and the config parsed to populate module details (input and output variables, readme, submodules, etc.). The [Module Registry Requirements](/terraform/registry/modules/publish#requirements) define additional requirements on naming, standard module structure and tags for releases.
 
@@ -349,7 +349,7 @@ curl \
 
 | Parameter            | Description                                                                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must have the "**Manage modules**" permission. |
+| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to a team or member of this team with the "**Manage modules**" permission. |
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
@@ -511,7 +511,7 @@ curl \
 
 | Parameter            | Description                                                                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must have the "**Manage modules**" permission. |
+| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to a team or member of this team with the "**Manage modules**" permission. |
 | `:namespace`         | The namespace of the module for which the version is being created. For private modules this is the same as the `:organization_name` parameter                                                           |
 | `:name`              | The name of the module for which the version is being created.                                                                                                                                           |
 | `:provider`          | The name of the provider for which the version is being created.                                                                                                                                         |


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

I have changed the page: website/docs/cloud-docs/api-docs/private-registry/modules.mdx

More specifically I changed the part where it is mentioned that the API token must belong to the "owners" team or a member of this team.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

I have changed it because it is not correct. Currently you can perform the actions with a different team token which has Manage modules permission, it does not have to be the "owners" team specifically.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
