### PR TITLE
Update mismatch file name in create a version step

### DIFF
--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -136,7 +136,7 @@ $ curl \
   --header "Authorization: Bearer TOKEN" \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
-  --data @payload.json \
+  --data @version.json \
   https://app.terraform.io/api/v2/organizations/ORG_NAME/registry-providers/private/ORG_NAME/aws/versions
 ```
 


### PR DESCRIPTION

### What
Page: website/docs/cloud-docs/registry/publish-providers.mdx
Currently the docs have the reader create a file `version.json` and then upload `payload.json` in the curl command.


### Why
Cleaning up a file name discrepency

### Screenshots
![Underlined the discrepancy in file names](https://github.com/user-attachments/assets/a554b1c4-7613-4de1-927d-a4963ec0099d)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded. 
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
