### PR TITLE
Minor update to BBDC VCS Cloud Docs

### DIFF
--- a/website/docs/cloud-docs/vcs/bitbucket-data-center.mdx
+++ b/website/docs/cloud-docs/vcs/bitbucket-data-center.mdx
@@ -34,9 +34,7 @@ The following steps provide an overview of how to connect HCP Terraform and Terr
 
 - Your instance of Bitbucket Data Center must be internet-accessible on its SSH and HTTP(S) ports. This is because HCP Terraform must be able to contact Bitbucket Data Center over both SSH and HTTP or HTTPS during setup and during normal operation.
 
-### Terrafrom Enterprise requirements
-
-- Terraform Enterprise must have network connectivity to Bitbucket Data Center instances. Note that [Bitbucket Data Center's default ports](https://confluence.atlassian.com/bitbucketserverkb/which-ports-does-bitbucket-server-listen-on-and-what-are-they-used-for-806029586.html) are `7999` for SSH and `7990` for HTTP. Check your configuration to confirm your instance's real ports.
+- HCP Terraform must have network connectivity to Bitbucket Data Center instances. Note that [Bitbucket Data Center's default ports](https://confluence.atlassian.com/bitbucketserverkb/which-ports-does-bitbucket-server-listen-on-and-what-are-they-used-for-806029586.html) are `7999` for SSH and `7990` for HTTP. Check your configuration to confirm your BitBucket instance's real ports.
 
 ## Add a new VCS provider to Terraform
 
@@ -53,7 +51,7 @@ The following steps provide an overview of how to connect HCP Terraform and Terr
    - Set the **HTTP URL** field to your Bitbucket Data Center instance URL and add the context path: `https://<BITBUCKET INSTANCE HOSTNAME>/<CONTEXT PATH>`.
    - Set the **API URL** field to your Bitbucket Data Center instance URL: `https://<BITBUCKET INSTANCE HOSTNAME>`.
 
-   By default, HCP Terraform uses port `80` for HTTP and  `443` for HTTPS. If Bitbucket Data Center is configured to use non-standard ports or is behind a reverse proxy, you must include the port number in the URL.
+   By default, HCP Terraform uses port `80` for HTTP and  `443` for HTTPS. If Bitbucket Data Center is configured to use non-standard ports or is behind a reverse proxy, you may need to include the port number in the URL.
 
 1. You can either generate new consumer and public keys that you can use to create a new application link in Bitbucket Data Center described in [Create an application link](#create-an-application-link) or use keys from an existing application link:
    - To generate new keys, click **Continue**. Do not leave this screen until you have copied the key values.


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
I changed TF Enterprise to HCP Terraform as TF Enterprise has it's own docs for this.
I also removed lines to make it one set of requirements. (not Req + TFE Reqs)

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
Had a ticket with customer were it was mentioned, see slack thread:
https://hashicorp.slack.com/archives/C02LM947SMB/p1724445314669769

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->
N/A
----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ NotSure] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ NA] Description links to related pull requests or issues, if any.

#### Content
- [NA] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [NA] API documentation and the API Changelog have been updated. 
- [NA] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [NA] Pages with related content are updated and link to this content when appropriate.
- [NA] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [NA] New pages have metadata (page name and description) at the top.
- [NA] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [NA] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [NA] UI elements (button names, page names, etc.) are bolded.
- [NA] The Vercel website preview successfully deployed.

#### Reviews
- [SlackThread/PR] I or someone else reviewed the content for technical accuracy.
- [NotYet/PR] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
