### PR TITLE
Update Workspace API creation examples to remove unneeded attributes

### DIFF
--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -106,8 +106,6 @@ _Without a VCS repository_
   "data": {
     "attributes": {
       "name": "workspace-1",
-      "resource-count": 0,
-      "updated-at": "2017-11-29T19:18:09.976Z"
     },
     "type": "workspaces"
   }
@@ -121,7 +119,6 @@ _With a VCS repository_
   "data": {
     "attributes": {
       "name": "workspace-2",
-      "resource-count": 0,
       "terraform_version": "0.11.1",
       "working-directory": "",
       "vcs-repo": {
@@ -129,8 +126,7 @@ _With a VCS repository_
         "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
         "branch": "",
         "tags-regex": null
-      },
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      }
     },
     "type": "workspaces"
   }
@@ -145,7 +141,6 @@ HCP Terraform triggers a run when you push a Git tag that matches the regular ex
   "data": {
     "attributes": {
       "name": "workspace-3",
-      "resource-count": 0,
       "terraform_version": "0.12.1",
       "file-triggers-enabled": false,
       "working-directory": "/networking",
@@ -154,8 +149,7 @@ HCP Terraform triggers a run when you push a Git tag that matches the regular ex
         "oauth-token-id": "ot-hmAyP66qk2AMVdbJ",
         "branch": "",
         "tags-regex": "\d+.\d+.\d+"
-      },
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      }
     },
     "type": "workspaces"
   }
@@ -171,8 +165,8 @@ A run will be triggered in this workspace when changes are detected in any of th
   "data": {
     "attributes": {
       "name": "workspace-3",
-      "resource-count": 0,
       "terraform_version": "0.12.1",
+      "file-triggers-enabled": true,
       "trigger-prefixes": ["/modules", "/vendor"],
       "working-directory": "/networking",
       "vcs-repo": {
@@ -199,8 +193,8 @@ A run will be triggered in this workspace when HCP Terraform detects any of the 
   "data": {
     "attributes": {
       "name": "workspace-4",
-      "resource-count": 0,
       "terraform_version": "1.2.2",
+      "file-triggers-enabled": true,
       "trigger-patterns": ["/**/networking/*.tf", "/base/*", "/submodule/**/*"],
       "vcs-repo": {
         "identifier": "example/terraform-test-proj-monorepo",
@@ -224,9 +218,7 @@ _Using HCP Terraform agents_
     "attributes": {
       "name":"workspace-1",
       "execution-mode": "agent",
-      "agent-pool-id": "apool-ZjT6A7mVFm5WHT5a",
-      "resource-count": 0,
-      "updated-at": "2017-11-29T19:18:09.976Z"
+      "agent-pool-id": "apool-ZjT6A7mVFm5WHT5a"
     }
   },
   "type": "workspaces"


### PR DESCRIPTION
### What

Removes some unnecessary attributes from workspace creation payload examples (mostly `resource-count` and `updated-at`, which dont do anything during workspace create.

### Why

As described in [this Github Issue ](https://github.com/hashicorp/terraform-docs-common/issues/86) these values in the payload request imply that they will actually have some effect on workspace creation...which makes it unclear what these attributes actually represent.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] (N/A) One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
