### PR TITLE
Move migration docs higher in nav

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -30,6 +30,41 @@
     "href": "https://learn.hashicorp.com/collections/terraform/cloud-get-started?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS"
   },
   {
+    "title": "Migrate to HCP Terraform",
+    "routes": [
+      {
+        "title": "Overview",
+        "path": "migrate"
+      },
+      {
+        "title": "The tf-migrate CLI",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "migrate/tf-migrate"
+          },
+          {
+            "title": "CLI Reference",
+            "routes": [
+              {
+                "title": "tf-migrate prepare",
+                "path": "migrate/tf-migrate/reference/prepare"
+              },
+              {
+                "title": "tf-migrate execute",
+                "path": "migrate/tf-migrate/reference/execute"
+              },
+              {
+                "title": "Configuration file reference",
+                "path": "migrate/tf-migrate/reference/configuration"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     "title": "API",
     "routes": [
       {
@@ -475,41 +510,6 @@
       {
         "title": "Provisioning No-Code Infrastructure",
         "path": "no-code-provisioning/provisioning"
-      }
-    ]
-  },
-  {
-    "title": "Migrate to HCP Terraform",
-    "routes": [
-      {
-        "title": "Overview",
-        "path": "migrate"
-      },
-      {
-        "title": "The tf-migrate CLI",
-        "routes": [
-          {
-            "title": "Overview",
-            "path": "migrate/tf-migrate"
-          },
-          {
-            "title": "CLI Reference",
-            "routes": [
-              {
-                "title": "tf-migrate prepare",
-                "path": "migrate/tf-migrate/reference/prepare"
-              },
-              {
-                "title": "tf-migrate execute",
-                "path": "migrate/tf-migrate/reference/execute"
-              },
-              {
-                "title": "Configuration file reference",
-                "path": "migrate/tf-migrate/reference/configuration"
-              }
-            ]
-          }
-        ]
       }
     ]
   },


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

Move migration docs higher in the cloud doc nav to raise visibility. 

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

The current migration docs are hidden near the bottom of the nav.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
