### PR TITLE
fixes broken link to sentinel docs

### DIFF
--- a/website/docs/cloud-docs/run/states.mdx
+++ b/website/docs/cloud-docs/run/states.mdx
@@ -69,7 +69,7 @@ _Leaving this stage:_
 - If the plan succeeded with no changes and neither cost estimation nor Sentinel policy checks will be done, HCP Terraform considers the run complete (**Planned and Finished** state).
 - If the plan succeeded and requires changes:
   - If cost estimation is enabled, the run proceeds automatically to the cost estimation stage.
-  - If cost estimation is disabled and [Sentinel policies][] are enabled, the run proceeds automatically to the policy check stage.
+  - If cost estimation is disabled and [Sentinel policies][/terraform/enterprise/policy-enforcement/sentinel] are enabled, the run proceeds automatically to the policy check stage.
   - If there are no Sentinel policies and the plan can be auto-applied, the run proceeds automatically to the apply stage. Plans can be auto-applied if the auto-apply setting is enabled on the workspace and the plan was queued by a new VCS commit or by a user with permission to apply runs. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))
   - If there are no Sentinel policies and HCP Terraform cannot auto-apply the plan, the run pauses in the **Needs Confirmation** state until a user with permission to apply runs takes action. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions)) If an authorized user approves the apply, the run proceeds to the apply stage. If an authorized user rejects the apply, the run does not continue (**Discarded** state).
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
On the `Run States and Stages` page there is a broken/missing link

### Why
🧹  help users get to the relevant docs by updating the link to point to: https://developer.hashicorp.com/terraform/enterprise/policy-enforcement/sentinel

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
