### PR TITLE
Policy Set params are now enabled for managed policy sets

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets.mdx
@@ -192,10 +192,3 @@ The policy set no longer appears on the UI and HCP Terraform no longer applies i
 [Sentinel parameters](https://docs.hashicorp.com/sentinel/language/parameters) are a list of key/value pairs that HCP Terraform sends to the Sentinel runtime when performing policy checks on workspaces. If the value parses as JSON, HCP Terraform sends it to Sentinel as the corresponding type (string, boolean, integer, map, or list). If the value fails JSON validation, HCP Terraform sends it as a string.
 
 You can set Sentinel parameters when you [edit a policy set](#edit-policy-sets).
-
-You can only set parameters for policy sets added through:
-* A connected VCS repository
-* The [policy sets API](/terraform/cloud-docs/api-docs/policy-sets)
-* The `tfe` provider's [`tfe_policy_set`](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/policy_set) resource
-
-Individually managed policies created through HCP Terraform's UI, API, or the TFE provider do not support attaching parameters.


### PR DESCRIPTION
### What

Policy Set Parameters are now available for managed policy sets.

### Why

As above, un-commenting some words that are no longer valid.

### Screenshots

N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] (N/A) The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
