### PR TITLE
Docs/omit audit trails token api tfe

### DIFF
--- a/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/audit-trails-tokens.mdx
@@ -2,6 +2,7 @@
 page_title: Audit Trail Tokens - API Docs - HCP Terraform
 description: >-
   Use the `/authentication-token` endpoint with the `token` query param to manage audit trails API tokens. Generate and delete audit trail tokens using the HTTP API.
+tfc_only: true
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -48,12 +48,14 @@ HashiCorp provides a [stability policy](/terraform/cloud-docs/api-docs/stability
 
 All requests must be authenticated with a bearer token. Use the HTTP header `Authorization` with the value `Bearer <token>`. If the token is absent or invalid, HCP Terraform responds with [HTTP status 401][401] and a [JSON API error object][]. The 401 status code is reserved for problems with the authentication token; forbidden requests with a valid token result in a 404.
 
-There are four kinds of tokens available:
+You can use the following types of tokens to authenticate:
 
 - [User tokens](/terraform/cloud-docs/users-teams-organizations/users#api-tokens) — each HCP Terraform user can have any number of API tokens, which can make requests on their behalf.
 - [Team tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens#team-api-tokens) — each team can have one API token at a time. This is intended for performing plans and applies via a CI/CD pipeline.
 - [Organization tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens#organization-api-tokens) — each organization can have one API token at a time. This is intended for automating the management of teams, team membership, and workspaces. The organization token cannot perform plans and applies.
+<!-- BEGIN: TFC:only -->
 - [Audit trails token](/terraform/cloud-docs/users-teams-organizations/api-tokens#audit-trails-tokens) - each organization can have a single token that can read that organization's audit trails. Use this token type to authenticate integrations pulling audit trail data, for example, using the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app. Audit trail tokens are currently in beta.
+<!-- END: TFC:only -->
 
 ### Blob Storage Authentication
 

--- a/website/docs/cloud-docs/api-docs/no-code-provisioning.mdx
+++ b/website/docs/cloud-docs/api-docs/no-code-provisioning.mdx
@@ -853,7 +853,7 @@ This endpoint returns the plan details and status for updating a workspace to ne
 | `:workspace_id`      | The ID of workspace.           |
 | `:id`                | The ID of update.              |
 
-Returns the details of a no-code workspace update run, including the run's current state, such as `pending`, `fetching`, `planning`, `planned`, or `cost_estimated`. Refer to [Run States and Stages](https://developer.hashicorp.com/terraform/enterprise/run/states) for more information on the states a run can return.
+Returns the details of a no-code workspace update run, including the run's current state, such as `pending`, `fetching`, `planning`, `planned`, or `cost_estimated`. Refer to [Run States and Stages](/terraform/enterprise/run/states) for more information on the states a run can return.
 
 | Status  | Response                                                | Reason                                                              |
 | ------- | ------------------------------------------------------- | --------------------------------------------------------------------|

--- a/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/modules.mdx
@@ -238,7 +238,7 @@ curl \
 
 | Parameter            | Description                                                                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to a team or team member with the "Manage modules" permission. |
+| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to a team or team member with the **Manage modules** permission enabled. |
 
 Publishes a new registry private module from a VCS repository, with module versions managed automatically by the repository's tags. The publishing process will fetch all tags in the source repository that look like [SemVer](https://semver.org/) versions with optional 'v' prefix. For each version, the tag is cloned and the config parsed to populate module details (input and output variables, readme, submodules, etc.). The [Module Registry Requirements](/terraform/registry/modules/publish#requirements) define additional requirements on naming, standard module structure and tags for releases.
 
@@ -349,7 +349,7 @@ curl \
 
 | Parameter            | Description                                                                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to a team or team member with the "Manage modules" permission. |
+| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to a team or team member with the **Manage modules** permission enabled. |
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
@@ -511,7 +511,7 @@ curl \
 
 | Parameter            | Description                                                                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to a team or team member with the "Manage modules" permission. |
+| `:organization_name` | The name of the organization to create a module in. The organization must already exist, and the token authenticating the API request must belong to a team or team member with the **Manage modules** permission enabled. |
 | `:namespace`         | The namespace of the module for which the version is being created. For private modules this is the same as the `:organization_name` parameter                                                           |
 | `:name`              | The name of the module for which the version is being created.                                                                                                                                           |
 | `:provider`          | The name of the provider for which the version is being created.                                                                                                                                         |

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -51,6 +51,8 @@ Organization API tokens have permissions across the entire organization. They ca
 
 -> **Note:** This endpoint cannot be accessed with [organization tokens](#organization-api-tokens). You must access it with a [user token](/terraform/cloud-docs/users-teams-organizations/users#api-tokens) or [team token](#team-api-tokens).
 
+<!-- BEGIN: TFC:only -->
+
 ## Audit trail tokens (Beta)
 
 You can generate an audit trails token to read an organization's [audit trails](/terraform/cloud-docs/api-docs/audit-trails). Use this token type to authenticate integrations pulling audit trail data, for example, using the [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) app.
@@ -62,6 +64,8 @@ Each organization can only have a _single_ valid audit trails token. Only [organ
 Audit trail tokens are currently in beta.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
+
+<!-- END: TFC:only -->
 
 ## Agent API Tokens
 

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -7,11 +7,11 @@ description: >-
 
 # API Tokens
 
-HCP Terraform supports many distinct types of API tokens with varying levels of access: user, team, organization, and audit trails. There are differences in access levels and generation workflows for each of these token types, which are outlined below.
+This topic describe the distinct types of API tokens you can use to authenticate with HCP Terraform.
 
-API tokens are displayed only once when they are created, and are obfuscated thereafter. If the token is lost, it must be regenerated.
+Note that HCP Terraform only displays API tokens once when you initially create them and are obfuscated thereafter. If the token is lost, it must be regenerated.
 
--> **API:** See the [Team Token API](/terraform/cloud-docs/api-docs/team-tokens) and [Organization Token API](/terraform/cloud-docs/api-docs/organization-tokens).
+Refer to [Team Token API](/terraform/cloud-docs/api-docs/team-tokens) and [Organization Token API](/terraform/cloud-docs/api-docs/organization-tokens) for additional information about using the APIs.
 
 ## User API Tokens
 

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # API Tokens
 
-This topic describe the distinct types of API tokens you can use to authenticate with HCP Terraform.
+This topic describes the distinct types of API tokens you can use to authenticate with HCP Terraform.
 
 Note that HCP Terraform only displays API tokens once when you initially create them and are obfuscated thereafter. If the token is lost, it must be regenerated.
 


### PR DESCRIPTION
This PR adds TFE exclusions for the audit trails tokens documentation so that it only renders in HCP Terraform docs. I have also implemented some style guide related changes that I found while reviewing the automated docs PR for TFE v202407.
