### PR TITLE
add version redir backend ref

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -219,9 +219,6 @@ module.exports = [
     permanent: true,
   },
   {
-    source: "/terraform/language/settings/backends/configuration"
-  },
-  {
     source: "/terraform/cli/cloud/migrating",
     destination: "/terraform/cli/cloud/settings",
     permanent: true,

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -209,9 +209,17 @@ module.exports = [
     permanent: true,
   },
   {
+    source: "/terraform/language/:version(v1\.(?:7|8|9|10|11|12|13)\.x)/settings/backends/configuration",
+    destination: "/terraform/language/backend",
+    permanent: true,
+  },
+  {
     source: "/terraform/language/settings/backends/:slug*",
     destination: "/terraform/language/backend/:slug*",
     permanent: true,
+  },
+  {
+    source: "/terraform/language/settings/backends/configuration"
   },
   {
     source: "/terraform/cli/cloud/migrating",


### PR DESCRIPTION
This PR adds a redirect rule so that switching from a previous version of the backend block reference content routes to the correct page when switching to the latest version. 