### PR TITLE
Adding an overview page for all Terraform integrations.

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -623,6 +623,10 @@
     "title": "Integrations",
     "routes": [
       {
+        "title": "Overview", 
+        "path": "integrations"
+      },
+      {
         "title": "Kubernetes Operator",
         "routes": [
           {

--- a/website/docs/cloud-docs/integrations/index.mdx
+++ b/website/docs/cloud-docs/integrations/index.mdx
@@ -1,0 +1,24 @@
+---
+page_title: Integrations - HCP Terraform
+description: >-
+  This overview page lists HCP Terraform integrations with various third-party platforms and systems. 
+---
+
+# Overview
+
+The HCP Terraform ecosystem features a variety of integrations – applications
+designed to extend Terraform’s capabilities across various third-party systems
+and platforms. As demand grows for managing complex infrastructure across
+multiple clouds, data centers, and third-party services, our integrations are
+expanding.
+
+This section lists the current HCP Terraform integrations, which are API-based
+and leverage HCP Terraform's robust set of APIs. Each integration has its own
+dedicated page where you can find more details:
+
+1. [HCP Terraform Operator for Kubernetes](/terraform/cloud-docs/integrations/kubernetes)
+1. [ServiceNow Service Catalog for Terraform](/terraform/cloud-docs/integrations/service-now/service-catalog-terraform)
+1. [ServiceNow Service Graph Connector for Terraform](/terraform/cloud-docs/integrations/service-now/service-graph) 
+1. [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk)
+1. [Run Task integrations](/terraform/cloud-docs/integrations/run-tasks)
+1. [HCP Terraform for AWS Service Catalog](/terraform/cloud-docs/integrations/aws-service-catalog)

--- a/website/docs/cloud-docs/integrations/index.mdx
+++ b/website/docs/cloud-docs/integrations/index.mdx
@@ -1,7 +1,7 @@
 ---
-page_title: Integrations - HCP Terraform
+page_title: Integrations overview for HCP Terraform
 description: >-
-  This overview page lists HCP Terraform integrations with various third-party platforms and systems. 
+ Use HCP Terraform integrations to connect HCP Terraform with third-party platforms and systems. 
 ---
 
 # Overview
@@ -16,9 +16,10 @@ This section lists the current HCP Terraform integrations, which are API-based
 and leverage HCP Terraform's robust set of APIs. Each integration has its own
 dedicated page where you can find more details:
 
-1. [HCP Terraform Operator for Kubernetes](/terraform/cloud-docs/integrations/kubernetes)
-1. [ServiceNow Service Catalog for Terraform](/terraform/cloud-docs/integrations/service-now/service-catalog-terraform)
-1. [ServiceNow Service Graph Connector for Terraform](/terraform/cloud-docs/integrations/service-now/service-graph) 
-1. [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk)
-1. [Run Task integrations](/terraform/cloud-docs/integrations/run-tasks)
-1. [HCP Terraform for AWS Service Catalog](/terraform/cloud-docs/integrations/aws-service-catalog)
+- The [HCP Terraform Operator for Kubernetes](/terraform/cloud-docs/integrations/kubernetes) integration can manage HCP Terraform resources with Kubernetes custom resources.
+- The [Terraform ServiceNow Catalog integration](/terraform/cloud-docs/integrations/service-now/service-catalog-terraform) lets you provision self-serve infrastructure using ServiceNow.
+- The [ServiceNow Service Graph Connector for Terraform](/terraform/cloud-docs/integrations/service-now/service-graph) integration lets you securely import HCP Terraform resources into your ServiceNow instance.
+- The [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) integration lets you pull HCP Terraform logs into Splunk.
+- The [HCP Terraform for AWS Service Catalog](/terraform/cloud-docs/integrations/aws-service-catalog) integration lets you create pre-approved Terraform configurations on the AWS Service Catalog.
+
+If the platform you want to integrate HCP Terraform with does not have an official integration, you can build a custom run task to integrate with a tool of your choice. Run tasks can access plan details, display custom messages in the run pipeline, and prevent runs from applying. Learn more about [Run tasks](/terraform/cloud-docs/integrations/run-tasks).

--- a/website/docs/cloud-docs/integrations/index.mdx
+++ b/website/docs/cloud-docs/integrations/index.mdx
@@ -6,20 +6,19 @@ description: >-
 
 # Overview
 
-The HCP Terraform ecosystem features a variety of integrations – applications
-designed to extend Terraform’s capabilities across various third-party systems
-and platforms. As demand grows for managing complex infrastructure across
-multiple clouds, data centers, and third-party services, our integrations are
-expanding.
-
-This section lists the current HCP Terraform integrations, which are API-based
-and leverage HCP Terraform's robust set of APIs. Each integration has its own
-dedicated page where you can find more details:
+The HCP Terraform ecosystem features a variety of integrations to let HCP
+Terraform connect with third-party systems and platforms. The following list
+contains HashiCorp's official HCP Terraform integrations, which use HCP
+Terraform's native APIs:
 
 - The [HCP Terraform Operator for Kubernetes](/terraform/cloud-docs/integrations/kubernetes) integration can manage HCP Terraform resources with Kubernetes custom resources.
-- The [Terraform ServiceNow Catalog integration](/terraform/cloud-docs/integrations/service-now/service-catalog-terraform) lets you provision self-serve infrastructure using ServiceNow.
+- The [ServiceNow Service Catalog for Terraform](/terraform/cloud-docs/integrations/service-now/service-catalog-terraform) lets you provision self-serve infrastructure using ServiceNow.
 - The [ServiceNow Service Graph Connector for Terraform](/terraform/cloud-docs/integrations/service-now/service-graph) integration lets you securely import HCP Terraform resources into your ServiceNow instance.
 - The [HCP Terraform for Splunk](/terraform/cloud-docs/integrations/splunk) integration lets you pull HCP Terraform logs into Splunk.
 - The [HCP Terraform for AWS Service Catalog](/terraform/cloud-docs/integrations/aws-service-catalog) integration lets you create pre-approved Terraform configurations on the AWS Service Catalog.
 
-If the platform you want to integrate HCP Terraform with does not have an official integration, you can build a custom run task to integrate with a tool of your choice. Run tasks can access plan details, display custom messages in the run pipeline, and prevent runs from applying. Learn more about [Run tasks](/terraform/cloud-docs/integrations/run-tasks).
+If the platform you want to integrate HCP Terraform with does not have an
+official integration, you can build a custom run task to integrate with a tool
+of your choice. Run tasks can access plan details, display custom messages in
+the run pipeline, and prevent runs from applying. Learn more about [Run
+tasks](/terraform/cloud-docs/integrations/run-tasks).


### PR DESCRIPTION
### What
Our Terraform integrations are listed under the "Integrations" dropdown, with each having its own separate documentation page. Adding a single "overview" page listing all of them. This way, we could share a single link with anyone interested in all of our apps. This need has come up multiple times.

This page will be very helpful for the upcoming HashiTalks and the ServiceNow Webinar (Feb 21 and 27)

### Why
A single link can be shared with stakeholders and the audience during public marketing events.

### Screenshots
N/A
----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [N/A] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [N/A] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [N/A] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [N/A] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [N/A] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
