### PR TITLE
Update terraform test variable documentation to include format restrictions for var keys.

### DIFF
--- a/website/docs/cloud-docs/api-docs/private-registry/tests.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/tests.mdx
@@ -558,7 +558,7 @@ Properties without a default value are required.
 | Key path                      | Type   | Default | Description                                                                                           |
 | ----------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------- |
 | `data.type`                   | string | none | Must be `"vars"`.                                                                                     |
-| `data.attributes.key`         | string | none | The name of the variable.                                                                             |
+| `data.attributes.key`         | string | none | The name of the variable. Test Variable keys must begin with a letter or underscore and can only contain letters, numbers or underscores.                                                                          |
 | `data.attributes.value`       | string | `""`    | The value of the variable.                                                                            |
 | `data.attributes.description` | string | none | The description of the variable.                                                                      |
 | `data.attributes.category`    | string | none | This must be `"env"`.                                                                                   |

--- a/website/docs/cloud-docs/api-docs/private-registry/tests.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/tests.mdx
@@ -558,7 +558,7 @@ Properties without a default value are required.
 | Key path                      | Type   | Default | Description                                                                                           |
 | ----------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------- |
 | `data.type`                   | string | none | Must be `"vars"`.                                                                                     |
-| `data.attributes.key`         | string | none | The name of the variable. Test Variable keys must begin with a letter or underscore and can only contain letters, numbers or underscores.                                                                          |
+| `data.attributes.key`         | string | none | The variable's name. Test variable keys must begin with a letter or underscore and can only contain letters, numbers, and underscores.                                                                          |
 | `data.attributes.value`       | string | `""`    | The value of the variable.                                                                            |
 | `data.attributes.description` | string | none | The description of the variable.                                                                      |
 | `data.attributes.category`    | string | none | This must be `"env"`.                                                                                   |


### PR DESCRIPTION
### What
Added some info explaining the formatting restrictions on tf test variables.
### Why
<!-- Explain why this change is necessary and how it benefits users. -->
This formatting convention is missing from the api docs
### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).

#### Content

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
