### PR TITLE
[TF-21109] Remove beta tags for Change requests and team notifications

### DIFF
--- a/website/docs/cloud-docs/api-docs/change-requests.mdx
+++ b/website/docs/cloud-docs/api-docs/change-requests.mdx
@@ -38,8 +38,6 @@ description: >-
 
 # Change requests API reference
 
--> **Note**: Change requests are in public beta. All APIs and workflows are subject to change.
-
 You can use change requests to keep track of workspace to-dos directly on that workspace. Change requests are a backlog of the changes that a workspace requires, often to ensure that workspace keeps up with compliance and best practices of your company. Change requests can also trigger [team notifications](/terraform/cloud-docs/users-teams-organizations/teams/notifications) to directly notify team members whenever someone creates a new change request.
 
 @include 'tfc-package-callouts/change-requests.mdx'

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,11 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
+{/* BEGIN: TFC:only name:explorer */}
+## 2025-01-30
+* Remove beta tags from documentation for Explorer, Change request and Team notifications.
+{/* END: TFC:only name:explorer */}
+
 ## 2024-11-19
 * Clarifies listing tag-bindings and effective-tag-bindings on [Workspaces](/terraform/cloud-docs/api-docs/workspaces) and [Projects](/terraform/cloud-docs/api-docs/projects)
 * Adds new documentation for PATCHing tag bindings on [Projects](/terraform/cloud-docs/api-docs/projects)/[Workspaces](/terraform/cloud-docs/api-docs/workspaces)

--- a/website/docs/cloud-docs/api-docs/explorer.mdx
+++ b/website/docs/cloud-docs/api-docs/explorer.mdx
@@ -461,8 +461,6 @@ all_checks_succeeded,checks_errored,checks_failed,checks_passed,checks_unknown,c
 
 ## List saved views
 
--> **Note**: The ability to save views in the explorer is in public beta. All APIs and workflows are subject to change.
-
 Use this endpoint to display all of the explorer's [saved views](/terraform/cloud-docs/workspaces/explorer#saved-views) in an organization.
 
 `GET /api/v2/organizations/:organization_name/explorer/views`
@@ -510,8 +508,6 @@ curl \
 ```
 
 ## Create saved view
-
--> **Note**: The ability to save views in the explorer is in public beta. All APIs and workflows are subject to change.
 
 Use this endpoint to create a [saved view](/terraform/cloud-docs/workspaces/explorer#saved-views) in the explorer.
 

--- a/website/docs/cloud-docs/api-docs/notification-configurations.mdx
+++ b/website/docs/cloud-docs/api-docs/notification-configurations.mdx
@@ -1106,8 +1106,6 @@ $ curl \
 
 ##  Team notification configuration
 
--> **Note**: Team notifications are in public beta. All APIs and workflows are subject to change.
-
 Team notifications allow you to configure relevant alerts that notify teams you specify whenever a certain event occurs. 
 
 <!-- BEGIN: TFC:only name:pnp-callout -->

--- a/website/docs/cloud-docs/users-teams-organizations/teams/notifications.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/teams/notifications.mdx
@@ -13,8 +13,6 @@ You can configure an individual team notification to notify up to twenty teams. 
 
 ## Requirements
 
--> **Note**: Team notifications are in public beta. All APIs and workflows are subject to change.
-
 To configure team notifications, you need the [**Manage teams**](/terraform/cloud-docs/users-teams-organizations/permissions#manage-teams) permissions for the team for which you want to configure notifications.
 
 ## View notification configuration settings

--- a/website/docs/cloud-docs/workspaces/change-requests/index.mdx
+++ b/website/docs/cloud-docs/workspaces/change-requests/index.mdx
@@ -24,8 +24,6 @@ If a specific person or team owns a workspace, you can set up and configure a te
 
 ## Primary workflow
 
--> **Note**: Change requests are in public beta. All APIs and workflows are subject to change.
-
 Administrators can [create new change requests](/terraform/cloud-docs/workspaces/change-requests/manage#create-a-change-request) directly from explorer queries on workspace data. After selecting the workspaces to include in the request, they can write a message describing the details and goal of that change request. 
 
 Workspaces manage and track their change requests directly, and team members can [archive a change request](/terraform/cloud-docs/workspaces/change-requests/manage#archive-existing-change-requests)  once they’ve completed that request’s task. 

--- a/website/docs/cloud-docs/workspaces/explorer.mdx
+++ b/website/docs/cloud-docs/workspaces/explorer.mdx
@@ -80,8 +80,6 @@ You can create multiple filter conditions for a query. When you provide multiple
 
 You can save explorer views to revisit a custom query or use case.
 
--> **Note**: The ability to save views in the explorer is in public beta. All APIs and workflows are subject to change.
-
 You can save the explorer’s view of your data by performing the following steps:
 
 1. Navigate to the **Explorer** page in the sidebar of your organization.  


### PR DESCRIPTION
### What
Removed beta tags from Explorer, Change Requests and Team Notification pages. 

website/docs/cloud-docs/api-docs/changelog.mdx
website/docs/cloud-docs/api-docs/explorer.mdx
website/docs/cloud-docs/workspaces/explorer.mdx
website/docs/cloud-docs/api-docs/change-requests.mdx
website/docs/cloud-docs/workspaces/change-requests/index.mdx
website/docs/cloud-docs/api-docs/notification-configurations.mdx

### Why
This changed was due to the MLM features in Explorer are going GA by end of FY25Q4 - Jan 2025.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
