### PR TITLE
Fix Variable Set API creation attribute paths

### DIFF
--- a/website/docs/cloud-docs/api-docs/variable-sets.mdx
+++ b/website/docs/cloud-docs/api-docs/variable-sets.mdx
@@ -24,13 +24,13 @@ Properties without a default value are required.
 
 | Key path                        | Type    | Default | Description                                                                                                                 |
 |---------------------------------|---------|---------|-----------------------------------------------------------------------------------------------------------------------------|
-| `data.name`                     | string  |         | The name of the variable set.                                                                                               |
-| `data.description`              | string  | `""`    | Text displayed in the UI to contextualize the variable set and its purpose.                                                 |
-| `data.global`                   | boolean | `false` | When true, HCP Terraform automatically applies the variable set to all current and future workspaces in the organization. |
-| `data.priority`                 | boolean | `false` | When true, the variables in the set override any other variable values with a more specific scope, including values set on the command line. |
-| `data.relationships.workspaces` | array   | \`[]`     | Array of references to workspaces that the variable set should be assigned to.                                              |
-| `data.relationships.projects`   | array   | \`[]`    | Array of references to projects that the variable set should be assigned to.                                                |
-| `data.relationships.vars`       | array   | \`[]`     | Array of complete variable definitions that comprise the variable set.                                                      |
+| `data.attributes.name`          | string  |         | The name of the variable set.                                                                                               |
+| `data.attributes.description`   | string  | `""`    | Text displayed in the UI to contextualize the variable set and its purpose.                                                 |
+| `data.attributes.global`        | boolean | `false` | When true, HCP Terraform automatically applies the variable set to all current and future workspaces in the organization. |
+| `data.attributes.priority`      | boolean | `false` | When true, the variables in the set override any other variable values with a more specific scope, including values set on the command line. |
+| `data.relationships.workspaces` | array   | \`[]`   | Array of references to workspaces that the variable set should be assigned to.                                              |
+| `data.relationships.projects`   | array   | \`[]`   | Array of references to projects that the variable set should be assigned to.                                                |
+| `data.relationships.vars`       | array   | \`[]`   | Array of complete variable definitions that comprise the variable set.                                                      |
 
 HCP Terraform does not allow different global variable sets to contain conflicting variables with the same name and type. You will receive a 422 response if you try to create a global variable set that contains conflicting variables.
 
@@ -94,7 +94,7 @@ curl \
 ```json
 {
   "data": {
-    "id": "varset-kjkN545LH2Sfercv"
+    "id": "varset-kjkN545LH2Sfercv",
     "type": "varsets",
     "attributes": {
       "name": "MyVarset",
@@ -122,7 +122,7 @@ curl \
       "vars": {
         "data": [
           {
-            "id": "var-Nh0doz0hzj9hrm34qq"
+            "id": "var-Nh0doz0hzj9hrm34qq",
             "type": "vars",
             "attributes": {
               "key": "c2e4612d993c18e42ef30405ea7d0e9ae",
@@ -151,10 +151,10 @@ HCP Terraform does not allow global variable sets to contain conflicting variabl
 
 | Key path                        | Type    | Default | Description                                                                                                                                          |
 |---------------------------------|---------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `data.name`                     | string  |         | The name of the variable set.                                                                                                                        |
-| `data.description`              | string  |         | Text displayed in the UI to contextualize the variable set and its purpose.                                                                          |
-| `data.global`                   | boolean |         | When true, HCP Terraform automatically applies the variable set to all current and future workspaces in the organization.                          |
-| `data.priority`                 | boolean | `false` | When true, the variables in the set override any other variable values set with a more specific scope, including values set on the command line. |
+| `data.attributes.name`          | string  |         | The name of the variable set.                                                                                                                        |
+| `data.attributes.description`   | string  |         | Text displayed in the UI to contextualize the variable set and its purpose.                                                                          |
+| `data.attributes.global`        | boolean |         | When true, HCP Terraform automatically applies the variable set to all current and future workspaces in the organization.                          |
+| `data.attributes.priority`      | boolean | `false` | When true, the variables in the set override any other variable values set with a more specific scope, including values set on the command line. |
 | `data.relationships.workspaces` | array   |         | **Optional** Array of references to workspaces that the variable set should be assigned to. Sending an empty array clears all workspace assignments. |
 | `data.relationships.projects`   | array   |         | **Optional** Array of references to projects that the variable set should be assigned to. Sending an empty array clears all project assignments.     |
 | `data.relationships.vars`       | array   |         | **Optional** Array of complete variable definitions to add to the variable set.                                                                      |
@@ -227,7 +227,7 @@ curl \
 ```json
 {
   "data": {
-    "id": "varset-kjkN545LH2Sfercv"
+    "id": "varset-kjkN545LH2Sfercv",
     "type": "varsets",
     "attributes": {
       "name": "MyVarset",
@@ -239,7 +239,7 @@ curl \
       "vars": {
         "data": [
           {
-            "id": "var-Nh0doz0hzj9hrm34qq"
+            "id": "var-Nh0doz0hzj9hrm34qq",
             "type": "vars",
             "attributes": {
               "key": "c2e4612d993c18e42ef30405ea7d0e9ae",
@@ -572,7 +572,7 @@ curl \
 ```json
 {
   "data": {
-    "id":"var-EavQ1LztoRTQHSNT"
+    "id":"var-EavQ1LztoRTQHSNT",
     "type": "vars",
     "attributes": {
       "key": "g6e45ae7564a17e81ef62fd1c7fa86138",
@@ -637,7 +637,7 @@ curl \
 ```json
 {
   "data": {
-    "id":"var-EavQ1LztoRTQHSNT"
+    "id":"var-EavQ1LztoRTQHSNT",
     "type": "vars",
     "attributes": {
       "key": "g6e45ae7564a17e81ef62fd1c7fa86138",


### PR DESCRIPTION
### What

As described in [this issue](https://github.com/hashicorp/terraform-docs-common/issues/388) the tables of attributes for varset creation/update have slightly incorrect paths (`data.X` instead of `data.attributes.X`)

### Why

Clarify, and be consistent with the rest of our API docs

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
