### PR TITLE
removed beta badge and alerts

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -329,12 +329,7 @@
           {"title": "Overview","path": "users-teams-organizations/organizations"},
           {
             "title": "Manage reserved tag keys", 
-            "path": "users-teams-organizations/organizations/manage-reserved-tags",
-            "badge": {
-              "text": "BETA",
-              "type": "outlined",
-              "color": "neutral"
-            }
+            "path": "users-teams-organizations/organizations/manage-reserved-tags"            
           },
           { "title": "VCS Status Checks", "path": "users-teams-organizations/organizations/vcs-status-checks" },
           { "title": "Automatically cancel plan-only runs", "path": "users-teams-organizations/organizations/vcs-speculative-plan-management" }

--- a/website/docs/cloud-docs/projects/manage.mdx
+++ b/website/docs/cloud-docs/projects/manage.mdx
@@ -39,9 +39,6 @@ To view your organization's projects:
 1. Specify a name for the project. The name must be unique within the organization and can only include letters, numbers, inner spaces, hyphens, and underscores.
 1. Add a description for the project. This field is optional.
 1. Open the **Add key value tags** menu to add tags to your project. Workspaces you create within the project inherit project tags. Refer to [Define project tags](#define-project-tags) for additional information.
-   
-   ~> **Project tags are in beta**: We do not recommend using beta features in production environments.
-
 1. Click **+Add tag** and specify a tag key and tag value. If your organization has defined reserved tag keys, they appear in the **Tag key** field as suggestions. Refer to [Create and manage reserved tags](/terraform/cloud-docs/users-teams-organizations/organizations/manage-reserved-tags) for additional information.
 1. Click **+ Add tag** to attach any additional tags.
 1. Click **Create** to finish creating the project.
@@ -103,8 +100,6 @@ HCP Terraform returns to the **Projects** view with the deleted project
 removed from the list.
 
 ## Define project tags
-
-~> **Project tags are in beta**: We do not recommend using beta features in production environments.  
 
 You can define tags stored as key-value pairs to help you organize your projects and track resource consumption. Workspaces created in the project automatically inherit the tags, but workspace administrators with appropriate permissions can attach new key-value pairs to their workspaces to override inherited tags. Refer to [Create workspace tags](/terraform/cloud-docs/workspaces/tags) for additional information about using tags in workspaces.
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations/manage-reserved-tags.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations/manage-reserved-tags.mdx
@@ -7,8 +7,6 @@ description: Reserved tag keys let you organize projects and workspaces and trac
 
 This topic describes how to create and manage reserved tag keys in HCP Terraform. You can use reserved tag keys to help managers consistently label workspaces and projects in your organization.    
 
-~> **This feature is in beta**: We do not recommend using beta features in production environments.
-
 ## Introduction
 
 You can define reserved tag keys that appear as suggested labels when managers want to add tags to their projects and workspaces in the organization. Doing so helps you standardize tag keys and prevent duplicates that affect your ability to track resources. 

--- a/website/docs/cloud-docs/workspaces/tags.mdx
+++ b/website/docs/cloud-docs/workspaces/tags.mdx
@@ -20,8 +20,6 @@ HCP Terraform stores tags as key-value pairs or as key-only tags. Key-only tags 
 
 You can reserve a set of tag keys for each organization. Reserved tag keys appear as suggestions when people create tags for projects and workspaces so that you can use consistent terms for tags. Refer to [Create and manage reserved tags](/terraform/cloud-docs/users-teams-organizations/organizations/manage-reserved-tags) for additional information.
 
-~> **Reserved tags are in beta**: We do not recommend using beta features in production environments.
-
 ### Single-value tags
 
 Your system may contain single-value tags created using Terraform v1.10 and older. You can migrate existing single-value tags to the key-value scheme. Refer to [Migrate single-value tags](#migrate-single-value-tags) for instructions.


### PR DESCRIPTION
This PR removes the beta badge in the nav and alerts in the content for key-value tags on projects and workspaces for GA.