### PR TITLE
Fix exclusion tags for change requests and manage module versions

### DIFF
--- a/website/docs/cloud-docs/api-docs/change-requests.mdx
+++ b/website/docs/cloud-docs/api-docs/change-requests.mdx
@@ -2,7 +2,7 @@
 page_title: /change_requests API reference for HCP Terraform
 description: >-
   Use the `/change_requests` endpoint to view and archive change requests on given workspace.
-terraform_cloud_only: true
+tfc_only: true
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/api-docs/private-registry/manage-module-versions.mdx
+++ b/website/docs/cloud-docs/api-docs/private-registry/manage-module-versions.mdx
@@ -2,7 +2,6 @@
 page_title: Manage module versions API reference for HCP Terraform
 description: |-
  Use the module management endpoints to deprecate and revert the deprecation of module versions you published to an organization's private registry. 
-tfc_only: true
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200

--- a/website/docs/cloud-docs/registry/manage-module-versions.mdx
+++ b/website/docs/cloud-docs/registry/manage-module-versions.mdx
@@ -1,8 +1,7 @@
 ---
 page_title: Deprecate module versions in HCP Terraform
 description: >-
-  Learn how to deprecate a module version and revert a module version’s deprecation. Deprecating a module version allows you to warn users of that version’s end of life, enabling consumers to upgrade their modules when it’s convenient and without disrupting their workflows. 
-tfc_only: true
+  Learn how to deprecate a module version and revert a module version’s deprecation. Deprecating a module version allows you to warn users of that version’s end of life, enabling consumers to upgrade their modules when it’s convenient and without disrupting their workflows.
 ---
 
 # Deprecate module versions

--- a/website/docs/cloud-docs/workspaces/change-requests/manage.mdx
+++ b/website/docs/cloud-docs/workspaces/change-requests/manage.mdx
@@ -1,7 +1,7 @@
 ---
 page_title: Manage change requests
 description: Learn how to create, view, and archive change requests to manage a backlog of actionable todos on workspaces.
-terraform_cloud_only: true  
+tfc_only: true  
 ---
 
 # Manage change requests


### PR DESCRIPTION
### What
Clean up from last TFE release -> accidentally got the exclusion tag name wrong, and removing `tfc_only` from the deprecate module docs because they are both in TFE as of last release.