### PR TITLE
Update HCP Operator Labels documentation

### DIFF
--- a/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
@@ -18,4 +18,9 @@ This topic contains reference information about the annotations and labels the H
 
 ## Labels
 
-The operators do not use labels for Kubernetes.
+| Label key | Target resources | Possible values | Description |
+| --- | --- | --- | --- |
+| `agentpool.app.terraform.io/pool-name` | Pod[Agent] | `Any valid AgentPool name` |This label is 
+used to associate the resource with a specific agent pool, by specifying the name of the agent pool. |
+| `agentpool.app.terraform.io/pool-id` | Pod[Agent] | `Any valid AgentPool ID` | This label is 
+used to associate the resource with a specific agent pool, by specifying the ID of the agent pool. |

--- a/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/annotations-and-labels.mdx
@@ -20,7 +20,5 @@ This topic contains reference information about the annotations and labels the H
 
 | Label key | Target resources | Possible values | Description |
 | --- | --- | --- | --- |
-| `agentpool.app.terraform.io/pool-name` | Pod[Agent] | `Any valid AgentPool name` |This label is 
-used to associate the resource with a specific agent pool, by specifying the name of the agent pool. |
-| `agentpool.app.terraform.io/pool-id` | Pod[Agent] | `Any valid AgentPool ID` | This label is 
-used to associate the resource with a specific agent pool, by specifying the ID of the agent pool. |
+| `agentpool.app.terraform.io/pool-name` | Pod[Agent] | Any valid AgentPool name | Associate the resource with a specific agent pool by specifying the name of the agent pool. |
+| `agentpool.app.terraform.io/pool-id` | Pod[Agent] | Any valid AgentPool ID | Associate the resource with a specific agent pool by specifying the ID of the agent pool. |


### PR DESCRIPTION
### What
This PR updates `labels section` in the HCP Operator Labels and Annotations section.

### Why
Supplemental to the newly supported labels feature. 

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
