### PR TITLE
Update manage-policy-sets.mdx

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -193,4 +193,9 @@ The policy set no longer appears on the UI and HCP Terraform no longer applies i
 
 You can set Sentinel parameters when you [edit a policy set](#edit-policy-sets).
 
-Parameters can only be set for policy sets added through a connected VCS repository or when policy sets are created with the [HCP Terraform Policy Sets API](/terraform/cloud-docs/api-docs/policy-sets) or the `tfe` provider [`tfe_policy_set`](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/policy_set) resource and then a policy set version is uploaded with a file containing the policy rules. Individually managed policies created through the UI, API or TFE provider do not support parameter attachment.
+You can only set parameters for policy sets added through:
+* A connected VCS repository
+* The [policy sets API](/terraform/cloud-docs/api-docs/policy-sets)
+* The `tfe` provider's [`tfe_policy_set`](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/policy_set) resource
+
+Individually managed policies created through HCP Terraform's UI, API, or the TFE provider do not support attaching parameters.

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -193,4 +193,4 @@ The policy set no longer appears on the UI and HCP Terraform no longer applies i
 
 You can set Sentinel parameters when you [edit a policy set](#edit-policy-sets).
 
-You can only set parameters for existing policy sets that you added through the `tfe` provider, API, or a connected VCS repository. Parameters are not available for managed policy sets.
+Parameters can only be set for policy sets added through a connected VCS repository or when policy sets are created with the [HCP Terraform Policy Sets API](/terraform/cloud-docs/api-docs/policy-sets) or the `tfe` provider [`tfe_policy_set`](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/policy_set) resource and then a policy set version is uploaded with a file containing the policy rules. Individually managed policies created through the UI, API or TFE provider do not support parameter attachment.


### PR DESCRIPTION
### What

Add additional clarification when the parameters are not supported.

### Why

The current explanation can mislead users that they will be able to add parameters to policies that are created via API or TFE provider, but those policy sets can be still individually managed type even if they are added via api or tfe.

### Screenshots

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
