### PR TITLE
Update Team API Docs to Include Team Token Setting Reference

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,8 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
+## 2024-07-15
+* Update the [Team API](/terraform/cloud-docs/api-docs/teams) to include `allow-member-token-management`.
 
 ## 2024-07-12
 * Add beta tags to documentation for audit trail tokens.

--- a/website/docs/cloud-docs/api-docs/teams.mdx
+++ b/website/docs/cloud-docs/api-docs/teams.mdx
@@ -84,6 +84,7 @@ $ curl \
 ### Sample Response
 
 The `sso-team-id` attribute is only returned in Terraform Enterprise 202204-1 and later, or in HCP Terraform.
+The `allow-member-token-management` attribute is false for Terraform Enterprise versions older than 202408-1.
 
 ```json
 {
@@ -96,6 +97,7 @@ The `sso-team-id` attribute is only returned in Terraform Enterprise 202204-1 an
         "sso-team-id": "cb265c8e41bddf3f9926b2cf3d190f0e1627daa4",
         "users-count": 0,
         "visibility": "organization",
+        "allow-member-token-management": true,
         "permissions": {
           "can-update-membership": true,
           "can-destroy": true,
@@ -225,7 +227,8 @@ The `sso-team-id` attribute is only returned in Terraform Enterprise 202204-1 an
         "can-update-visibility": true
       },
       "users-count": 0,
-      "visibility": "secret"
+      "visibility": "secret",
+      "allow-member-token-management": true
     },
     "id": "team-6p5jTwJQXwqZBncC",
     "links": {
@@ -276,6 +279,7 @@ The `sso-team-id` attribute is only returned in Terraform Enterprise 202204-1 an
       "sso-team-id": "cb265c8e41bddf3f9926b2cf3d190f0e1627daa4",
       "users-count": 0,
       "visibility": "organization",
+      "allow-member-token-management": true,
       "permissions": {
         "can-update-membership": true,
         "can-destroy": true,
@@ -347,6 +351,7 @@ Properties without a default value are required.
 | `data.attributes.sso-team-id`           | string | (previous value) | The unique identifier of the team from the SAML `MemberOf` attribute. Only available in Terraform Enterprise 202204-1 and later, or in HCP Terraform.                                                                                             |
 | `data.attributes.organization-access`   | object | (previous value) | Settings for the team's organization access. This object can include the `manage-policies`, `manage-policy-overrides`, `manage-run-tasks`, `manage-workspaces`, `manage-vcs-settings`, `manage-agent-pools`, `manage-providers`, `manage-modules`, `manage-projects`, `read-projects`, `read-workspaces`, `manage-membership`, `manage-teams`, and `manage-organization-access` properties with boolean values. All properties default to `false`. |
 | `data.attributes.visibility` **(beta)** | string | (previous value) | The team's visibility. Must be `"secret"` or `"organization"` (visible).                                                                                                                                                                                                                                          |
+| `data.attributes.allow-team-token-management` | boolean | (previous value) | The ability to enable and disable team token management for a team. Defaults to true.                                                                                                                                                                                                                                         |
 
 ### Sample Payload
 
@@ -356,6 +361,7 @@ Properties without a default value are required.
     "type": "teams",
     "attributes": {
       "visibility": "organization",
+      "allow-member-token-management": true,
       "organization-access": {
         "manage-vcs-settings": true
       }
@@ -402,6 +408,7 @@ The `sso-team-id` attribute is only returned in Terraform Enterprise 202204-1 an
         "manage-organization-access": false
       },
       "visibility": "organization",
+      "allow-member-token-management": true,
       "permissions": {
         "can-update-membership": true,
         "can-destroy": true,


### PR DESCRIPTION
### What
Update the team API documentation to include a reference to `allow-member-token-management`.

### Why
This update adds clarity to the existing team API documentation so that it references the newly released team token management setting.

### Links
- Related [PR](https://github.com/hashicorp/terraform-docs-common/pull/674)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
