### PR TITLE
Added a reference to provider configuration in Test Integrated Modules

### DIFF
--- a/website/docs/cloud-docs/registry/test.mdx
+++ b/website/docs/cloud-docs/registry/test.mdx
@@ -44,9 +44,9 @@ To add environment variables to your module's tests:
 1. Provide a **Key** and **Value** for your environment variable, and if you want to protect the variable's value, click the **Sensitive** checkbox. `TF_VAR_x` variables of a string type that are not defined in a config must be wrapped in double-quotes.
 1. Click **Add variable** to save it.
 
-## Provider configurations
+## Configure providers
 
-You can define test-specific provider configurations that HCP Terraform will use for testing. For guidance on how to implement a test-specific provider configuration, please refer to the [Terraform Test documentation](/terraform/language/tests#providers).
+You can define test-specific provider configurations for HCP Terraform to use while testing. For guidance on implementing test-specific provider configuration, refer to [Terraform test](/terraform/language/tests#providers).
 
 <!-- BEGIN: TFC:only name:generate-module-tests -->
 

--- a/website/docs/cloud-docs/registry/test.mdx
+++ b/website/docs/cloud-docs/registry/test.mdx
@@ -44,6 +44,10 @@ To add environment variables to your module's tests:
 1. Provide a **Key** and **Value** for your environment variable, and if you want to protect the variable's value, click the **Sensitive** checkbox. `TF_VAR_x` variables of a string type that are not defined in a config must be wrapped in double-quotes.
 1. Click **Add variable** to save it.
 
+## Provider configurations
+
+You can define test-specific provider configurations that HCP Terraform will use for testing. For guidance on how to implement a test-specific provider configuration, please refer to the [Terraform Test documentation](/terraform/language/tests#providers).
+
 <!-- BEGIN: TFC:only name:generate-module-tests -->
 
 ## Generated module tests


### PR DESCRIPTION
I was doing research into Test Integrated Modules for a recent project, and it took me a little while to work out how to provide a test-specific provider configuration as there is no mention of this in the registry docs. Have added a link to the specific section of the terraform test docs that deal with this.

### What
<!-- Explain what you changed and provide a list of changed page names. -->
* cloud-docs/test.mdx 

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
Provides clarity on how to implement test specific provider configurations when all module authorship guidelines currently state that a module should not own its provider configuration and should inherit it from the parent module.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
