### PR TITLE
Fix example that is too specific to AWS provider

### DIFF
--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -129,7 +129,7 @@ Create a file named `version.json` with the following contents. Replace the valu
 }
 ```
 
-Use the [Create a Provider Version endpoint](/terraform/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) to create a version for your provider. Replace `TOKEN` in the `Authorization` header with your HCP Terraform API token, and replace both instances of `ORG_NAME` with the name of your organization.
+Use the [Create a Provider Version endpoint](/terraform/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) to create a version for your provider. Replace `TOKEN` in the `Authorization` header with your HCP Terraform API token, and replace both instances of `ORG_NAME` with the name of your organization. Replace `TF_PROVIDER_NAME` in the URL path with your terraform provider name
 
 ```shell-session
 $ curl \
@@ -137,7 +137,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://app.terraform.io/api/v2/organizations/ORG_NAME/registry-providers/private/ORG_NAME/aws/versions
+  https://app.terraform.io/api/v2/organizations/ORG_NAME/registry-providers/private/ORG_NAME/TF_PROVIDER_NAME/versions
 ```
 
  The response includes URL links that you will use to upload the `SHA256SUMS` and `SHA256.sig` files.


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Private provider doc has an example that is too specific to the aws provider.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
Was working through the tutorial and ran into this hurdle. This should help clear confusion

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
