### PR TITLE
cloud-docs: Update HCP TF security model

### DIFF
--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -116,7 +116,7 @@ Marking a variable as “sensitive” will prevent it from being displayed in th
 
 The logs from a Terraform plan or apply operation are visible to any user with at least “read” level access in the associated workspace. While Terraform tries to avoid writing sensitive information to logs, redactions are best-effort. This feature should not be treated as a security boundary, but instead as a mechanism to mitigate accidental exposure. Additionally, HCP Terraform is unable to protect against malicious users who attempt to use Terraform logs to exfiltrate sensitive data.
 
-### Redaction of ephemeral values in Terraform logs
+### Redact ephemeral values from Terraform logs
 
 The logs from a Terraform plan or apply operation are visible to any user with at least “read” level access in the associated workspace. Terraform tries to avoid writing ephemeral values to logs
 and provider developers are discouraged from logging those as well but Terraform cannot provide guarantees that providers will not log ephemeral values.

--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -116,6 +116,16 @@ Marking a variable as “sensitive” will prevent it from being displayed in th
 
 The logs from a Terraform plan or apply operation are visible to any user with at least “read” level access in the associated workspace. While Terraform tries to avoid writing sensitive information to logs, redactions are best-effort. This feature should not be treated as a security boundary, but instead as a mechanism to mitigate accidental exposure. Additionally, HCP Terraform is unable to protect against malicious users who attempt to use Terraform logs to exfiltrate sensitive data.
 
+### Redaction of ephemeral values in Terraform logs
+
+The logs from a Terraform plan or apply operation are visible to any user with at least “read” level access in the associated workspace. Terraform tries to avoid writing ephemeral values to logs
+and provider developers are discouraged from logging those as well but Terraform cannot provide guarantees that providers will not log ephemeral values.
+You can reduce the risk by only [using trusted modules and providers within Terraform configuration](#malicious-terraform-providers-or-modules).
+
+### Redaction of ephemeral values in memory
+
+Ephemeral Values prevents values from being persisted to disk (as part of a plan file or state file) but no efforts are made to protect ephemeral values from memory analysis of the running application.
+
 ## Recommendations for securely using HCP Terraform
 
 ### Enforce strong authentication

--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -119,7 +119,7 @@ The logs from a Terraform plan or apply operation are visible to any user with a
 ### Redact ephemeral values from Terraform logs
 
 The logs from a Terraform plan or apply operation are visible to any workspace's users with **Read** permissions. Terraform attempts to avoid writing [ephemeral values](/terraform/language/resources/ephemeral) to logs, but Terraform cannot guarantee that all providers will not log ephemeral values.
-You can reduce the risk by only [using trusted modules and providers within Terraform configuration](#malicious-terraform-providers-or-modules).
+You can reduce the risk of ephemeral values being potentially logged by malicious providers by only [using trusted modules and providers within Terraform configuration](#malicious-terraform-providers-or-modules).
 
 ### Redact ephemeral values in memory
 

--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -119,7 +119,6 @@ The logs from a Terraform plan or apply operation are visible to any user with a
 ### Redact ephemeral values from Terraform logs
 
 The logs from a Terraform plan or apply operation are visible to any workspace's users with **Read** permissions. Terraform attempts to avoid writing [ephemeral values](/terraform/language/resources/ephemeral) to logs, but Terraform cannot guarantee that all providers will not log ephemeral values.
-and provider developers are discouraged from logging those as well but Terraform cannot provide guarantees that providers will not log ephemeral values.
 You can reduce the risk by only [using trusted modules and providers within Terraform configuration](#malicious-terraform-providers-or-modules).
 
 ### Redaction of ephemeral values in memory

--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -123,7 +123,7 @@ You can reduce the risk by only [using trusted modules and providers within Terr
 
 ### Redact ephemeral values in memory
 
-Ephemeral Values prevents values from being persisted to disk (as part of a plan file or state file) but no efforts are made to protect ephemeral values from memory analysis of the running application.
+Terraform does not persist ephemeral values to plan or state files. However, Terraform does not protect ephemeral values from a memory analysis of Terraform while its running.
 
 ## Recommendations for securely using HCP Terraform
 

--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -118,7 +118,7 @@ The logs from a Terraform plan or apply operation are visible to any user with a
 
 ### Redact ephemeral values from Terraform logs
 
-The logs from a Terraform plan or apply operation are visible to any user with at least “read” level access in the associated workspace. Terraform tries to avoid writing ephemeral values to logs
+The logs from a Terraform plan or apply operation are visible to any workspace's users with **Read** permissions. Terraform attempts to avoid writing [ephemeral values](/terraform/language/resources/ephemeral) to logs, but Terraform cannot guarantee that all providers will not log ephemeral values.
 and provider developers are discouraged from logging those as well but Terraform cannot provide guarantees that providers will not log ephemeral values.
 You can reduce the risk by only [using trusted modules and providers within Terraform configuration](#malicious-terraform-providers-or-modules).
 

--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -121,7 +121,7 @@ The logs from a Terraform plan or apply operation are visible to any user with a
 The logs from a Terraform plan or apply operation are visible to any workspace's users with **Read** permissions. Terraform attempts to avoid writing [ephemeral values](/terraform/language/resources/ephemeral) to logs, but Terraform cannot guarantee that all providers will not log ephemeral values.
 You can reduce the risk by only [using trusted modules and providers within Terraform configuration](#malicious-terraform-providers-or-modules).
 
-### Redaction of ephemeral values in memory
+### Redact ephemeral values in memory
 
 Ephemeral Values prevents values from being persisted to disk (as part of a plan file or state file) but no efforts are made to protect ephemeral values from memory analysis of the running application.
 


### PR DESCRIPTION
Added a few clarifications in the security/threat model concerning ephemeral values, as released recently in 1.10.