### PR TITLE
update force delete workspace documentation to mention the 'Latest wo…

### DIFF
--- a/website/docs/cloud-docs/api-docs/workspaces.mdx
+++ b/website/docs/cloud-docs/api-docs/workspaces.mdx
@@ -774,7 +774,7 @@ You can use two endpoints to force delete a workspace, which behave identically.
 | Status  | Response                  | Reason(s)                                                             |
 | ------- | --------------------------| --------------------------------------------------------------------- |
 | [204][] | No Content                | Successfully deleted the workspace                                    |
-| [403][] | [JSON API error object][] | Not authorized to perform a force delete on the workspace. If the error message includes `Latest workspace state is being processed to discover resources`, please refer to [the `resources-processed` attribute in the State Versions API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/state-versions)          |
+| [403][] | [JSON API error object][] | Not authorized to perform a force delete on the workspace. If the error message includes `Latest workspace state is being processed to discover resources`, please refer to [the `resources-processed` attribute in the State Versions API.](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/state-versions)          |
 | [404][] | [JSON API error object][] | Workspace not found, or user unauthorized to perform workspace delete |
 
 ### Sample Request


### PR DESCRIPTION
…rkspace state is being processed to discover resources' error

### What
Update website/docs/cloud-docs/api-docs/workspaces.mdx

### Why

To mention the error "Latest workspace state is being processed to discover resources, try again later", which users may stop seeing after retrying the force-delete endpoint and waiting for `resources-processed` to be set to `true`. 
We mention in the State Versions API docs how to use "resources-processed" attribute to find out if resources are still being processed when the value of the attribute is `false`.
It'd be good to refer the users to that doc so they know that the "Latest workspace state is being processed to discover resources, try again later" error could be a temporary one while State is still processing resources.

JIRA ticket: https://hashicorp.atlassian.net/browse/TF-23222

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
