### PR TITLE
Updated all mentions of Enhanced to Agent in codebase

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets/index.mdx
@@ -32,7 +32,7 @@ Only Sentinel policies can run as policy checks. Checks can access cost estimati
 
 ### Policy evaluations
 
-OPA policy sets can only run as policy evaluations, and you can enable policy evaluations for Sentinel policy sets by selecting the `Enhanced` policy set type. Policy evaluations run within the [HCP Terraform agent](/terraform/cloud-docs/agents) in HCP Terraform's infrastructure.
+OPA policy sets can only run as policy evaluations, and you can enable policy evaluations for Sentinel policy sets by selecting the `Agent` policy set type. Policy evaluations run within the [HCP Terraform agent](/terraform/cloud-docs/agents) in HCP Terraform's infrastructure.
 
 For Sentinel policy sets, using policy evaluations lets you:
 - Enable overrides for soft-mandatory and hard-mandatory policies, letting any user with [Manage Policy Overrides permission](/terraform/cloud-docs/users-teams-organizations/permissions#manage-policy-overrides) proceed with a run in the event of policy failure.
@@ -139,7 +139,7 @@ To create a policy set:
 1. **(Optional)** Add **Policy exclusions** for this policy set. Specify any workspaces in the policy set's scope that HCP Terraform will not enforce this policy set on.
 1. **(Sentinel Only)** Choose a policy set type:
    - **Standard:** This is the default workflow. A Sentinel policy set uses a [policy check](#policy-checks) in HCP Terraform and lets you access cost estimation data.
-   - **Enhanced:** A Sentinel policy set uses a [policy evaluation](#policy-evaluations) in HCP Terraform. This lets you enable policy overrides and enforce a Sentinel runtime version
+   - **Agent:** A Sentinel policy set uses a [policy evaluation](#policy-evaluations) in HCP Terraform. This lets you enable policy overrides and enforce a Sentinel runtime version
 1. **(OPA Only)** Select a **Runtime version** for this policy set.
 
 1. **(OPA Only)** Allow **Overrides**, which enables users with override policy permissions to apply plans that have [mandatory policy](#policy-enforcement-levels) failures.


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

Changed all mentions of the `Enhanced` policy set type, which has been superseded, to `Agent`. Changed pages:
- [Manage policies and policy sets in HCP Terraform](https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement/manage-policy-sets)

Addresses this JIRA ticket: https://hashicorp.atlassian.net/browse/TF-23884

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
The `Enhanced` naming is deprecated, and HCP Terraform now refers to it as `Agent`.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] N/A Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] N/A API documentation and the API Changelog have been updated. 
- [x] N/A Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] N/A Pages with related content are updated and link to this content when appropriate.
- [x] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A New pages have metadata (page name and description) at the top.
- [x] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] N/A New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
