### PR TITLE
minor update, remove expiry specifics

### DIFF
--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -153,7 +153,7 @@ You can share [HCP Terraform Agents](/terraform/cloud-docs/agents) across all wo
 
 ### Treat Archivist URLs as secrets
 
-HCP Terraform uses a blob storage service called Archivist for storing various pieces of customer data. Archivist URLs have the origin `https://archivist.terraform.io` and are returned by various HCP Terraform APIs, such as the [state versions API](/terraform/cloud-docs/api-docs/state-versions#fetch-the-current-state-version-for-a-workspace). You do not need to submit a bearer token with each request to call the Archivist API. Instead, Archivist URLs contain a signed authorization token that performs authorization checks. The token expires in approximately 24 hours. As a result, you must treat Archivist URLs as secrets and avoid logging or sharing them.
+HCP Terraform uses a blob storage service called Archivist for storing various pieces of customer data. Archivist URLs have the origin `https://archivist.terraform.io` and are returned by various HCP Terraform APIs, such as the [state versions API](/terraform/cloud-docs/api-docs/state-versions#fetch-the-current-state-version-for-a-workspace). You do not need to submit a bearer token with each request to call the Archivist API. Instead, Archivist URLs contain a short-term signed authorization token that performs authorization checks. As a result, you must treat Archivist URLs as secrets and avoid logging or sharing them.
 
 ### Use dynamic credentials
 

--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -153,7 +153,7 @@ You can share [HCP Terraform Agents](/terraform/cloud-docs/agents) across all wo
 
 ### Treat Archivist URLs as secrets
 
-HCP Terraform uses a blob storage service called Archivist for storing various pieces of customer data. Archivist URLs have the origin `https://archivist.terraform.io` and are returned by various HCP Terraform APIs, such as the [state versions API](/terraform/cloud-docs/api-docs/state-versions#fetch-the-current-state-version-for-a-workspace). You do not need to submit a bearer token with each request to call the Archivist API. Instead, Archivist URLs contain a short-term signed authorization token that performs authorization checks. As a result, you must treat Archivist URLs as secrets and avoid logging or sharing them.
+HCP Terraform uses a blob storage service called Archivist for storing various pieces of customer data. Archivist URLs have the origin `https://archivist.terraform.io` and are returned by various HCP Terraform APIs, such as the [state versions API](/terraform/cloud-docs/api-docs/state-versions#fetch-the-current-state-version-for-a-workspace). You do not need to submit a bearer token with each request to call the Archivist API. Instead, Archivist URLs contain a short-term signed authorization token that performs authorization checks. The expiry time depends on the API endpoints you used to generate the Archivist link. As a result, you must treat Archivist URLs as secrets and avoid logging or sharing them.
 
 ### Use dynamic credentials
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Removed line 'The token expires in approximately 24 hours.' and add back in 'short-term'
to keep this vague.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
There are differences in expiry time depending on the context, eg: plans and various other API endpoints that may be shorter than ~24 hours(applies). They are also subject to change without notice, so we don't want to declare values that would then be expected.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [NA] Description links to related pull requests or issues, if any.

#### Content
- [NA] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [NA] API documentation and the API Changelog have been updated. 
- [NA] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [NA] Pages with related content are updated and link to this content when appropriate.
- [NA] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [NA] New pages have metadata (page name and description) at the top.
- [NA] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [NA] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [NA] UI elements (button names, page names, etc.) are bolded.
- [NA] The Vercel website preview successfully deployed.

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
PR is based on follow-up conversation with Eng
- [X] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
(just myself, but please feel free to double-check/make changes)