### PR TITLE
Add documentation for the project variable sets permission

### DIFF
--- a/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
@@ -180,9 +180,9 @@ You can grant the following project permissions to teams on a per-project basis.
   - **Read:** — Allows users to see teams assigned to the project for visible teams.
   - **Manage:** — _Implies permission to read._ Allows users to set or remove project permissions for visible teams. Project admins can not view or manage [secret teams](/terraform/cloud-docs/users-teams-organizations/teams/manage#team-visibility) unless they are also organization owners.
 - **Variable sets:**
-  - **None:** — No access to view variable sets applied to the project.
-  - **Read:** — Allows users to view variable sets applied to the project.
-  - **Manage:** — _Implies permission to read._ Allows users to create, update, and delete variable sets applied to the project.
+  - **None:** — No access to variable sets owned by the project. However, users with Variable access permissions can view variable sets applied to this project and its workspaces.
+  - **Read:** — Allows users to view variable sets owned by this project.
+  - **Manage:** — _Implies permission to read._ Allows users to create, update, and delete variable sets owned by the project.
 
 See [General Workspace Permissions](#general-workspace-permissions)for the complete list of available permissions for a project's workspaces.
 

--- a/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/permissions.mdx
@@ -179,6 +179,10 @@ You can grant the following project permissions to teams on a per-project basis.
   - **None:** — No access to view teams assigned to the project.
   - **Read:** — Allows users to see teams assigned to the project for visible teams.
   - **Manage:** — _Implies permission to read._ Allows users to set or remove project permissions for visible teams. Project admins can not view or manage [secret teams](/terraform/cloud-docs/users-teams-organizations/teams/manage#team-visibility) unless they are also organization owners.
+- **Variable sets:**
+  - **None:** — No access to view variable sets applied to the project.
+  - **Read:** — Allows users to view variable sets applied to the project.
+  - **Manage:** — _Implies permission to read._ Allows users to create, update, and delete variable sets applied to the project.
 
 See [General Workspace Permissions](#general-workspace-permissions)for the complete list of available permissions for a project's workspaces.
 

--- a/website/docs/cloud-docs/workspaces/variables/managing-variables.mdx
+++ b/website/docs/cloud-docs/workspaces/variables/managing-variables.mdx
@@ -29,6 +29,7 @@ To create, edit, or apply project-owned variable sets, you must be part of a tea
 -   **Write** project permissions
 -   **Maintain** project permissions
 -   **Admin** project permissions
+-   [**Manage variable sets**](/terraform/cloud-docs/users-teams-organizations/permissions#general-project-permissions) project permissions
 -   [**Manage all projects**](/terraform/cloud-docs/users-teams-organizations/permissions#manage-all-projects) organization permissions
 
 ## Run-Specific Variables


### PR DESCRIPTION
### What
Adds documentation for the project variable sets permission, which manages a user’s access to the variable sets of a project.

- https://terraform-docs-common-git-mkam-tf-23336custom-243724-hashicorp.vercel.app/terraform/cloud-docs/users-teams-organizations/permissions#general-project-permissions
- https://terraform-docs-common-git-mkam-tf-23336custom-243724-hashicorp.vercel.app/terraform/cloud-docs/workspaces/variables/managing-variables#permissions

### Why
This is a new permission, so needed to update wherever we reference required permissions for variable sets. This feature is not in GA yet, so I've labeled it as do not merge temporarily.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
