### PR TITLE
added note about HC API service account

### DIFF
--- a/website/docs/cloud-docs/api-docs/teams.mdx
+++ b/website/docs/cloud-docs/api-docs/teams.mdx
@@ -60,6 +60,8 @@ Any member of an organization can view visible teams and any secret teams they a
 | -------------------- | ------------------------------------------------ |
 | `:organization_name` | The name of the organization to list teams from. |
 
+-> **Note:** HashiCorp API service accounts eg:`api-team_XXXXXX` may return as a member of a team. However when checking in the UI these accounts will not be shown. This may lead to scenarios where the UI reports 0 members on a team and the API reports 1.
+
 ### Query Parameters
 
 This endpoint supports pagination [with standard URL query parameters](/terraform/cloud-docs/api-docs#query-parameters). Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.

--- a/website/docs/cloud-docs/api-docs/teams.mdx
+++ b/website/docs/cloud-docs/api-docs/teams.mdx
@@ -60,7 +60,7 @@ Any member of an organization can view visible teams and any secret teams they a
 | -------------------- | ------------------------------------------------ |
 | `:organization_name` | The name of the organization to list teams from. |
 
--> **Note:** HashiCorp API service accounts eg:`api-team_XXXXXX` may return as a member of a team. However when checking in the UI these accounts will not be shown. This may lead to scenarios where the UI reports 0 members on a team and the API reports 1.
+The response may identify HashiCorp API service accounts, for example `api-team_XXXXXX`,  as a members of a team. However, API service accounts do not appear in the UI. As a result, there may be differences between the number of team members reported by the UI and the API. For example, the UI may report `0` members on a team when and the API reports `1`.
 
 ### Query Parameters
 

--- a/website/docs/cloud-docs/api-docs/teams.mdx
+++ b/website/docs/cloud-docs/api-docs/teams.mdx
@@ -60,7 +60,7 @@ Any member of an organization can view visible teams and any secret teams they a
 | -------------------- | ------------------------------------------------ |
 | `:organization_name` | The name of the organization to list teams from. |
 
-The response may identify HashiCorp API service accounts, for example `api-team_XXXXXX`,  as a members of a team. However, API service accounts do not appear in the UI. As a result, there may be differences between the number of team members reported by the UI and the API. For example, the UI may report `0` members on a team when and the API reports `1`.
+The response may identify HashiCorp API service accounts, for example `api-team_XXXXXX`, as a members of a team. However, API service accounts do not appear in the UI. As a result, there may be differences between the number of team members reported by the UI and the API. For example, the UI may report `0` members on a team when and the API reports `1`.
 
 ### Query Parameters
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Added a note detailing that while the UI doesn't show HashiCorp service accounts as members of a team the API can return them causing a discrepancy between what's reported. This is currently expected behavior.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
I had ticket 158661 where a user reported this originally as a potential bug but I've since confirmed with engineering team this is expected behavior currently. 

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [NA] Description links to related pull requests or issues, if any.

#### Content
- [NA] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [NA] API documentation and the API Changelog have been updated. 
- [NA] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [NA] Pages with related content are updated and link to this content when appropriate.
- [NA] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [NA] New pages have metadata (page name and description) at the top.
- [NA] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [NA] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [NA] UI elements (button names, page names, etc.) are bolded.
- [NA] The Vercel website preview successfully deployed.

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
- [X/PR] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
PR reviewer please double-check me
