### PR TITLE
/api/v2/vars query parameters are now required

### DIFF
--- a/website/docs/cloud-docs/api-docs/variables.mdx
+++ b/website/docs/cloud-docs/api-docs/variables.mdx
@@ -149,10 +149,10 @@ curl \
 
 [These are standard URL query parameters](/terraform/cloud-docs/api-docs#query-parameters). Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
 
-| Parameter                    | Description                                                                                                                               |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `filter[workspace][name]`    | **Optional** The name of one workspace to list variables for. If included, you must also include the organization name filter.            |
-| `filter[organization][name]` | **Optional** The name of the organization that owns the desired workspace. If included, you must also included the workspace name filter. |
+| Parameter                    | Description                                                                |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| `filter[workspace][name]`    | **Required** The name of one workspace to list variables for.              |
+| `filter[organization][name]` | **Required** The name of the organization that owns the desired workspace. |
 
 These two parameters are optional but linked; if you include one, you must include both. Without a filter, this method lists variables for all workspaces where you have permission to read variables. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))
 


### PR DESCRIPTION
### What

This change is stemming from a desire to remove the optional inclusion of `filter[workspace][name] and `filter[organization][name]` from the `/api/v2/vars` endpoint. These parameters are now required by the endpoint. 

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
