### PR TITLE
Update Explorer API docs with new field current_rum_count

### DIFF
--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -9,6 +9,11 @@ description: >-
 
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
+<!-- BEGIN: TFC:only name:explorer -->
+## 2025-01-30
+* Add new field `billable_rum_count` to [Explorer](/terraform/cloud-docs/api-docs/explorer) View Type: `workspaces`
+<!-- END: TFC:only name:explorer -->
+
 ## 2024-11-19
 * Clarifies listing tag-bindings and effective-tag-bindings on [Workspaces](/terraform/cloud-docs/api-docs/workspaces) and [Projects](/terraform/cloud-docs/api-docs/projects)
 * Adds new documentation for PATCHing tag bindings on [Projects](/terraform/cloud-docs/api-docs/projects)/[Workspaces](/terraform/cloud-docs/api-docs/workspaces)

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -11,7 +11,7 @@ Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
 <!-- BEGIN: TFC:only name:explorer -->
 ## 2025-01-30
-* Add new field `current_rum_count` to the [explorer](/terraform/cloud-docs/api-docs/explorer) in the `workspaces` view type. 
+* Add new field `current_rum_count` to the [explorer API](/terraform/cloud-docs/api-docs/explorer) in the `workspaces` view type that lists a workspace's current resources under management. 
 <!-- END: TFC:only name:explorer -->
 
 ## 2024-11-19

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -11,7 +11,7 @@ Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
 <!-- BEGIN: TFC:only name:explorer -->
 ## 2025-01-30
-* Add new field `billable_rum_count` to [Explorer](/terraform/cloud-docs/api-docs/explorer) View Type: `workspaces`
+* Add new field `billable_rum_count` to the [explorer](/terraform/cloud-docs/api-docs/explorer) in the `workspaces` view type. 
 <!-- END: TFC:only name:explorer -->
 
 ## 2024-11-19

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -11,7 +11,7 @@ Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
 <!-- BEGIN: TFC:only name:explorer -->
 ## 2025-01-30
-* Add new field `billable_rum_count` to the [explorer](/terraform/cloud-docs/api-docs/explorer) in the `workspaces` view type. 
+* Add new field `current_rum_count` to the [explorer](/terraform/cloud-docs/api-docs/explorer) in the `workspaces` view type. 
 <!-- END: TFC:only name:explorer -->
 
 ## 2024-11-19

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -10,7 +10,7 @@ description: >-
 Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 
 <!-- BEGIN: TFC:only name:explorer -->
-## 2025-01-30
+## 2025-03-10
 * Add new field `current_rum_count` to the [explorer API](/terraform/cloud-docs/api-docs/explorer) in the `workspaces` view type that lists a workspace's current resources under management. 
 <!-- END: TFC:only name:explorer -->
 

--- a/website/docs/cloud-docs/api-docs/explorer.mdx
+++ b/website/docs/cloud-docs/api-docs/explorer.mdx
@@ -103,7 +103,7 @@ fields available for each view type are detailed below:
 | Field                             | Type       | Description |
 | --------------------------------- | ---------- | ----------------------------------------------------------------------------- |
 | `all_checks_succeeded`            | `boolean`  | True if checks have succeeded for the workspace, false otherwise. |
-| `billable_rum_count`              | `number`   | The number of Resources Under Management (RUM). |
+| `billable_rum_count`              | `number`   | The number of [resources under management](terraform/cloud-docs/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
 | `checks_errored`                  | `number`   | The number of checks that errored without completing. |
 | `checks_failed`                   | `number`   | The number of checks that completed and failed. |
 | `checks_passed`                   | `number`   | The number of checks that completed and passed. |

--- a/website/docs/cloud-docs/api-docs/explorer.mdx
+++ b/website/docs/cloud-docs/api-docs/explorer.mdx
@@ -103,7 +103,7 @@ fields available for each view type are detailed below:
 | Field                             | Type       | Description |
 | --------------------------------- | ---------- | ----------------------------------------------------------------------------- |
 | `all_checks_succeeded`            | `boolean`  | True if checks have succeeded for the workspace, false otherwise. |
-| `billable_rum_count`              | `number`   | The number of "Resources Under Management (RUM)". |
+| `billable_rum_count`              | `number`   | The number of Resources Under Management (RUM). |
 | `checks_errored`                  | `number`   | The number of checks that errored without completing. |
 | `checks_failed`                   | `number`   | The number of checks that completed and failed. |
 | `checks_passed`                   | `number`   | The number of checks that completed and passed. |

--- a/website/docs/cloud-docs/api-docs/explorer.mdx
+++ b/website/docs/cloud-docs/api-docs/explorer.mdx
@@ -103,7 +103,7 @@ fields available for each view type are detailed below:
 | Field                             | Type       | Description |
 | --------------------------------- | ---------- | ----------------------------------------------------------------------------- |
 | `all_checks_succeeded`            | `boolean`  | True if checks have succeeded for the workspace, false otherwise. |
-| `billable_rum_count`              | `number`   | The number of [resources under management](terraform/cloud-docs/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
+| `billable_rum_count`              | `number`   | The number of [resources under management](/terraform/cloud-docs/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
 | `checks_errored`                  | `number`   | The number of checks that errored without completing. |
 | `checks_failed`                   | `number`   | The number of checks that completed and failed. |
 | `checks_passed`                   | `number`   | The number of checks that completed and passed. |

--- a/website/docs/cloud-docs/api-docs/explorer.mdx
+++ b/website/docs/cloud-docs/api-docs/explorer.mdx
@@ -103,7 +103,7 @@ fields available for each view type are detailed below:
 | Field                             | Type       | Description |
 | --------------------------------- | ---------- | ----------------------------------------------------------------------------- |
 | `all_checks_succeeded`            | `boolean`  | True if checks have succeeded for the workspace, false otherwise. |
-| `billable_rum_count`              | `number`   | The number of [resources under management](/terraform/cloud-docs/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
+| `current_rum_count`               | `number`   | The number of [resources under management](/terraform/cloud-docs/overview/estimate-hcp-terraform-cost#what-is-a-managed-resource) (RUM). |
 | `checks_errored`                  | `number`   | The number of checks that errored without completing. |
 | `checks_failed`                   | `number`   | The number of checks that completed and failed. |
 | `checks_passed`                   | `number`   | The number of checks that completed and passed. |
@@ -329,7 +329,7 @@ _Show data for all workspaces_
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "billable_rum_count": 0,
+        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
@@ -361,7 +361,7 @@ _Show data for all workspaces_
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "billable_rum_count": 0,
+        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
@@ -457,7 +457,7 @@ curl \
 _Show data for all workspaces_
 
 ```csv
-all_checks_succeeded,billable_rum_count,checks_errored,checks_failed,checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,current_run_status,drifted,external_id,module_count,modules,organization_name,project_external_id,project_name,provider_count,providers,resources_drifted,resources_undrifted,state_version_terraform_version,vcs_repo_identifier,workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at
+all_checks_succeeded,current_rum_count,checks_errored,checks_failed,checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,current_run_status,drifted,external_id,module_count,modules,organization_name,project_external_id,project_name,provider_count,providers,resources_drifted,resources_undrifted,state_version_terraform_version,vcs_repo_identifier,workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at
 "true","0","0","0","0","0","","run-rdoEKh2Gy3K6SbCZ","planned_and_finished","false","ws-j2sAeWRxou1b5HYf","0","","acme-corp","prj-V61QLE8tvs4NvVZG","Default Project","0","","0","0","1.5.7","","2023-10-17T21:56:45+00:00","payments-service","1.5.7","2023-12-13T15:48:16+00:00"
 "true","0","0","0","0","0","2023-08-18T16:24:59+00:00","run-9MmJaoQTvDCh5wUa","applied","true","ws-igUVNQSYVXRkhYuo","0","","acme-corp","prj-uU2xNqGeG86U9WgT","web","0","","3","3","1.4.5","acmecorp/api","2023-04-25T17:09:14+00:00","api-service","1.4.5","2023-12-13T15:29:03+00:00"
 ```
@@ -765,7 +765,7 @@ curl \
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "billable_rum_count": 0,
+        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
@@ -797,7 +797,7 @@ curl \
     {
       "attributes": {
         "all-checks-succeeded": true,
-        "billable_rum_count": 0,
+        "current_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,

--- a/website/docs/cloud-docs/api-docs/explorer.mdx
+++ b/website/docs/cloud-docs/api-docs/explorer.mdx
@@ -103,6 +103,7 @@ fields available for each view type are detailed below:
 | Field                             | Type       | Description |
 | --------------------------------- | ---------- | ----------------------------------------------------------------------------- |
 | `all_checks_succeeded`            | `boolean`  | True if checks have succeeded for the workspace, false otherwise. |
+| `billable_rum_count`              | `number`   | The number of "Resources Under Management (RUM)". |
 | `checks_errored`                  | `number`   | The number of checks that errored without completing. |
 | `checks_failed`                   | `number`   | The number of checks that completed and failed. |
 | `checks_passed`                   | `number`   | The number of checks that completed and passed. |
@@ -328,6 +329,7 @@ _Show data for all workspaces_
     {
       "attributes": {
         "all-checks-succeeded": true,
+        "billable_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
@@ -359,6 +361,7 @@ _Show data for all workspaces_
     {
       "attributes": {
         "all-checks-succeeded": true,
+        "billable_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
@@ -454,9 +457,9 @@ curl \
 _Show data for all workspaces_
 
 ```csv
-all_checks_succeeded,checks_errored,checks_failed,checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,current_run_status,drifted,external_id,module_count,modules,organization_name,project_external_id,project_name,provider_count,providers,resources_drifted,resources_undrifted,state_version_terraform_version,vcs_repo_identifier,workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at
-"true","0","0","0","0","","run-rdoEKh2Gy3K6SbCZ","planned_and_finished","false","ws-j2sAeWRxou1b5HYf","0","","acme-corp","prj-V61QLE8tvs4NvVZG","Default Project","0","","0","0","1.5.7","","2023-10-17T21:56:45+00:00","payments-service","1.5.7","2023-12-13T15:48:16+00:00"
-"true","0","0","0","0","2023-08-18T16:24:59+00:00","run-9MmJaoQTvDCh5wUa","applied","true","ws-igUVNQSYVXRkhYuo","0","","acme-corp","prj-uU2xNqGeG86U9WgT","web","0","","3","3","1.4.5","acmecorp/api","2023-04-25T17:09:14+00:00","api-service","1.4.5","2023-12-13T15:29:03+00:00"
+all_checks_succeeded,billable_rum_count,checks_errored,checks_failed,checks_passed,checks_unknown,current_run_applied_at,current_run_external_id,current_run_status,drifted,external_id,module_count,modules,organization_name,project_external_id,project_name,provider_count,providers,resources_drifted,resources_undrifted,state_version_terraform_version,vcs_repo_identifier,workspace_created_at,workspace_name,workspace_terraform_version,workspace_updated_at
+"true","0","0","0","0","0","","run-rdoEKh2Gy3K6SbCZ","planned_and_finished","false","ws-j2sAeWRxou1b5HYf","0","","acme-corp","prj-V61QLE8tvs4NvVZG","Default Project","0","","0","0","1.5.7","","2023-10-17T21:56:45+00:00","payments-service","1.5.7","2023-12-13T15:48:16+00:00"
+"true","0","0","0","0","0","2023-08-18T16:24:59+00:00","run-9MmJaoQTvDCh5wUa","applied","true","ws-igUVNQSYVXRkhYuo","0","","acme-corp","prj-uU2xNqGeG86U9WgT","web","0","","3","3","1.4.5","acmecorp/api","2023-04-25T17:09:14+00:00","api-service","1.4.5","2023-12-13T15:29:03+00:00"
 ```
 
 ## List saved views
@@ -762,6 +765,7 @@ curl \
     {
       "attributes": {
         "all-checks-succeeded": true,
+        "billable_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,
@@ -793,6 +797,7 @@ curl \
     {
       "attributes": {
         "all-checks-succeeded": true,
+        "billable_rum_count": 0,
         "checks-errored": 0,
         "checks-failed": 0,
         "checks-passed": 0,


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
A new field has been added to Workspace Explorer in HCP Terraform

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
This change helps customers see the new field and field type to help when querying data from Explorer.  Sample response has also been updated with this new field

Related [Jira](https://hashicorp.atlassian.net/browse/TF-10032)
Related [Atlas PR ](https://github.com/hashicorp/atlas/pull/22116)

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages. (N/A)
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.). (N/A)
- [x] Pages with related content are updated and link to this content when appropriate. (N/A)
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A)
- [x] New pages have metadata (page name and description) at the top. (N/A)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. (N/A)
- [x] UI elements (button names, page names, etc.) are bolded. (N/A)
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
