### PR TITLE
Add deprecation notice to Policy Check documentation

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,7 +9,7 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
-## 2024-08-14
+## 2024-09-02
 * Add warning about the deprecation and future removal of the [Policy Checks](/terraform/cloud-docs/api-docs/policy-checks) API.
 
 ## 2024-08-16

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,13 +9,16 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
+## 2024-08-14
+* Add warning about the deprecation and future removal of the [Policy Checks](/terraform/cloud-docs/api-docs/policy-checks) API.
+
 ## 2024-08-16
 * Fixes Workspace API responses to be consistent and contain all attributes and relationships.
 
 ## 2024-08-14
 * Add documentation for a new API endpoint that lists an [organization's team tokens](/terraform/cloud-docs/api-docs/team-tokens).
 
-## 2024-08-01 
+## 2024-08-01
 
 <EnterpriseAlert>
 This endpoint is exclusive to Terraform Enterprise, and not available in HCP Terraform.

--- a/website/docs/cloud-docs/api-docs/policy-checks.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-checks.mdx
@@ -45,6 +45,8 @@ description: >-
 Policy checks are the default workflow for Sentinel. Policy checks use the latest version of the Sentinel runtime and have access to cost estimation data.
 This set of APIs provides endpoints to get, list, and override policy checks.
 
+~> **Warning:** Policy checks are deprecated and will be permanently removed in August 2025. We recommend that you start using policy evaluations to avoid disruptions.
+
 ## List Policy Checks
 
 This endpoint lists the policy checks in a run.

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -26,11 +26,13 @@ Policy checks and evaluations can access different types of data and enable slig
 
 ### Policy checks
 
-Only Sentinel policies can run as policy checks, and it is the default mode for Sentinel policy sets. Checks can access cost estimation data but can only use the latest version of Sentinel.
+Only Sentinel policies can run as policy checks. Checks can access cost estimation data but can only use the latest version of Sentinel.
+
+~> **Warning:** Policy checks are deprecated and will be permanently removed in August 2025. We recommend that you start using policy evaluations to avoid disruptions.
 
 ### Policy evaluations
 
-OPA policy sets can only run as policy evaluations, and you can enable policy evaluations for Sentinel policy sets by selecting the `Enhanced` policy set type. Policy evaluations run within the [HCP Terraform agent](/terraform/cloud-docs/agents) in HCP Terraform's infrastructure. 
+OPA policy sets can only run as policy evaluations, and you can enable policy evaluations for Sentinel policy sets by selecting the `Enhanced` policy set type. Policy evaluations run within the [HCP Terraform agent](/terraform/cloud-docs/agents) in HCP Terraform's infrastructure.
 
 For Sentinel policy sets, using policy evaluations lets you:
 - Enable overrides for soft-mandatory and hard-mandatory policies, letting any user with [Manage Policy Overrides permission](/terraform/cloud-docs/users-teams-organizations/permissions#manage-policy-overrides) proceed with a run in the event of policy failure.


### PR DESCRIPTION
### What
Changed the contents of the Policy Enforcement and Policy Check API documentation to include a new feature deprecation warning.

### Why
We are deprecating the Policy Check feature in favor of the new Policy Evaluation model as it provides users with a more flexible workflow when managing policies at scale. 

### Screenshots
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
