### PR TITLE
Document unique pagination method used in Org Runs Index endpoint

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,10 +9,11 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
-<!-- BEGIN: TFC:only name:explorer -->
+## 2025-3-10
+* Document unique pagination metadata given in the response of [Organization Runs Index API](/terraform/cloud-docs/api-docs/run##list-runs-in-an-organization).
+
 ## 2025-03-10
 * Add new field `current_rum_count` to the [explorer API](/terraform/cloud-docs/api-docs/explorer) in the `workspaces` view type that lists a workspace's current resources under management. 
-<!-- END: TFC:only name:explorer -->
 
 ## 2024-11-19
 

--- a/website/docs/cloud-docs/api-docs/run.mdx
+++ b/website/docs/cloud-docs/api-docs/run.mdx
@@ -583,8 +583,7 @@ curl \
       "current-page": 1,
       "next-page": 2,
       "prev-page": null,
-      "page-size": 20,
-      "page-count": 20
+      "page-size": 20
     }
   }
 }

--- a/website/docs/cloud-docs/api-docs/run.mdx
+++ b/website/docs/cloud-docs/api-docs/run.mdx
@@ -456,7 +456,7 @@ curl \
 
 This endpoint has an adjusted rate limit of 30 requests per minute. Note that most endpoints are limited to 30 requests per second.
 
-Note that this endpoint differs from others in the pagination metadata included in the response, such as the exclusion of the typical `total-count`. See the Sample Response below for more details.
+Note that this endpoint differs from others in the pagination metadata included in the response, such as the exclusion of the typical `total-count` and `total-pages`. See the Sample Response below for more details.
 
 | Status  | Response                                         | Reason                   |
 |---------|--------------------------------------------------|--------------------------|

--- a/website/docs/cloud-docs/api-docs/run.mdx
+++ b/website/docs/cloud-docs/api-docs/run.mdx
@@ -456,6 +456,8 @@ curl \
 
 This endpoint has an adjusted rate limit of 30 requests per minute. Note that most endpoints are limited to 30 requests per second.
 
+Note that this endpoint differs from others in the pagination metadata included in the response, such as the exclusion of the typical `total-count`. See the Sample Response below for more details.
+
 | Status  | Response                                         | Reason                   |
 |---------|--------------------------------------------------|--------------------------|
 | [200][] | Array of [JSON API document][]s (`type: "runs"`) | Successfully listed runs |
@@ -553,7 +555,16 @@ curl \
       }
     },
     {...}
-  ]
+  ],
+  "meta": {
+    "pagination": {
+      "current-page": 1,
+      "next-page": 2,
+      "prev-page": null,
+      "page-size": 20,
+      "page-count": 20
+    }
+  }
 }
 ```
 

--- a/website/docs/cloud-docs/api-docs/run.mdx
+++ b/website/docs/cloud-docs/api-docs/run.mdx
@@ -442,7 +442,24 @@ curl \
       }
     },
     {...}
-  ]
+  ],
+  "links": {
+    "first": "https://app.terraform.io/api/v2/workspaces/ws-yF7z4gyEQRhaCNG9/runs?page[number]=1&page[size]=20",
+    "last": "https://app.terraform.io/api/v2/workspaces/ws-yF7z4gyEQRhaCNG9/runs?page[number]=19206&page[size]=20",
+    "self": "https://app.terraform.io/api/v2/workspaces/ws-yF7z4gyEQRhaCNG9/runs?page[number]=2&page[size]=20",
+    "prev": "https://app.terraform.io/api/v2/workspaces/ws-yF7z4gyEQRhaCNG9/runs?page[number]=1&page[size]=20",
+    "next": "https://app.terraform.io/api/v2/workspaces/ws-yF7z4gyEQRhaCNG9/runs?page[number]=3&page[size]=20"
+  },
+  "meta": {
+    "pagination": {
+      "current-page": 2,
+      "next-page": 3,
+      "prev-page": 1,
+      "page-size": 20,
+      "total-count": 384105,
+      "total-pages": 19206
+    }
+  }
 }
 ```
 
@@ -556,6 +573,11 @@ curl \
     },
     {...}
   ],
+  "links": {
+    "self": "https://app.terraform.io/api/v2/organizations/hashicorp/runs?page[number]=2&page[size]=20",
+    "prev": "https://app.terraform.io/api/v2/organizations/hashicorp/runs?page[number]=1&page[size]=20",
+    "next": "https://app.terraform.io/api/v2/organizations/hashicorp/runs?page[number]=3&page[size]=20"
+  },
   "meta": {
     "pagination": {
       "current-page": 1,


### PR DESCRIPTION
### What
Documented the unique pagination used in the `GET /organizations/:organization_name/runs` endpoint.

Related PR: https://github.com/hashicorp/atlas/pull/21346

### Why
To surface to users the details of the atypical pagination metadata included in the response.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages. N/A
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.). N/A
- [x] Pages with related content are updated and link to this content when appropriate. N/A
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. N/A
- [x] New pages have metadata (page name and description) at the top. N/A
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. N/A
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded. N/A
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
