### PR TITLE
Updates and corrections for generated module tests

### DIFF
--- a/website/docs/cloud-docs/registry/test.mdx
+++ b/website/docs/cloud-docs/registry/test.mdx
@@ -50,7 +50,7 @@ To add environment variables to your module's tests:
 
 ~> **Note**: Generated module tests are available in HCP Terraform **Plus** Edition and are in public beta. Refer to [HCP Terraform pricing](https://www.hashicorp.com/products/terraform/pricing) for details.
 
-HCP Terraform can generate [test files](/terraform/language/tests) for any private module in your registry. You can generate tests one time per module.
+HCP Terraform can generate [test files](/terraform/language/tests) for any private module in your registry. You can only generate tests one time per module.
 
 To generate tests for your module:
 
@@ -60,7 +60,7 @@ To generate tests for your module:
 1. Create a `tests` directory in your configuration.
 1. Unzip the downloaded files into the new `tests` directory.
 
-Generated test files remain available on the module overview page for later retrieval. Click **View test files** to view and download the previously generated tests.
+Generated test files remain available on the module overview page for later retrieval. Click **View test files** to view and download any previously generated tests.
 
 Organization owners can control this feature on the organization's [General Settings](/terraform/cloud-docs/users-teams-organizations/organizations#organization-settings) page.
 

--- a/website/docs/cloud-docs/registry/test.mdx
+++ b/website/docs/cloud-docs/registry/test.mdx
@@ -50,7 +50,7 @@ To add environment variables to your module's tests:
 
 ~> **Note**: Generated module tests are available in HCP Terraform **Plus** Edition and are in public beta. Refer to [HCP Terraform pricing](https://www.hashicorp.com/products/terraform/pricing) for details.
 
-HCP Terraform can generate [test files](/terraform/language/tests) for any private modules that use the [branch-based publishing workflow](/terraform/cloud-docs/registry/publish-modules#branch-based-publishing) and do not already contain tests in their source code. 
+HCP Terraform can generate [test files](/terraform/language/tests) for any private module in your registry. You can generate tests one time per module.
 
 To generate tests for your module:
 
@@ -59,5 +59,9 @@ To generate tests for your module:
 1. HCP Terraform displays generated configuration. To download all of the test files, click **Download generated tests**.
 1. Create a `tests` directory in your configuration.
 1. Unzip the downloaded files into the new `tests` directory.
+
+Generated test files remain available on the module overview page for later retrieval. Click **View test files** to view and download the previously generated tests.
+
+Organization owners can control this feature on the organization's [General Settings](/terraform/cloud-docs/users-teams-organizations/organizations#organization-settings) page.
 
 <!-- END: TFC:only name:generate-module-tests -->

--- a/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
@@ -85,7 +85,7 @@ Organization owners can also choose whether [workspace administrators](/terrafor
 
 <!-- BEGIN: TFC:only name:generated-tests -->
 
-HCP Terraform Plus Edition organization owners can choose whether members with [module management permissions](/terraform/cloud-docs/users-teams-organizations/permissions#manage-private-registry) can [generate module tests](/terraform/cloud-docs/registry/test#generated-module-tests).
+Organization owners using HCP Terraform Plus edition can choose whether members with [module management permissions](/terraform/cloud-docs/users-teams-organizations/permissions#manage-private-registry) can [generate module tests](/terraform/cloud-docs/registry/test#generated-module-tests).
 
 <!-- END: TFC:only name:generated-tests -->
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
@@ -71,7 +71,7 @@ To view and manage an organization's settings, click **Settings**.
 
 The contents of the organization settings depends on your permissions within the organization. All users can review the organization's contact email, view the membership of any teams they belong to, and view the organization's authentication policy. [Organization owners][owners] can view and manage the entire list of organization settings. Refer to [Organization Permissions](/terraform/cloud-docs/users-teams-organizations/permissions#organization-permissions) for details.
 
-You may be able to manage the following organization permissions.
+You may be able to manage the following organization settings.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
@@ -82,6 +82,12 @@ You may be able to manage the following organization permissions.
 Review the organization name and contact email. Organization owners can choose to change the organization name, contact email, and the default execution mode, or delete the organization. When an organization owner updates the default execution mode, all workspaces configured to [inherit this value](/terraform/cloud-docs/workspaces/settings#execution-mode) will be affected.
 
 Organization owners can also choose whether [workspace administrators](/terraform/cloud-docs/users-teams-organizations/permissions#workspace-admins) can delete workspaces that are managing resources. Deleting a workspace with resources under management introduces risk because Terraform can no longer track or manage the infrastructure. The workspace's users must manually delete any remaining resources or [import](/terraform/cli/commands/import) them into another Terraform workspace.
+
+<!-- BEGIN: TFC:only name:generated-tests -->
+
+HCP Terraform Plus Edition organization owners can choose whether members with [module management permissions](/terraform/cloud-docs/users-teams-organizations/permissions#manage-private-registry) can [generate module tests](/terraform/cloud-docs/registry/test#generated-module-tests).
+
+<!-- END: TFC:only name:generated-tests -->
 
 ##### Renaming an Organization
 

--- a/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
@@ -309,16 +309,6 @@ This permission implicitly grants access to read all workspaces, which is necess
 
 Allows members to publish and delete providers, modules, or both providers and modules in the organization's [private registry](/terraform/cloud-docs/registry). These permissions are otherwise only available to organization owners.
 
-### Manage Module Test Generation (Beta)
-
-Allow members to generate module tests for private registry modules. 
-
-<!-- BEGIN: TFC:only name:pnp-callout -->
-
-Your organization must be an HCP Terraform Plus subscription to enable this feature.
-
-<!-- END: TFC:only name:pnp-callout -->
-
 ### Team Management Permissions
 
 HCP Terraform has three levels of team management permissions: manage membership, manage teams, and manage organization access. Each permission level grants users the ability to perform specific actions and each progressively requires prerequisite permissions. 


### PR DESCRIPTION
### What
Several updates and corrections for the private registry generated module tests feature.

### Why
Corrections:

- The ability to generate module tests is an organization setting, not a team permission ([JIRA](https://hashicorp.atlassian.net/browse/TF-19251)).
- Tests can be generated for private modules using either publishing method.
- Tests can be generated on modules that already contain tests in their source code. Corrected to note the generation can be run only once per module.

Additions:

- Added note about retrieving tests later

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
