### PR TITLE
docs/plugin: Updated naming page headers

### DIFF
--- a/website/docs/plugin/best-practices/naming.mdx
+++ b/website/docs/plugin/best-practices/naming.mdx
@@ -5,14 +5,14 @@ description: |-
   providers.
 ---
 
-## Naming
+# Naming
 
 Most names in a Terraform provider will be drawn from the upstream API/SDK that
 the provider is using. The upstream API names will likely need to be
 modified for casing or changing between plural and singular to make
 the provider more consistent with the common Terraform practices below.
 
-### Resource Names
+## Resource Names
 
 Resource names are nouns, since resource blocks each represent a single
 object Terraform is managing. Resource names must always start with their
@@ -22,7 +22,7 @@ the provider `postgresql` might be named `postgresql_database`.
 It is preferable to use resource names that will be familiar to those with
 prior experience using the service in question, e.g. via a web UI it provides.
 
-### Data Source Names
+## Data Source Names
 
 Similar to resource names, data source names should be nouns. The main difference
 is that in some cases data sources are used to return a list and can in
@@ -30,13 +30,13 @@ those cases be plural. For example the data source
 [`aws_availability_zones`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones)
 in the AWS provider returns a list of availability zones.
 
-### Function Names
+## Function Names
 
 Function names are verbs, since they encapsulate computational logic for usage in practitioner configurations. Unlike resource and data source naming, function names should _NOT_ include the provider name since the configuration language syntax for calling the function must already specify the provider name separately. For example, a `time` provider-defined function that parses RFC3339 timestamp strings should be named `parse_rfc3339` since it would be called via `provider::time::parse_rfc3339`.
 
 Function names should be all lowercase and use underscores to separate words. The built-in functions in the Terraform language do not use underscores for historical reasons, but all functions defined in providers should use underscores to improve readability.
 
-### Attribute Names
+## Attribute Names
 
 Below is an example of a resource configuration block which illustrates some
 general design patterns that can apply across all plugin object types:


### PR DESCRIPTION
### What
Adjusted the [`best-practices/naming.mdx`](https://developer.hashicorp.com/terraform/plugin/best-practices/naming) headers, which seem to be incorrectly displayed (see screenshot). I'm not 100% sure if this will fix the duplicate header, but it's the only difference I noticed when looking at the other best practice pages.


### Why
<!-- Explain why this change is necessary and how it benefits users. -->

Hopefully removes the duplicate header.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

![image](https://github.com/hashicorp/terraform-docs-common/assets/8650838/7e9bb67f-8a82-4d2b-9593-2a821fa7c3a7)


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
