### PR TITLE
Update Organizations API docs for speculative-plan-management-enabled

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,14 +9,12 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
-## 2024-10-28
-* Update the [Organizations API](/terraform/cloud-docs/api-docs/organizations) to support the `speculative-plan-management-enabled` attribute, which controls whether [Automatically cancel plan-only runs](/terraform/cloud-docs/users-teams-organizations/organizations/vcs-speculative-plan-management) is enabled.
 
 ## 2024-10-15
 * Add new documentation for the ability to deprecate, and revert the deprecation of, module versions. Learn more about [Managing module versions](/terraform/cloud-docs/api-docs/private-registry/manage-module-versions).
 
 ## 2024-10-14
-* Update the [Organizations API](/terraform/cloud-docs/api-docs/organizations) to support the `vcs-speculative-plan-management` attribute, which controls [automatic cancellation of plan-only runs triggered by outdated commits](/terraform/cloud-docs/users-teams-organizations/organizations/vcs-speculative-plan-management).
+* Update the [Organizations API](/terraform/cloud-docs/api-docs/organizations) to support the `speculative-plan-management-enabled` attribute, which controls [automatic cancellation of plan-only runs triggered by outdated commits](/terraform/cloud-docs/users-teams-organizations/organizations/vcs-speculative-plan-management).
 
 ## 2024-10-11
 * Add documentation for new timeframe filter on List endpoints for [Runs](/terraform/cloud-docs/api-docs/run) API

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,8 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
+## 2024-10-28
+* Update the [Organizations API](/terraform/cloud-docs/api-docs/organizations) to support the `speculative-plan-management-enabled` attribute, which controls whether [Automatically cancel plan-only runs](/terraform/cloud-docs/users-teams-organizations/organizations/vcs-speculative-plan-management) is enabled.
 
 ## 2024-10-15
 * Add new documentation for the ability to deprecate, and revert the deprecation of, module versions. Learn more about [Managing module versions](/terraform/cloud-docs/api-docs/private-registry/manage-module-versions).

--- a/website/docs/cloud-docs/api-docs/organizations.mdx
+++ b/website/docs/cloud-docs/api-docs/organizations.mdx
@@ -98,6 +98,7 @@ curl \
         "cost-estimation-enabled": true,
         "send-passing-statuses-for-untriggered-speculative-plans": true,
         "aggregated-commit-status-enabled": false,
+        "speculative-plan-management-enabled": true,
         "allow-force-delete-workspaces": true,
         "name": "hashicorp",
         "permissions": {
@@ -186,6 +187,7 @@ curl \
         "cost-estimation-enabled": false,
         "send-passing-statuses-for-untriggered-speculative-plans": false,
         "aggregated-commit-status-enabled": true,
+        "speculative-plan-management-enabled": true,
         "allow-force-delete-workspaces": false,
         "name": "hashicorp-two",
         "permissions": {
@@ -323,6 +325,7 @@ curl \
       "cost-estimation-enabled": false,
       "send-passing-statuses-for-untriggered-speculative-plans": false,
       "aggregated-commit-status-enabled": true,
+      "speculative-plan-management-enabled": true,
       "allow-force-delete-workspaces": false,
       "name": "hashicorp",
       "permissions": {
@@ -420,6 +423,7 @@ Properties without a default value are required.
 | `data.attributes.cost-estimation-enabled`                                 | boolean | false      | Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to false. In Terraform Enterprise, you must also enable cost estimation in [Site Administration](/terraform/enterprise/admin/application/integration#cost-estimation-integration). |
 | `data.attributes.send-passing-statuses-for-untriggered-speculative-plans` | boolean | false     | Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting is always false and cannot be changed but is also available in Site Administration. |
 | `data.attributes.aggregated-commit-status-enabled`                        | boolean | true      | Whether or not to aggregate VCS status updates for triggered workspaces. This is useful for monorepo projects with configuration spanning many workspaces. Defaults to `true`. You cannot use this option if `send-passing-statuses-for-untriggered-speculative-plans` is set to `true`.   |
+| `data.attributes.speculative-plan-management-enabled`                     | boolean | true      | Whether or not to enable [Automatically cancel plan-only runs](/terraform/cloud-docs/users-teams-organizations/organizations/vcs-speculative-plan-management). Defaults to `true`.                                                                                                                                                                                                 |
 | `data.attributes.owners-team-saml-role-id`                                | string  | (nothing) | **Optional.** **SAML only** The name of the ["owners" team](/terraform/enterprise/saml/team-membership#managing-membership-of-the-owners-team)                                                                                                                                                                                                                               |
 | `data.attributes.assessments-enforced`                                    | boolean | (false)   | Whether or not to compel health assessments for all eligible workspaces. When true, health assessments occur on all compatible workspaces, regardless of the value of the workspace setting `assessments-enabled`. When false, health assessments only occur for workspaces that opt in by setting `assessments-enabled: true`.         |
 | `data.attributes.allow-force-delete-workspaces`                           | boolean | (false)   | Whether workspace administrators can [delete workspaces with resources under management](/terraform/cloud-docs/users-teams-organizations/organizations#general). If false, only organization owners may delete these workspaces.                                                                                                                                                                              |
@@ -474,6 +478,7 @@ curl \
       "cost-estimation-enabled": false,
       "send-passing-statuses-for-untriggered-speculative-plans": false,
       "aggregated-commit-status-enabled": true,
+      "speculative-plan-management-enabled": true,
       "allow-force-delete-workspaces": false,
       "name": "hashicorp",
       "permissions": {
@@ -609,6 +614,7 @@ This PATCH endpoint requires a JSON object with the following properties as a re
 | `data.attributes.cost-estimation-enabled`                                 | boolean | false      | Whether or not the cost estimation feature is enabled for all workspaces in the organization. Defaults to false. In Terraform Enterprise, you must also enable cost estimation in [Site Administration](/terraform/enterprise/admin/application/integration#cost-estimation-integration). |
 | `data.attributes.send-passing-statuses-for-untriggered-speculative-plans` | boolean | false     | Whether or not to send VCS status updates for untriggered speculative plans. This can be useful if large numbers of untriggered workspaces are exhausting request limits for connected version control service providers like GitHub. Defaults to false. In Terraform Enterprise, this setting is always false and cannot be changed but is also available in Site Administration. |
 | `data.attributes.aggregated-commit-status-enabled`                        | boolean | true      | Whether or not to aggregate VCS status updates for triggered workspaces. This is useful for monorepo projects with configuration spanning many workspaces. Defaults to `true`. You cannot use this option if `send-passing-statuses-for-untriggered-speculative-plans` is set to `true`.   |
+| `data.attributes.speculative-plan-management-enabled`                     | boolean | true      | Whether or not to enable [Automatically cancel plan-only runs](/terraform/cloud-docs/users-teams-organizations/organizations/vcs-speculative-plan-management). Defaults to `true`.                                                                                                                                                                                                 |
 | `data.attributes.owners-team-saml-role-id`                                | string  | (nothing) | **Optional.** **SAML only** The name of the ["owners" team](/terraform/enterprise/saml/team-membership#managing-membership-of-the-owners-team)                                                                                                                                                                                                                               |
 | `data.attributes.assessments-enforced`                                    | boolean | false     | Whether or not to compel health assessments for all eligible workspaces. When true, health assessments occur on all compatible workspaces, regardless of the value of the workspace setting `assessments-enabled`. When false, health assessments only occur for workspaces that opt in by setting `assessments-enabled: true`.             |
 | `data.attributes.allow-force-delete-workspaces`                           | boolean | false     | Whether workspace administrators can [delete workspaces with resources under management](/terraform/cloud-docs/users-teams-organizations/organizations#general). If false, only organization owners may delete these workspaces.                                                                                                                                                                              |
@@ -662,6 +668,7 @@ curl \
       "cost-estimation-enabled": false,
       "send-passing-statuses-for-untriggered-speculative-plans": false,
       "aggregated-commit-status-enabled": true,
+      "speculative-plan-management-enabled": true,
       "name": "hashicorp",
       "permissions": {
         "can-update": true,


### PR DESCRIPTION
### What
Add missing attribute `speculative-plan-management-enabled` in the Organizations API.

### Why
The attribute was missing in the Organizations API doc when we introduced this feature in https://github.com/hashicorp/terraform-docs-common/pull/749.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

<img width="1037" alt="Screenshot 2024-10-28 at 12 04 05 PM" src="https://github.com/user-attachments/assets/6e36930a-01e2-4f3f-9458-d316734076bd">


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
