### PR TITLE
Fix tf-migrate generated config directory name

### DIFF
--- a/website/docs/cloud-docs/migrate/tf-migrate/reference/prepare.mdx
+++ b/website/docs/cloud-docs/migrate/tf-migrate/reference/prepare.mdx
@@ -22,7 +22,7 @@ The `tf-migrate prepare` command prompts you for the following information:
 - If you would like to create a new branch named `hcp-migrate-main`.  
 - If you would like it to automatically create a pull request with the updated code change when the migration is complete.
 
-After you run the `prepare` command, Terraform migrate generates a new Terraform configuration in the `hcp-migrate-config` directory to perform the migration. This configuration creates the following resources:
+After you run the `prepare` command, Terraform migrate generates a new Terraform configuration in the `_hcp-migrate-configs` directory to perform the migration. This configuration creates the following resources:
 
 - One workspace per state file  
 - One project to store all workspaces  


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

Fixed the name of the directory that `tf-migrate` creates with the generated config after running `tf-migrate prepare`.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
