### PR TITLE
Add write-only argument names best practices section

### DIFF
--- a/website/docs/plugin/best-practices/naming.mdx
+++ b/website/docs/plugin/best-practices/naming.mdx
@@ -97,3 +97,9 @@ in the above example. The patterns described above can also apply to such
 sub-blocks. Sub-blocks are usually introduced by a singular noun, even if
 multiple instances of the same-named block are accepted, since each distinct
 instance represents a single object.
+
+### Write-only Argument Names
+
+In addition to the regular guidance on attribute naming conventions, write-only arguments names
+should use a `_wo` suffix, such as `password_wo` to differentiate them from non-write-only arguments,
+such as `password`.


### PR DESCRIPTION
### What
Add a section to the provider naming best practices page for write-only arguments.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
Documents the recommended `_wo` suffix naming convention for write-only arguments

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
