### PR TITLE
Add note to Microsoft Entra ID to troubleshoot SAML group limit

### DIFF
--- a/website/docs/cloud-docs/users-teams-organizations/single-sign-on/entra-id.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/single-sign-on/entra-id.mdx
@@ -98,4 +98,7 @@ If you plan to use SAML to set usernames in your Microsoft Entra ID application:
 If you namespaced any of your claims, then Microsoft Entra ID passes the attribute name using the format `<claim_namespace/claim_name>`. Consider this format when setting team and username attribute names.
 
 ## Troubleshooting the SAML assertion
+
 [Use this guide](https://support.hashicorp.com/hc/en-us/articles/1500005371682-Capturing-a-SAML-Assertion) to verify and validate the claims being sent in the SAML response. 
+
+Azure AD limits the number of group claims to 150 groups for SAML tokens and 200 groups for JWT tokens. If you exceed this limit, we recommend that you create a group filter to only include the necessary groups. Refer to [Configure group claims for applications by using Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims#group-filtering) for more information.


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

Add a note on how to troubleshoot the SAML group limit for Microsoft Entra ID

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

Users that use Microsoft Entra ID will encounter an issue if they have more than 150 groups due to limitations from Azure AD. If they encounter this issue, users can create a group filter to reduce the total number of groups.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
