### PR TITLE
Updating the curl command which is supposed to create new provider version.

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -193,4 +193,9 @@ The policy set no longer appears on the UI and HCP Terraform no longer applies i
 
 You can set Sentinel parameters when you [edit a policy set](#edit-policy-sets).
 
-Parameters can only be set for policy sets added through a connected VCS repository or when policy sets are created with the [HCP Terraform Policy Sets API](/terraform/cloud-docs/api-docs/policy-sets) or the `tfe` provider [`tfe_policy_set`](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/policy_set) resource and then a policy set version is uploaded with a file containing the policy rules. Individually managed policies created through the UI, API or TFE provider do not support parameter attachment.
+You can only set parameters for policy sets added through:
+* A connected VCS repository
+* The [policy sets API](/terraform/cloud-docs/api-docs/policy-sets)
+* The `tfe` provider's [`tfe_policy_set`](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/policy_set) resource
+
+Individually managed policies created through HCP Terraform's UI, API, or the TFE provider do not support attaching parameters.

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -193,4 +193,4 @@ The policy set no longer appears on the UI and HCP Terraform no longer applies i
 
 You can set Sentinel parameters when you [edit a policy set](#edit-policy-sets).
 
-You can only set parameters for existing policy sets that you added through the `tfe` provider, API, or a connected VCS repository. Parameters are not available for managed policy sets.
+Parameters can only be set for policy sets added through a connected VCS repository or when policy sets are created with the [HCP Terraform Policy Sets API](/terraform/cloud-docs/api-docs/policy-sets) or the `tfe` provider [`tfe_policy_set`](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/policy_set) resource and then a policy set version is uploaded with a file containing the policy rules. Individually managed policies created through the UI, API or TFE provider do not support parameter attachment.

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -58,7 +58,7 @@ Create a file named `provider.json` with the following contents. Replace `PROVID
 }
 ```
 
-Use the [Create a Provider endpoint](/terraform/cloud-docs/api-docs/private-registry/providers#create-a-provider) to create the provider in HCP Terraform. Replace `TOKEN` in the `Authorization` header with your HCP Terraform API token and replace `ORG_NAME` with the name of your organization. If are not using the `aws` provider, then replace `aws` with your provider's name.
+Use the [Create a Provider endpoint](/terraform/cloud-docs/api-docs/private-registry/providers#create-a-provider) to create the provider in HCP Terraform. Replace `TOKEN` in the `Authorization` header with your HCP Terraform API token and replace `ORG_NAME` with the name of your organization.
 
 ```shell-session
 $ curl \
@@ -129,7 +129,8 @@ Create a file named `version.json` with the following contents. Replace the valu
 }
 ```
 
-Use the [Create a Provider Version endpoint](/terraform/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) to create a version for your provider. Replace `TOKEN` in the `Authorization` header with your HCP Terraform API token, and replace both instances of `ORG_NAME` with the name of your organization.
+Use the [Create a Provider Version endpoint](/terraform/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) to create a version for your provider. Replace `TOKEN` in the `Authorization` header with your HCP Terraform API token, and replace both instances of `ORG_NAME` with the name of your organization. If are not using the `aws` provider, then replace `aws` with your provider's name.
+
 
 ```shell-session
 $ curl \
@@ -137,7 +138,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://app.terraform.io/api/v2/organizations/ORG_NAME/registry-providers/private/ORG_NAME/PROVIDER_NAME/versions
+  https://app.terraform.io/api/v2/organizations/ORG_NAME/registry-providers/private/ORG_NAME/aws/versions
 ```
 
  The response includes URL links that you will use to upload the `SHA256SUMS` and `SHA256.sig` files.

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -131,7 +131,6 @@ Create a file named `version.json` with the following contents. Replace the valu
 
 Use the [Create a Provider Version endpoint](/terraform/cloud-docs/api-docs/private-registry/provider-versions-platforms#create-a-provider-version) to create a version for your provider. Replace `TOKEN` in the `Authorization` header with your HCP Terraform API token, and replace both instances of `ORG_NAME` with the name of your organization. If are not using the `aws` provider, then replace `aws` with your provider's name.
 
-
 ```shell-session
 $ curl \
   --header "Authorization: Bearer TOKEN" \

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -58,7 +58,7 @@ Create a file named `provider.json` with the following contents. Replace `PROVID
 }
 ```
 
-Use the [Create a Provider endpoint](/terraform/cloud-docs/api-docs/private-registry/providers#create-a-provider) to create the provider in HCP Terraform. Replace `TOKEN` in the `Authorization` header with your HCP Terraform API token and replace `ORG_NAME` with the name of your organization.
+Use the [Create a Provider endpoint](/terraform/cloud-docs/api-docs/private-registry/providers#create-a-provider) to create the provider in HCP Terraform. Replace `TOKEN` in the `Authorization` header with your HCP Terraform API token and replace `ORG_NAME` with the name of your organization. If are not using the `aws` provider, then replace `aws` with your provider's name.
 
 ```shell-session
 $ curl \

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -1,4 +1,4 @@
- f---
+---
 page_title: Publishing Private Providers - Private Registry
 description: >-
   Prepare private providers for publishing, add them to the private registry,

--- a/website/docs/cloud-docs/registry/publish-providers.mdx
+++ b/website/docs/cloud-docs/registry/publish-providers.mdx
@@ -1,4 +1,4 @@
----
+ f---
 page_title: Publishing Private Providers - Private Registry
 description: >-
   Prepare private providers for publishing, add them to the private registry,
@@ -137,7 +137,7 @@ $ curl \
   --header "Content-Type: application/vnd.api+json" \
   --request POST \
   --data @payload.json \
-  https://app.terraform.io/api/v2/organizations/ORG_NAME/registry-providers/private/ORG_NAME/aws/versions
+  https://app.terraform.io/api/v2/organizations/ORG_NAME/registry-providers/private/ORG_NAME/PROVIDER_NAME/versions
 ```
 
  The response includes URL links that you will use to upload the `SHA256SUMS` and `SHA256.sig` files.


### PR DESCRIPTION
### What

Just changed a little bit the curl request which is supposed to create version, as the current example has the provider name set as "aws" and never mention to change this to your actual provider name.

### Why

This might be confusing for some customers, since they might not have named their provider "aws".

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
