### PR TITLE
doc: Removed erroneous deprecation warning from tfconfig/v2 listing

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/import-reference/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/import-reference/index.mdx
@@ -12,11 +12,11 @@ You can add Sentinel the `import` function, which enables a policy to access reu
 HCP Terraform provides the following importable libraries to define policy rules for the plan, configuration, state, and run associated with a policy check.
 
 - [`tfplan`](/terraform/cloud-docs/policy-enforcement/import-reference/tfplan) : Provides access to a Terraform plan, which is the file created when you run the `terraform plan` command. This library is deprecated. Use `tfplanv/2` instead.
-- [`tfplan/v2`](/terraform/cloud-docs/policy-enforcement/import-reference/tfplan-v2): Provides access to a Terraform plan, which is the file created when you run the `terraform plan` command. 
+- [`tfplan/v2`](/terraform/cloud-docs/policy-enforcement/import-reference/tfplan-v2): Provides access to a Terraform plan, which is the file created when you run the `terraform plan` command.
 - [`tfconfig`](/terraform/cloud-docs/policy-enforcement/import-reference/tfconfig): Provides access to a Terraform configuration. The configuration is the set of `.tf` files that describe the desired infrastructure state. This library is deprecated. Use `tfconfig/v2` instead.
-- [`tfconfig/v2`](/terraform/cloud-docs/policy-enforcement/import-reference/tfconfig-v2): Provides access to a Terraform configuration. The configuration is the set of `.tf` files that describe the desired infrastructure state. This library is deprecated. Use `tfconfig/v2` instead.
+- [`tfconfig/v2`](/terraform/cloud-docs/policy-enforcement/import-reference/tfconfig-v2): Provides access to a Terraform configuration. The configuration is the set of `.tf` files that describe the desired infrastructure state.
 - [`tfstate`](/terraform/cloud-docs/policy-enforcement/import-reference/tfstate): Provides access to the Terraform state. Terraform uses state to map real-world resources to your configuration. This library is deprecated. Use `tfstate/v2` instead.
-- [`tfstate/v2`](/terraform/cloud-docs/policy-enforcement/import-reference/tfstate-v2): Provides access to the Terraform state. Terraform uses state to map real-world resources to your configuration. 
+- [`tfstate/v2`](/terraform/cloud-docs/policy-enforcement/import-reference/tfstate-v2): Provides access to the Terraform state. Terraform uses state to map real-world resources to your configuration.
 - [`tfrun`](/terraform/cloud-docs/policy-enforcement/import-reference/tfrun): Provides access to data associated with a run in HCP Terraform. For example, you could retrieve the run's workspace.
 
 ## Test `import` functions


### PR DESCRIPTION
### What
* This removes a deprecation warning from the `tfconfig/v2` listing as it was a clear sign of accidental copy/paste.
* https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement/import-reference

### Why
* Fixes obvious mistake in documentation.

### Screenshots
n/a

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages. (N/A)
- [x] API documentation and the API Changelog have been updated.  (N/A)
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate. (N/A)
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A)
- [x] New pages have metadata (page name and description) at the top. (N/A)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. (N/A)
- [x] UI elements (button names, page names, etc.) are bolded. (N/A)
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
