### PR TITLE
Fix logo download links on GitHub docs

### DIFF
--- a/website/docs/cloud-docs/vcs/github-enterprise.mdx
+++ b/website/docs/cloud-docs/vcs/github-enterprise.mdx
@@ -73,7 +73,7 @@ Leave the page open in a browser tab. In the next step you will copy values from
 
 1. Click the "Register application" button, which creates the application and takes you to its page.
 
-1. <a href="/img/docs/hcp-terraform-logo-on-white.png" download>Download this image of the HCP Terraform logo</a> and upload it with the "Upload new logo" button or the drag-and-drop target. This optional step helps you identify HCP Terraform's pull request checks at a glance.
+1. <a href="https://content.hashicorp.com/api/assets?product=terraform-docs-common&version=main&asset=website/img/docs/hcp-terraform-logo-on-white.png" download>Download this image of the HCP Terraform logo</a> and upload it with the "Upload new logo" button or the drag-and-drop target. This optional step helps you identify HCP Terraform's pull request checks at a glance.
 
 1. Click the "Generate a new client secret" button. You will need this secret in the next step.
 

--- a/website/docs/cloud-docs/vcs/github.mdx
+++ b/website/docs/cloud-docs/vcs/github.mdx
@@ -78,7 +78,7 @@ Alternately, create the OAuth application manually on GitHub.com.
 
 1. Click the "Register application" button, which creates the application and takes you to its page.
 
-1. <a href="/img/docs/hcp-terraform-logo-on-white.png" download>Download this image of the HCP Terraform logo</a> and upload it with the "Upload new logo" button or the drag-and-drop target. This optional step helps you identify HCP Terraform's pull request checks at a glance.
+1. <a href="https://content.hashicorp.com/api/assets?product=terraform-docs-common&version=main&asset=website/img/docs/hcp-terraform-logo-on-white.png" download>Download this image of the HCP Terraform logo</a> and upload it with the "Upload new logo" button or the drag-and-drop target. This optional step helps you identify HCP Terraform's pull request checks at a glance.
 
 1. Click the **Generate a new client secret** button. You will need this secret in the next step.
 


### PR DESCRIPTION
### What
Fixes the HCP Terraform logo download links on vcs/github.mdx and vcs/github-enterprise.mdx

### Why
Relative image reference does not work, replaced with absolute URL.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
