### PR TITLE
VAULT-20139 Add information about how user_claim=workspace can affect client counts when renaming

### DIFF
--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -83,6 +83,8 @@ Create a Vault role that HCP Terraform can use when authenticating to Vault.
 
 Vault offers a lot of flexibility in determining how to map roles and permissions in Vault to workspaces in HCP Terraform. You can have one role for each workspace, one role for a group of workspaces, or one role for all workspaces in an organization. You can also configure different roles for the plan and apply phases of a run.
 
+test
+
 -> **Note:** Setting the `user_claim` to be per workspace will tie the entity created in Vault to that workspace. Since workspaces are the uniqueness factor, if the workspace is renamed, this can create an additional identity object within Vault. To avoid this, the alias name in Vault can be updated to the new workspace name before updating the workspace name in HCP Terraform.
 
 The following example creates a role called `tfc-role`. The role is mapped to a single workspace and HCP Terraform can use it for both plan and apply runs.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -83,6 +83,8 @@ Create a Vault role that HCP Terraform can use when authenticating to Vault.
 
 Vault offers a lot of flexibility in determining how to map roles and permissions in Vault to workspaces in HCP Terraform. You can have one role for each workspace, one role for a group of workspaces, or one role for all workspaces in an organization. You can also configure different roles for the plan and apply phases of a run.
 
+~> **Note**: Setting the `user_claim` to be per workspace will tie the entity created in Vault to that workspace. Since workspaces are the uniqueness factor, if the workspace is renamed, this can create an additional identity object within Vault. To avoid this, the alias name in Vault can be updated to the new workspace name before updating the workspace name in HCP Terraform.
+
 The following example creates a role called `tfc-role`. The role is mapped to a single workspace and HCP Terraform can use it for both plan and apply runs.
 
 Create a file called `vault-jwt-auth-role.json` with the following content:
@@ -100,8 +102,6 @@ Create a file called `vault-jwt-auth-role.json` with the following content:
   "token_ttl": "20m"
 }
 ```
-
-~> **Note**: Setting the `user_claim` to be a workspace will tie the entity created in Vault to this workspace. Since workspaces are the uniqueness factor, if the workspace is renamed, this can create an additional identity object within Vault. To avoid this, the alias name in Vault can be updated to the new workspace name before updating the workspace name in HCP Terraform.
 
 Then run the following command to create a role named `tfc-role` with this configuration in Vault:
 ```shell

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -101,6 +101,8 @@ Create a file called `vault-jwt-auth-role.json` with the following content:
 }
 ```
 
+~> **Note**: Setting the `user_claim` to be a workspace will tie the entity created in Vault to this workspace. Since workspaces are the uniqueness factor, if the workspace is renamed, this can create an additional identity object within Vault. To avoid this, the alias name in Vault can be updated to the new workspace name before updating the workspace name in HCP Terraform.
+
 Then run the following command to create a role named `tfc-role` with this configuration in Vault:
 ```shell
 vault write auth/jwt/role/tfc-role @vault-jwt-auth-role.json

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -83,8 +83,6 @@ Create a Vault role that HCP Terraform can use when authenticating to Vault.
 
 Vault offers a lot of flexibility in determining how to map roles and permissions in Vault to workspaces in HCP Terraform. You can have one role for each workspace, one role for a group of workspaces, or one role for all workspaces in an organization. You can also configure different roles for the plan and apply phases of a run.
 
-test
-
 -> **Note:** Setting the `user_claim` to be per workspace will tie the entity created in Vault to that workspace. Since workspaces are the uniqueness factor, if the workspace is renamed, this can create an additional identity object within Vault. To avoid this, the alias name in Vault can be updated to the new workspace name before updating the workspace name in HCP Terraform.
 
 The following example creates a role called `tfc-role`. The role is mapped to a single workspace and HCP Terraform can use it for both plan and apply runs.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -83,7 +83,7 @@ Create a Vault role that HCP Terraform can use when authenticating to Vault.
 
 Vault offers a lot of flexibility in determining how to map roles and permissions in Vault to workspaces in HCP Terraform. You can have one role for each workspace, one role for a group of workspaces, or one role for all workspaces in an organization. You can also configure different roles for the plan and apply phases of a run.
 
--> **Note:** Setting the `user_claim` to be per workspace will tie the entity created in Vault to that workspace. Since workspaces are the uniqueness factor, if the workspace is renamed, this can create an additional identity object within Vault. To avoid this, the alias name in Vault can be updated to the new workspace name before updating the workspace name in HCP Terraform.
+-> **Note:** If you set your `user_claim` to be per workspace, then Vault ties the entity it creates to that workspace's name. If you rename the workspace tied to your `user_claim`, Vault will create an additional identity object. To avoid this, update the alias name in Vault to your new workspace name before you update it in HCP Terraform.
 
 The following example creates a role called `tfc-role`. The role is mapped to a single workspace and HCP Terraform can use it for both plan and apply runs.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -83,7 +83,7 @@ Create a Vault role that HCP Terraform can use when authenticating to Vault.
 
 Vault offers a lot of flexibility in determining how to map roles and permissions in Vault to workspaces in HCP Terraform. You can have one role for each workspace, one role for a group of workspaces, or one role for all workspaces in an organization. You can also configure different roles for the plan and apply phases of a run.
 
-~> **Note**: Setting the `user_claim` to be per workspace will tie the entity created in Vault to that workspace. Since workspaces are the uniqueness factor, if the workspace is renamed, this can create an additional identity object within Vault. To avoid this, the alias name in Vault can be updated to the new workspace name before updating the workspace name in HCP Terraform.
+-> **Note:** Setting the `user_claim` to be per workspace will tie the entity created in Vault to that workspace. Since workspaces are the uniqueness factor, if the workspace is renamed, this can create an additional identity object within Vault. To avoid this, the alias name in Vault can be updated to the new workspace name before updating the workspace name in HCP Terraform.
 
 The following example creates a role called `tfc-role`. The role is mapped to a single workspace and HCP Terraform can use it for both plan and apply runs.
 


### PR DESCRIPTION
### What

I added a note to https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration


### Why
This was a request from Vault PM due to this causing confusion for some TFE + Vault users in affecting their client count. (See VAULT-20139)

### Screenshots

<img width="761" alt="image" src="https://github.com/user-attachments/assets/6fb6d105-aaaa-491b-950e-db21c630df37">


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [X] Description links to related pull requests or issues, if any.

#### Content
- [X] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [X] API documentation and the API Changelog have been updated. 
- [X] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [X] Pages with related content are updated and link to this content when appropriate.
- [X] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [X] New pages have metadata (page name and description) at the top.
- [X] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [X] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [X] UI elements (button names, page names, etc.) are bolded.
- [X] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
