### PR TITLE
Reword post-apply stage to remove ambiguity

### DIFF
--- a/website/docs/cloud-docs/run/states.mdx
+++ b/website/docs/cloud-docs/run/states.mdx
@@ -79,7 +79,7 @@ Note, if you want to directly integrate third-party tools and services between y
 
 ## The Post-Plan Stage
 
-The post-plan phase executes any configured run tasks after the plan is complete, so it only occurs if there are [run tasks](/terraform/cloud-docs/workspaces/settings/run-tasks) enabled
+The post-plan phase executes any configured run tasks after the plan is successfully complete, so it only occurs if there are [run tasks](/terraform/cloud-docs/workspaces/settings/run-tasks) enabled
 for the workspace. All runs can enter this phase, including [speculative plans](/terraform/cloud-docs/run/remote-operations#speculative-plans). During this phase, HCP Terraform sends information about the run to the configured external system and waits for a `passed` or `failed` response to determine whether the run can continue.
 
 -> **Note:** The information sent to the configured external system includes the [JSON output](/terraform/internals/json-format) of the Terraform plan.
@@ -190,11 +190,7 @@ After applying, the run proceeds automatically to completion.
 
 ## The Post-Apply Stage
 
-The post-apply phase only occurs if the workspace has [run tasks](/terraform/cloud-docs/workspaces/settings/run-tasks) configured to begin after Terraform complete the apply operation. 
-
-Unlike other run task stages, the post-apply stage gathers information about the resulting response of an apply operation because that operation has already occurred, and HCP Terraform has already provisioned infrastructure. HCP Terraform sends the information about the run to the configured external system with the `passed` or `failed` status along with the configuration version of the run.
-
-Only confirmed runs can enter this phase.
+The post-apply phase only occurs if the workspace has [run tasks](/terraform/cloud-docs/workspaces/settings/run-tasks) configured to begin after Terraform successfully completes an apply operation. During this phase, HCP Terraform sends information about the run to the configured external system and waits for a `passed` or `failed` response. However, unlike other stages in the run task process, a failed outcome will not halt the run since HCP Terraform has already provisioned the infrastructure.
 
 _States in this stage:_
 

--- a/website/docs/cloud-docs/run/states.mdx
+++ b/website/docs/cloud-docs/run/states.mdx
@@ -79,8 +79,8 @@ Note, if you want to directly integrate third-party tools and services between y
 
 ## The Post-Plan Stage
 
-The post-plan phase executes any configured run tasks after the plan is successfully complete, so it only occurs if there are [run tasks](/terraform/cloud-docs/workspaces/settings/run-tasks) enabled
-for the workspace. All runs can enter this phase, including [speculative plans](/terraform/cloud-docs/run/remote-operations#speculative-plans). During this phase, HCP Terraform sends information about the run to the configured external system and waits for a `passed` or `failed` response to determine whether the run can continue.
+The post-plan phase only occurs if you configure [run tasks](/terraform/cloud-docs/workspaces/settings/run-tasks) on a workspace to begin after Terraform successfully completes a plan operation.
+All runs can enter this phase, including [speculative plans](/terraform/cloud-docs/run/remote-operations#speculative-plans). During this phase, HCP Terraform sends information about the run to the configured external system and waits for a `passed` or `failed` response to determine whether the run can continue.
 
 -> **Note:** The information sent to the configured external system includes the [JSON output](/terraform/internals/json-format) of the Terraform plan.
 
@@ -190,7 +190,7 @@ After applying, the run proceeds automatically to completion.
 
 ## The Post-Apply Stage
 
-The post-apply phase only occurs if the workspace has [run tasks](/terraform/cloud-docs/workspaces/settings/run-tasks) configured to begin after Terraform successfully completes an apply operation. During this phase, HCP Terraform sends information about the run to the configured external system and waits for a `passed` or `failed` response. However, unlike other stages in the run task process, a failed outcome will not halt the run since HCP Terraform has already provisioned the infrastructure.
+The post-apply phase only occurs if you configure [run tasks](/terraform/cloud-docs/workspaces/settings/run-tasks) on a workspace to begin after Terraform successfully completes an apply operation. During this phase, HCP Terraform sends information about the run to the configured external system and waits for a `passed` or `failed` response. However, unlike other stages in the run task process, a failed outcome does not halt the run since HCP Terraform has already provisioned the infrastructure.
 
 _States in this stage:_
 


### PR DESCRIPTION
### What and Why
Previously the description for the post-apply stage was difficult to understand and implied HCP TF behaviour which wasn't true.

This commit rewords the description to make it more readable.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] ~~Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.~~
- [x] ~~API documentation and the API Changelog have been updated.~~
- [x] ~~Links to related content where appropriate (e.g., API endpoints, permissions, etc.).~~
- [x] ~~Pages with related content are updated and link to this content when appropriate.~~
- [x] ~~Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.~~
- [x] ~~New pages have metadata (page name and description) at the top.~~
- [x] ~~New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.~~
- [x] ~~New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.~~
- [x] ~~UI elements (button names, page names, etc.) are bolded.~~
- [x] ~~The Vercel website preview successfully deployed.~~

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.


[Jira](https://hashicorp.atlassian.net/browse/TF-19782)