### PR TITLE
Fix broken agent links in documentation

### DIFF
--- a/website/docs/cloud-docs/api-docs/agents.mdx
+++ b/website/docs/cloud-docs/api-docs/agents.mdx
@@ -71,7 +71,7 @@ This endpoint supports pagination [with standard URL query parameters](/terrafor
 | `sort`                             | **Optional.** Allows sorting the returned agents pools. Valid values are `"name"` and `"created-at"`. Prepending a hyphen to the sort parameter will reverse the order (e.g. `"-name"`).                                                                                                                                    |
 | `page[number]`                     | **Optional.** If omitted, the endpoint will return the first page.                                                                                                                                                                                                                                                          |
 | `page[size]`                       | **Optional.** If omitted, the endpoint will return 20 agent pools per page.                                                                                                                                                                                                                                                 |
-| `filter[allowed_workspaces][name]` | **Optional.** Filters agent pools to those associated with the given workspace. The workspace must have permission to use the agent pool. Refer to [Scoping Agent Pools to Specific Workspaces](/terraform/cloud-docs/agents#scope-an-agent-pool-to-specific-workspaces). |                                                                             |
+| `filter[allowed_workspaces][name]` | **Optional.** Filters agent pools to those associated with the given workspace. The workspace must have permission to use the agent pool. Refer to [Scoping Agent Pools to Specific Workspaces](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx#scope-an-agent-pool-to-specific-workspaces/index.mdx). |                                                                             |
 
 ### Sample Request
 
@@ -363,7 +363,7 @@ curl \
 }
 ```
 
-This endpoint lists details about an agent along with that agent's status. [Learn more about agents statuses](/terraform/cloud-docs/agents/agent-pools#view-agent-statuses).
+This endpoint lists details about an agent along with that agent's status. [Learn more about agents statuses](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/agent-pools.mdx#view-agent-statuses).
 
 ## Delete an Agent
 
@@ -416,7 +416,7 @@ Properties without a default value are required.
 | `data.attributes.name`                            | string |         | The name of the agent pool, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.                                                                                    |
 | `data.attributes.organization-scoped`             | bool   | true    | The scope of the agent pool. If true, all workspaces in the organization can use the agent pool.                                                                                          |
 | `data.relationships.allowed-workspaces.data.type` | string |         | Must be `"workspaces"`.                                                                                                                                                                    |
-| `data.relationships.allowed-workspaces.data.id`   | string |         | The ID of the workspace that has permission to use the agent pool. Refer to [Scoping Agent Pools to Specific Workspaces](/terraform/cloud-docs/agents#scope-an-agent-pool-to-specific-workspaces).  |
+| `data.relationships.allowed-workspaces.data.id`   | string |         | The ID of the workspace that has permission to use the agent pool. Refer to [Scoping Agent Pools to Specific Workspaces](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx#scope-an-agent-pool-to-specific-workspaces/index.mdx).  |
 
 ### Sample Payload
 
@@ -522,7 +522,7 @@ Properties without a default value are required.
 | `data.attributes.name`                            | string | (previous value) | The name of the agent pool, which can only include letters, numbers, `-`, and `_`. This will be used as an identifier and must be unique in the organization.                                                                                    |
 | `data.attributes.organization-scoped`             | bool   | true             | The scope of the agent pool. If true, all workspaces in the organization can use the agent pool.                                                                                          |
 | `data.relationships.allowed-workspaces.data.type` | string |                  | Must be `"workspaces"`.                                                                                                                                                                   |
-| `data.relationships.allowed-workspaces.data.id`   | string |                  | The ID of the workspace that has permission to use the agent pool. Refer to [Scoping Agent Pools to Specific Workspaces](/terraform/cloud-docs/agents#scope-an-agent-pool-to-specific-workspaces). |
+| `data.relationships.allowed-workspaces.data.id`   | string |                  | The ID of the workspace that has permission to use the agent pool. Refer to [Scoping Agent Pools to Specific Workspaces](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx#scope-an-agent-pool-to-specific-workspaces/index.mdx). |
 
 ### Sample Payload
 

--- a/website/docs/cloud-docs/api-docs/changelog.mdx
+++ b/website/docs/cloud-docs/api-docs/changelog.mdx
@@ -13,7 +13,7 @@ Keep track of changes to the API for HCP Terraform and Terraform Enterprise.
 * Document unique pagination metadata given in the response of [Organization Runs Index API](/terraform/cloud-docs/api-docs/run##list-runs-in-an-organization).
 
 ## 2025-03-10
-* Add new field `current_rum_count` to the [explorer API](/terraform/cloud-docs/api-docs/explorer) in the `workspaces` view type that lists a workspace's current resources under management. 
+* Add new field `current_rum_count` to the [explorer API](/terraform/cloud-docs/api-docs/explorer) in the `workspaces` view type that lists a workspace's current resources under management.
 
 ## 2024-11-19
 
@@ -319,7 +319,7 @@ This endpoint is exclusive to Terraform Enterprise, and not available in HCP Ter
 
 ### 2022-06-21
 * Updated [Admin Organizations](/terraform/enterprise/api-docs/admin/organizations) endpoints with new `workspace-limit` setting. This is available in Terraform Enterprise v202207-1 and later.
-* Updated [List Agent Pools](/terraform/cloud-docs/api-docs/agents#list-agent-pools) to accept a filter parameter `filter[allowed_workspaces][name]` so that agent pools can be filtered by name of an associated workspace. The given workspace must be allowed to use the agent pool. Refer to [Scoping Agent Pools to Specific Workspaces](/terraform/cloud-docs/agents#scope-an-agent-pool-to-specific-workspaces).
+* Updated [List Agent Pools](/terraform/cloud-docs/api-docs/agents#list-agent-pools) to accept a filter parameter `filter[allowed_workspaces][name]` so that agent pools can be filtered by name of an associated workspace. The given workspace must be allowed to use the agent pool. Refer to [Scoping Agent Pools to Specific Workspaces](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx#scope-an-agent-pool-to-specific-workspaces/index.mdx).
 * Added new `organization-scoped` attribute and `allowed-workspaces` relationship to the request/response body of the below endpoints. This is available in Terraform Enterprise v202207-1 and later.
   * [Show an Agent Pool](/terraform/cloud-docs/api-docs/agents#show-an-agent-pool)
   * [Create an Agent Pool](/terraform/cloud-docs/api-docs/agents#create-an-agent-pool)

--- a/website/docs/cloud-docs/architectural-details/security-model.mdx
+++ b/website/docs/cloud-docs/architectural-details/security-model.mdx
@@ -1,5 +1,5 @@
 ---
-page_title: HCP Terraform security model 
+page_title: HCP Terraform security model
 description: >-
  Learn about HCP Terraform's security and authorization model to identify potential security threats and follow our recommendations for using HCP Terraform securely.
 tfc_only: true
@@ -157,7 +157,7 @@ Workspaces may be configured to share their state with other workspaces within t
 
 ### Use separate agent pools for sensitive workspaces
 
-You can share [HCP Terraform Agents](/terraform/cloud-docs/agents) across all workspaces within an organization or [scope them to specific workspaces](/terraform/cloud-docs/agents#scope-an-agent-pool-to-specific-workspaces). If multiple workspaces share agent pools, a malicious actor in one of those workspaces could exfiltrate the agent’s API token, access private resources from the perspective of the agent, or modify the agent’s environment, potentially impacting other workspaces. For this reason, we recommend creating separate agent pools for sensitive workspaces and using the agent scoping setting to restrict which workspaces can target each agent pool.
+You can share [HCP Terraform Agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx) across all workspaces within an organization or [scope them to specific workspaces](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx#scope-an-agent-pool-to-specific-workspaces/index.mdx). If multiple workspaces share agent pools, a malicious actor in one of those workspaces could exfiltrate the agent’s API token, access private resources from the perspective of the agent, or modify the agent’s environment, potentially impacting other workspaces. For this reason, we recommend creating separate agent pools for sensitive workspaces and using the agent scoping setting to restrict which workspaces can target each agent pool.
 
 ### Treat Archivist URLs as secrets
 
@@ -167,4 +167,4 @@ HCP Terraform uses a blob storage service called Archivist for storing various p
 
 Storing static credentials in HCP Terraform increases the inherent risk of a malicious user or a compromised plan or apply operation exposing your credentials. Because static credentials are usually long-lived and exposed in many locations, they are troublesome to revoke and replace.
 
-Using [dynamic provider credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/) eliminates the need to store static credentials in HCP Terraform, reducing the risk of exposure. Dynamic provider credentials generate new temporary credentials for each operation and expire after that operation completes. 
+Using [dynamic provider credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/) eliminates the need to store static credentials in HCP Terraform, reducing the risk of exposure. Dynamic provider credentials generate new temporary credentials for each operation and expire after that operation completes.

--- a/website/docs/cloud-docs/integrations/kubernetes/api-reference.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/api-reference.mdx
@@ -75,9 +75,9 @@ _Appears in:_
 AgentPool manages HCP Terraform Agent Pools, HCP Terraform Agent Tokens and can perform HCP Terraform Agent scaling.
 
 More information:
-  - [Manage agent pools](/terraform/cloud-docs/agents/agent-pools)
+  - [Manage agent pools](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/agent-pools.mdx)
   - [Agent API tokens](/terraform/cloud-docs/users-teams-organizations/api-tokens#agent-api-tokens)
-  - [HCP Terraform agents](/terraform/cloud-docs/agents)
+  - [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx)
 
 | Field | Description |
 | --- | --- |
@@ -97,7 +97,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Agent Pool name. [More information](/terraform/cloud-docs/agents/agent-pools).|
+| `name` _string_ | Agent Pool name. [More information](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/agent-pools.mdx).|
 | `organization` _string_ | Organization name where the Workspace will be created. [More information](/terraform/cloud-docs/users-teams-organizations/organizations).|
 | `token` _[Token](#token)_ | API Token to be used for API calls. |
 | `agentTokens` _[AgentToken](#agenttoken) array_ | List of the agent tokens to generate. |
@@ -109,7 +109,7 @@ _Appears in:_
 Agent Token is a secret token that a HCP Terraform Agent is used to connect to the HCP Terraform Agent Pool. In `spec` only the field `Name` is allowed, the rest are used in `status`.
 
 More information:
-  - [HCP Terraform agents](/terraform/cloud-docs/agents)
+  - [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx)
 
 _Appears in:_
 - [AgentPoolSpec](#agentpoolspec)
@@ -634,7 +634,7 @@ Only one of the fields `ID` or `Name` is allowed.
 At least one of the fields `ID` or `Name` is mandatory.
 
 More information:
-  - [HCP Terraform agents](/terraform/cloud-docs/agents)
+  - [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx)
 
 _Appears in:_
 - [WorkspaceSpec](#workspacespec)
@@ -699,7 +699,7 @@ _Appears in:_
 | `applyMethod` _string_ | Define either change will be applied automatically(auto) or require an operator to confirm(manual). Must be one of the following values: `auto`, `manual`. Default: `manual`. [More information](/terraform/cloud-docs/workspaces/settings#auto-apply-and-manual-apply).|
 | `allowDestroyPlan` _boolean_ | Allows a destroy plan to be created and applied. Default: `true`. [More information](/terraform/cloud-docs/workspaces/settings#destruction-and-deletion).|
 | `description` _string_ | Workspace description. |
-| `agentPool` _[WorkspaceAgentPool](#workspaceagentpool)_ | HCP Terraform Agents allow HCP Terraform to communicate with isolated, private, or on-premises infrastructure. [More information](/terraform/cloud-docs/agents).|
+| `agentPool` _[WorkspaceAgentPool](#workspaceagentpool)_ | HCP Terraform Agents allow HCP Terraform to communicate with isolated, private, or on-premises infrastructure. [More information](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx).|
 | `executionMode` _string_ | Define where the Terraform code will be executed. Must be one of the following values: `agent`, `local`, `remote`. Default: `remote`. [More information](/terraform/cloud-docs/workspaces/settings#execution-mode).|
 | `runTasks` _[WorkspaceRunTask](#workspaceruntask) array_ | Run tasks allow HCP Terraform to interact with external systems at specific points in the HCP Terraform run lifecycle. [More information](/terraform/cloud-docs/workspaces/settings/run-tasks).|
 | `tags` _[Tag](#tag) array_ | Workspace tags are used to help identify and group together workspaces. Tags must be one or more characters; can include letters, numbers, colons, hyphens, and underscores; and must begin and end with a letter or number. |

--- a/website/docs/cloud-docs/overview/index.mdx
+++ b/website/docs/cloud-docs/overview/index.mdx
@@ -69,7 +69,7 @@ HCP Terraform offers a team-oriented remote Terraform workflow, designed to be c
 
 ### Remote Terraform Execution
 
-HCP Terraform runs Terraform on disposable virtual machines in its own cloud infrastructure by default. You can leverage [HCP Terraform agents](/terraform/cloud-docs/agents) to run Terraform on your own isolated, private, or on-premises infrastructure. Remote Terraform execution is sometimes referred to as "remote operations."
+HCP Terraform runs Terraform on disposable virtual machines in its own cloud infrastructure by default. You can leverage [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx) to run Terraform on your own isolated, private, or on-premises infrastructure. Remote Terraform execution is sometimes referred to as "remote operations."
 
 Remote execution helps provide consistency and visibility for critical provisioning operations. It also enables powerful features like Sentinel policy enforcement, cost estimation, notifications, version control integration, and more.
 
@@ -87,11 +87,11 @@ Terraform's local workflow manages a collection of infrastructure with a persist
 
 HCP Terraform organizes infrastructure into projects and workspaces instead of directories. Each workspace contains everything necessary to manage a given collection of infrastructure, and Terraform uses that content when it runs in the context of that workspace.
 
-You can use projects to organize your workspaces into groups. Organizations with HCP Terraform [Standard](https://www.hashicorp.com/products/terraform/pricing) Edition can assign teams permissions for specific projects. 
+You can use projects to organize your workspaces into groups. Organizations with HCP Terraform [Standard](https://www.hashicorp.com/products/terraform/pricing) Edition can assign teams permissions for specific projects.
 
-This lets you grant access to collections of workspaces instead of using workspace-specific or organization-wide permissions, making it easier to limit access to only the resources required for a team member's job function. 
+This lets you grant access to collections of workspaces instead of using workspace-specific or organization-wide permissions, making it easier to limit access to only the resources required for a team member's job function.
 
-Refer to the [Workspaces](/terraform/cloud-docs/workspaces) and [Projects](/terraform/cloud-docs/projects) documentation for more details. 
+Refer to the [Workspaces](/terraform/cloud-docs/workspaces) and [Projects](/terraform/cloud-docs/projects) documentation for more details.
 
 
 

--- a/website/docs/cloud-docs/policy-enforcement/manage-policy-sets/index.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/manage-policy-sets/index.mdx
@@ -32,7 +32,7 @@ Only Sentinel policies can run as policy checks. Checks can access cost estimati
 
 ### Policy evaluations
 
-OPA policy sets can only run as policy evaluations, and you can enable policy evaluations for Sentinel policy sets by selecting the `Agent` policy set type. Policy evaluations run within the [HCP Terraform agent](/terraform/cloud-docs/agents) in HCP Terraform's infrastructure.
+OPA policy sets can only run as policy evaluations, and you can enable policy evaluations for Sentinel policy sets by selecting the `Agent` policy set type. Policy evaluations run within the [HCP Terraform agent](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx) in HCP Terraform's infrastructure.
 
 For Sentinel policy sets, using policy evaluations lets you:
 - Enable overrides for soft-mandatory and hard-mandatory policies, letting any user with [Manage Policy Overrides permission](/terraform/cloud-docs/users-teams-organizations/permissions#manage-policy-overrides) proceed with a run in the event of policy failure.

--- a/website/docs/cloud-docs/run/remote-operations.mdx
+++ b/website/docs/cloud-docs/run/remote-operations.mdx
@@ -28,7 +28,7 @@ You can disable remote operations for any workspace by changing its [Execution M
 
 ### Protecting Private Environments
 
-[HCP Terraform agents](/terraform/cloud-docs/agents) are a paid feature that allows HCP Terraform to communicate with isolated, private, or on-premises infrastructure. The agent polls HCP Terraform or Terraform Enterprise for any changes to your configuration and executes the changes locally, so you do not need to allow public ingress traffic to your resources. Agents allow you to control infrastructure in private environments without modifying your network perimeter.
+[HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx) are a paid feature that allows HCP Terraform to communicate with isolated, private, or on-premises infrastructure. The agent polls HCP Terraform or Terraform Enterprise for any changes to your configuration and executes the changes locally, so you do not need to allow public ingress traffic to your resources. Agents allow you to control infrastructure in private environments without modifying your network perimeter.
 
 HCP Terraform agents also support running custom programs, called _hooks_, during strategic points of a Terraform run. For example, you may create a hook to dynamically download software required by the Terraform run or send an HTTP request to a system to kick off an external workflow.
 
@@ -76,9 +76,9 @@ HCP Terraform has three main workflows for managing runs, and your chosen workfl
 - The [API-driven run workflow](/terraform/cloud-docs/run/api), which is more flexible but requires you to create some tooling.
 - The [CLI-driven run workflow](/terraform/cloud-docs/run/cli), which uses Terraform's standard CLI tools to execute runs in HCP Terraform.
 
-You can use the following methods to initiate HCP Terraform runs: 
+You can use the following methods to initiate HCP Terraform runs:
 - Click the **+ New run** button on the workspace's page
-- Implement VCS webhooks 
+- Implement VCS webhooks
 - Run the standard `terraform apply` command when the CLI integration is configured
 - Call [the Runs API](/terraform/cloud-docs/api-docs/run) using any API tool
 

--- a/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/api-tokens.mdx
@@ -66,7 +66,7 @@ Each organization can only have a _single_ valid audit trails token. Only [organ
 
 ## Agent API Tokens
 
-[Agent pools](/terraform/cloud-docs/agents) have their own set of API tokens which allow agents to communicate with HCP Terraform, scoped to an organization. These tokens are not valid for direct usage in the HCP Terraform API and are only used by agents.
+[Agent pools](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx) have their own set of API tokens which allow agents to communicate with HCP Terraform, scoped to an organization. These tokens are not valid for direct usage in the HCP Terraform API and are only used by agents.
 
 ## Access Levels
 

--- a/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
+++ b/website/docs/cloud-docs/users-teams-organizations/organizations/index.mdx
@@ -16,7 +16,7 @@ This topic provides overview information about how to create and manage organiza
 
 ## Requirements
 
-The **admin** permission preset must be enabled on your profile to create and manage organizations in the HCP Terraform UI. Refer to [Permissions](/terraform/cloud-docs/users-teams-organizations/permissions#organization-permissions) for additional information. 
+The **admin** permission preset must be enabled on your profile to create and manage organizations in the HCP Terraform UI. Refer to [Permissions](/terraform/cloud-docs/users-teams-organizations/permissions#organization-permissions) for additional information.
 
 ## API and Terraform Enterprise Provider
 
@@ -40,7 +40,7 @@ To join an organization, the organization [owners][] or a user with specific [te
 ## Leave an organization
 
 1. Click the Terraform logo in the page header to navigate to the **Organizations** page.
-1. Open the **...** ellipses menu next to the organization and select **Leave organization**. 
+1. Open the **...** ellipses menu next to the organization and select **Leave organization**.
 
 You do not need permission from the owners to leave an organization, but you cannot leave if you are the last member of the owners team. Either add a new owner and then leave, or [delete the organization](/terraform/cloud-docs/users-teams-organizations/organizations#general).
 
@@ -73,7 +73,7 @@ You can view your organization's managed resource count on the **Usage** page.
 
 ~> **Reserved tag keys are in beta**: We do not recommend using beta features in production environments.
 
-You can define reserved tag keys that appear as suggested labels when managers want to add tags to their projects and workspaces in the organization. Refer to [Create and manage reserved tag keys](/terraform/cloud-docs/users-teams-organizations/organizations/manage-reserved-tags) for instructions. 
+You can define reserved tag keys that appear as suggested labels when managers want to add tags to their projects and workspaces in the organization. Refer to [Create and manage reserved tag keys](/terraform/cloud-docs/users-teams-organizations/organizations/manage-reserved-tags) for instructions.
 
 You can also view single-value tags that may already be attached to projects and workspaces. Refer to [Tags](#tags) in the organization settings reference for additional information.
 
@@ -124,9 +124,9 @@ Click the **Tags** tab in the **Tags Management** screen to view single-value ta
 
 The only action you can perform in the UI is deleting single-value tags from the system. You can use the following methods to delete single-value tags:
 
-1. Select one or more tags and click **Delete tags**. 
-1. Select the **Name** header to select all tags, then click **Delete tags**. 
-1. Click the trash icon for a tag and confirm that you want to permanently delete it when prompted. 
+1. Select one or more tags and click **Delete tags**.
+1. Select the **Name** header to select all tags, then click **Delete tags**.
+1. Click the trash icon for a tag and confirm that you want to permanently delete it when prompted.
 
 #### Teams
 
@@ -134,7 +134,7 @@ The only action you can perform in the UI is deleting single-value tags from the
 @include 'tfc-package-callouts/team-management.mdx'
 <!-- END: TFC:only name:pnp-callout -->
 
-All users in an organization can access the **Teams** page, which displays a list of [teams][] within the organization. 
+All users in an organization can access the **Teams** page, which displays a list of [teams][] within the organization.
 
 Organization owners and users with the [include secret teams permission](/terraform/cloud-docs/users-teams-organizations/permissions#include-secret-teams) can:
   * view all [secret teams](/terraform/cloud-docs/users-teams-organizations/teams/manage#team-visibility)
@@ -190,14 +190,14 @@ From the Workspaces page, click **Settings** in the sidebar, then **Runs** to vi
 - A button allowing you to cancel that run
 
 You can apply the following filters to limit the runs HCP Terraform displays:
-- Click **Needs Attention** to display runs that require user input to continue, such as approving a plan or overriding a policy. 
+- Click **Needs Attention** to display runs that require user input to continue, such as approving a plan or overriding a policy.
 - Click **Running** to display runs that are in progress.
 - Click **On Hold** to display paused runs.
 
 
-For precise filtering, click **More filters** and check the boxes to filter runs by specific [run statuses](/terraform/cloud-docs/run/states), [run operations](/terraform/cloud-docs/run/modes-and-options), workspaces, or [agent pools](/terraform/cloud-docs/agents/agent-pools). Click **Apply filters** to list the runs that match your criteria.
+For precise filtering, click **More filters** and check the boxes to filter runs by specific [run statuses](/terraform/cloud-docs/run/states), [run operations](/terraform/cloud-docs/run/modes-and-options), workspaces, or [agent pools](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/agent-pools.mdx). Click **Apply filters** to list the runs that match your criteria.
 
-You can dismiss any of your filtering criteria by clicking the **X** next to the filter name above the table displaying your runs. 
+You can dismiss any of your filtering criteria by clicking the **X** next to the filter name above the table displaying your runs.
 
 For more details about run states, refer to [Run States and Stages](/terraform/cloud-docs/run/states).
 
@@ -243,7 +243,7 @@ Manage the run tasks that you can add to workspaces within the organization. [Ru
 @include 'tfc-package-callouts/agents.mdx'
 <!-- END: TFC:only name:pnp-callout -->
 
-Create and manage [HCP Terraform agent pools](/terraform/cloud-docs/agents). HCP Terraform agents let HCP Terraform communicate with isolated, private, or on-premises infrastructure. This is useful for on-premises infrastructure types such as vSphere, Nutanix, OpenStack, enterprise networking providers, and infrastructure within a protected enclave.
+Create and manage [HCP Terraform agent pools](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx). HCP Terraform agents let HCP Terraform communicate with isolated, private, or on-premises infrastructure. This is useful for on-premises infrastructure types such as vSphere, Nutanix, OpenStack, enterprise networking providers, and infrastructure within a protected enclave.
 
 #### API Tokens
 

--- a/website/docs/cloud-docs/vcs/private.mdx
+++ b/website/docs/cloud-docs/vcs/private.mdx
@@ -19,7 +19,7 @@ You can use HCP Terraform agents to connect HCP Terraform to your private VCS pr
 - GitLab Enterprise
 - BitBucket Data Center
 
-For more information about HCP Terraform agents, refer to the [HCP Terraform agent documentation](/terraform/cloud-docs/agents).
+For more information about HCP Terraform agents, refer to the [HCP Terraform agent documentation](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx).
 
 ## Requirements
 
@@ -27,11 +27,11 @@ You must meet the following requirements to configure a connection to your priva
 
 - HCP Terraform agent v1.15.0 or newer.
 - Network connectivity between the HCP Terraform agent and private VCS provider.
-- Outbound network connectivity from the HCP Terraform agent to HCP Terraform. Refer to [networking requirements](/terraform/cloud-docs/agents/requirements#networking-requirements) for more information.
+- Outbound network connectivity from the HCP Terraform agent to HCP Terraform. Refer to [networking requirements](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/requirements.mdx#networking-requirements) for more information.
 
 ## Configure the agent pool and agent
 
-Before you start your HCP Terraform agent, you must create an agent pool and token. Refer to [Create an Agent Pool](/terraform/cloud-docs/agents/agent-pools#create-an-agent-pool) for a list of steps to create an agent pool.
+Before you start your HCP Terraform agent, you must create an agent pool and token. Refer to [Create an Agent Pool](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/agent-pools.mdx#create-an-agent-pool) for a list of steps to create an agent pool.
 
 To configure your HCP Terraform agent with private VCS support, you must set the following environment variables in the environment you run the agent. You can also set these environment variables with optional command-line flags.
 
@@ -39,7 +39,7 @@ To configure your HCP Terraform agent with private VCS support, you must set the
 | -------- | ----- | ----------------- |
 | `_TFC_AGENT_REQUEST_FORWARDING_ENABLED` | `true` | |
 | `TFC_AGENT_REQUEST_FORWARDING` | `true` | `-request-forwarding` |
-| `TFC_AGENT_ACCEPT` | A comma-separated list of values that  must include `ingress`. Refer to [Install and Run Agents](/terraform/cloud-docs/agents/agents#accept) for more information. | `-accept` |
+| `TFC_AGENT_ACCEPT` | A comma-separated list of values that  must include `ingress`. Refer to [Install and Run Agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/agents.mdx#accept) for more information. | `-accept` |
 
 Below is an example command to start the HCP Terraform agent:
 
@@ -80,4 +80,4 @@ There are two sources of information to help diagnose issues with Private VCS an
   - VCS events include errors that have resulted from making requests for private VCS during setup of the VCS Connection, and during normal operation.
   - This will not include messages during normal operations of private VCS.
 
-To aid in troubleshooting, you can increase the verbosity of the HCP Terraform agent's log messages  to `debug` and `trace` and retry the attempted action. Refer to [Install and Run Agents](/terraform/cloud-docs/agents/agents#log-level) for more information.
+To aid in troubleshooting, you can increase the verbosity of the HCP Terraform agent's log messages  to `debug` and `trace` and retry the attempted action. Refer to [Install and Run Agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/agents.mdx#log-level) for more information.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/aws-configuration.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Use dynamic credentials with the AWS provider
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.7.0](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.7.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with AWS to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the AWS provider in your HCP Terraform runs. Configuring the integration requires the following steps:
 
@@ -115,7 +115,7 @@ Make sure that you’re not using any of the other arguments or methods mentione
 
 ### Specifying Multiple Configurations
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.12.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can add additional variables to handle multiple distinct AWS setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace. You can configure each set of credentials independently, or use default values by configuring the variables prefixed with `TFC_DEFAULT_`.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/azure-configuration.mdx
@@ -9,7 +9,7 @@ description: >-
 
 ~> **Important:** Ensure you are using version **3.25.0** or later of the **AzureRM provider** and version **2.29.0** or later of the **Microsoft Entra ID provider** (previously Azure Active Directory) as required OIDC functionality was introduced in these provider versions.
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.7.0](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.7.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with Azure to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the AzureRM or Microsoft Entra ID providers in your HCP Terraform runs. Configuring the integration requires the following steps:
 
@@ -78,7 +78,7 @@ Make sure that you’re _not_ setting values for `client_id`, `use_oidc`, or `oi
 
 ~> **Important:** Ensure you are using version **3.60.0** or later of the **AzureRM provider** and version **2.43.0** or later of the **Microsoft Entra ID provider** as required functionality was introduced in these provider versions.
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.12.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can add additional variables to handle multiple distinct Azure setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace. You can configure each set of credentials independently, or use default values by configuring the variables prefixed with `TFC_DEFAULT_`.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/gcp-configuration.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Use dynamic credentials with the GCP provider
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.7.0](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.7.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 
 You can use HCP Terraform’s native OpenID Connect integration with GCP to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the GCP provider in your HCP Terraform runs. Configuring the integration requires the following steps:
@@ -111,7 +111,7 @@ Make sure that you’re not setting values for the `GOOGLE_CREDENTIALS` or `GOOG
 
 ### Specifying Multiple Configurations
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.12.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can add additional variables to handle multiple distinct GCP setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace. You can configure each set of credentials independently, or use default values by configuring the variables prefixed with `TFC_DEFAULT_`.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-configuration.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Dynamic Credentials with the HCP Provider
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.15.1](/terraform/cloud-docs/agents/changelog#1-15-1-05-01-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.15.1](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-15-1-05-01-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with HCP to authenticate with the HCP provider using [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) in your HCP Terraform runs. Configuring dynamic credentials for the HCP provider requires the following steps:
 
@@ -72,7 +72,7 @@ Do not set the `HCP_CRED_FILE` environment variable when configuring the HCP pro
 
 ### Specifying Multiple Configurations
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.15.1](/terraform/cloud-docs/agents/changelog#1-15-1-05-01-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.15.1](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-15-1-05-01-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can add additional variables to handle multiple distinct HCP setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace. You can configure each set of credentials independently, or use default values by configuring the variables prefixed with `TFC_DEFAULT_`.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/aws-configuration.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # HCP Vault Secrets-Backed Dynamic Credentials with the AWS Provider
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.16.0](/terraform/cloud-docs/agents/changelog#1-16-0-10-02-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.16.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-16-0-10-02-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with HCP to use [HCP Vault Secrets-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed) with the AWS provider in your HCP Terraform runs. Configuring the integration requires the following steps:
 
@@ -54,7 +54,7 @@ Ensure you are not using any of the arguments or methods mentioned in the [authe
 
 ### Specifying Multiple Configurations
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.16.0](/terraform/cloud-docs/agents/changelog#1-16-0-10-02-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.16.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-16-0-10-02-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can add additional variables to handle multiple distinct HCP Vault Secrets-backed AWS setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace. You can configure each set of credentials independently, or use default values by configuring the variables prefixed with `TFC_DEFAULT_`.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/gcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/gcp-configuration.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # HCP Vault Secrets-Backed Dynamic Credentials with the GCP Provider
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.16.0](/terraform/cloud-docs/agents/changelog#1-16-0-10-02-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.16.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-16-0-10-02-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with HCP to use [HCP Vault Secrets-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed) with the GCP provider in your HCP Terraform runs. Configuring the integration requires the following steps:
 
@@ -55,7 +55,7 @@ Ensure you are not setting values or environment variables for `GOOGLE_CREDENTIA
 
 ### Specifying Multiple Configurations
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.16.0](/terraform/cloud-docs/agents/changelog#1-16-0-10-02-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.16.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-16-0-10-02-2024) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can add additional variables to handle multiple distinct HCP Vault Secrets-backed GCP setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace. You can configure each set of credentials independently, or use default values by configuring the variables prefixed with `TFC_DEFAULT_`.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/index.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-vault-secrets-backed/index.mdx
@@ -16,15 +16,15 @@ This topic provides an overview of how to use HCP Vault Secrets to generate temp
 
 Configuring [dynamic provider credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) with different cloud providers is suitable for most use cases, but you can use HCP Vault Secrets-backed dynamic credentials to centralize and consolidate cloud credential management.
 
-HCP Vault Secrets-backed dynamic credentials leverage HCP Vault Secrets' [dynamic secrets capability](/hcp/docs/vault-secrets/dynamic-secrets), which allows you to generate short-lived credentials for various providers. This means you can authenticate a HCP instance using workload identity tokens and use dynamic secret capabilities on that instance to generate dynamic credentials for the various providers. 
+HCP Vault Secrets-backed dynamic credentials leverage HCP Vault Secrets' [dynamic secrets capability](/hcp/docs/vault-secrets/dynamic-secrets), which allows you to generate short-lived credentials for various providers. This means you can authenticate a HCP instance using workload identity tokens and use dynamic secret capabilities on that instance to generate dynamic credentials for the various providers.
 
-Refer to the [HCP Vault Secrets announcement](https://www.hashicorp.com/blog/hcp-vault-secrets-is-now-generally-available) to learn about the benefits of using HCP Vault Secrets to manage provider credentials. 
+Refer to the [HCP Vault Secrets announcement](https://www.hashicorp.com/blog/hcp-vault-secrets-is-now-generally-available) to learn about the benefits of using HCP Vault Secrets to manage provider credentials.
 
 ## Workflow
 
 Using HCP Vault Secrets-backed dynamic credentials in a workspace requires the following steps for each cloud platform:
 
-1. If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.16.0](/terraform/cloud-docs/agents/changelog#1-16-0-10-02-2024) or newer. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+1. If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.16.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-16-0-10-02-2024) or newer. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 1. Set up dynamic provider credentials with the HCP provider: You must first [configure dynamic credentials with the HCP provider](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/hcp-configuration).
 1. Configure the dynamic secrets integration: You must configure the desired Vault secrets integration in your HCP project, such as AWS or GCP.
 1. Configure your HCP Terraform workspace: You must add specific environment variables to your workspace to tell HCP Terraform how to authenticate to other cloud providers during runs. Each cloud platform has its own set of environment variables that are necessary to configure dynamic credentials.

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/index.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/index.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Dynamic provider credentials
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.7.0](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.7.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 Using static credentials in your workspaces to authenticate providers presents a security risk, even if you rotate your credentials regularly. Dynamic provider credentials improve your security posture by letting you provision new, temporary credentials for each run.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/kubernetes-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Use dynamic credentials with the Kubernetes and Helm providers
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.13.1](/terraform/cloud-docs/agents/changelog#1-13-1-10-25-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.13.1](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-13-1-10-25-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with Kubernetes to use [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the Kubernetes and Helm providers in your HCP Terraform runs. Configuring the integration requires the following steps:
 
@@ -30,7 +30,7 @@ When inputting an "issuer URL", use the address of HCP Terraform (`https://app.t
 
 The OIDC identity resolves authentication to the Kubernetes API, but it first requires authorization to interact with that API. So, you must bind RBAC roles to the OIDC identity in Kubernetes.
 
-You can use both "User" and "Group" subjects in your role bindings. For OIDC identities coming from TFC, the "User" value is formatted like so: `organization:<MY-ORG-NAME>:project:<MY-PROJECT-NAME>:workspace:<MY-WORKSPACE-NAME>:run_phase:<plan|apply>`. 
+You can use both "User" and "Group" subjects in your role bindings. For OIDC identities coming from TFC, the "User" value is formatted like so: `organization:<MY-ORG-NAME>:project:<MY-PROJECT-NAME>:workspace:<MY-WORKSPACE-NAME>:run_phase:<plan|apply>`.
 
 You can extract the "Group" value from the token claim you configured in your cluster OIDC configuration. For details on the structure of the HCP Terraform token, refer to [Workload Identity](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens).
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/manual-generation.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/manual-generation.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Manually generate workload identity tokens
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.7.0](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.7.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 If required for custom auth workflows or to perform auth with providers that are not natively supported by dynamic credentials, you can request that HCP Terraform inject a [workload identity token](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/workload-identity-tokens) into the run environment for usage in agent hooks.
 ## Configure HCP Terraform
@@ -19,7 +19,7 @@ You’ll need to set the following environment variable in your HCP Terraform wo
 
 ### Generating Multiple Tokens
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.12.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can generate multiple tokens if you want distinct audience values for different consumers of your workload identity tokens. For more details, see [Specifying Multiple Configurations](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations).
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/specifying-multiple-configurations.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Specify multiple dynamic credential configurations
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.12.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can create multiple dynamic credential configurations of the same provider in a workspace.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/aws-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Use Vault-backed dynamic credentials with the AWS provider
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.8.0](/terraform/cloud-docs/agents/changelog#1-8-0-04-18-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.8.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-8-0-04-18-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with Vault to use [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed) with the AWS provider in your HCP Terraform runs. Configuring the integration requires the following steps:
 
@@ -80,7 +80,7 @@ This includes the [`vault_aws_access_credentials`](https://registry.terraform.io
 
 ### Specifying Multiple Configurations
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.12.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can add additional variables to handle multiple distinct Vault-backed AWS setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace. You can configure each set of credentials independently, or use default values by configuring the variables prefixed with `TFC_DEFAULT_`.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/azure-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Use Vault-backed dynamic credentials with the Azure provider
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.8.0](/terraform/cloud-docs/agents/changelog#1-8-0-04-18-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.8.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-8-0-04-18-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with Vault to use [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed) with the Azure provider in your HCP Terraform runs. Configuring the integration requires the following steps:
 
@@ -61,7 +61,7 @@ This includes the [`vault_azure_access_credentials`](https://registry.terraform.
 
 ~> **Important:** Ensure you are using version **3.60.0** or later of the **AzureRM provider** and version **2.43.0** or later of the **Microsoft Entra ID provider** (previously Azure Active Directory) as required functionality was introduced in these provider versions.
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.12.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can add additional variables to handle multiple distinct Vault-backed Azure setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace. You can configure each set of credentials independently, or use default values by configuring the variables prefixed with `TFC_DEFAULT_`.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/gcp-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Use Vault-backed dynamic credentials with the GCP provider
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.8.0](/terraform/cloud-docs/agents/changelog#1-8-0-04-18-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.8.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-8-0-04-18-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with Vault to use [Vault-backed dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed) with the GCP provider in your HCP Terraform runs. Configuring the integration requires the following steps:
 
@@ -93,7 +93,7 @@ This includes instances of [`vault_generic_secret`](https://registry.terraform.i
 
 ### Specifying Multiple Configurations
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.12.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can add additional variables to handle multiple distinct Vault-backed GCP setups, enabling you to use multiple [provider aliases](/terraform/language/providers/configuration#alias-multiple-provider-configurations) within the same workspace. You can configure each set of credentials independently, or use default values by configuring the variables prefixed with `TFC_DEFAULT_`.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-backed/index.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Use Vault-backed dynamic credentials
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.8.0](/terraform/cloud-docs/agents/changelog#1-8-0-04-18-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.8.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-8-0-04-18-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 For most use cases, separately configuring [dynamic provider credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) with different cloud providers works well. However, Vault-backed dynamic credentials are for those looking for a way to:
  1. Use Vault's secrets engines as a centralized way to manage and consolidate cloud credentials management.
@@ -14,7 +14,7 @@ For most use cases, separately configuring [dynamic provider credentials](/terra
 
 The "Vault-backed" in "Vault-backed dynamic credentials" refers to Vault's [secrets engines](/vault/docs/secrets), which allow you to generate short-lived [dynamic secrets](https://www.vaultproject.io/use-cases/dynamic-secrets) for the AWS, GCP, or Azure providers. If you are using Terraform Enterprise and your Vault instance is configured within the same secure network, you can generate secrets while keeping your environment air-gapped.
 
-Vault-backed dynamic credentials combine the features of dynamic provider credentials and Vault's secrets engines. This means you can authenticate a Vault instance using workload identity tokens and use secrets engines on that instance to generate dynamic credentials for the AWS, GCP, and Azure providers. 
+Vault-backed dynamic credentials combine the features of dynamic provider credentials and Vault's secrets engines. This means you can authenticate a Vault instance using workload identity tokens and use secrets engines on that instance to generate dynamic credentials for the AWS, GCP, and Azure providers.
 
 For a comparison of Vault-backed dynamic credentials and dynamic provider credentials, refer to the article [Why use Vault-backed dynamic credentials to secure HCP Terraform infrastructure?](https://www.hashicorp.com/blog/why-use-vault-backed-dynamic-credentials-to-secure-hcp-terraform-infrastructure) on the HashiCorp blog.
 

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/vault-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Use dynamic credentials with the Vault provider
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.7.0](/terraform/cloud-docs/agents/changelog#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.7.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-7-0-03-02-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 You can use HCP Terraform’s native OpenID Connect integration with Vault to get [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for the Vault provider in your HCP Terraform runs. Configuring the integration requires the following steps:
 
@@ -144,7 +144,7 @@ You can use the Vault provider to read static secrets from Vault and use them wi
 
 ### Specifying Multiple Configurations
 
-~> **Important:** If you are self-hosting [HCP Terraform agents](/terraform/cloud-docs/agents), ensure your agents use [v1.12.0](/terraform/cloud-docs/agents/changelog#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](/terraform/cloud-docs/agents/changelog).
+~> **Important:** If you are self-hosting [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx), ensure your agents use [v1.12.0](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx#1-12-0-07-26-2023) or above. To use the latest dynamic credentials features, [upgrade your agents to the latest version](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/changelog.mdx).
 
 ~> **Important:** Ensure you are using version **3.18.0** or later of the **Vault provider** as the required [`auth_login_token_file`](https://registry.terraform.io/providers/hashicorp/vault/latest/docs#token-file) block was introduced in this provider version.
 

--- a/website/docs/cloud-docs/workspaces/health.mdx
+++ b/website/docs/cloud-docs/workspaces/health.mdx
@@ -33,7 +33,7 @@ Working with health assessments requires the following permissions:
 Workspaces require the following settings to receive health assessments:
 - Terraform version 0.15.4+ for drift detection only
 - Terraform version 1.3.0+ for drift detection and continuous validation
-- [Remote execution mode](/terraform/cloud-docs/workspaces/settings#execution-mode) or [Agent execution mode](/terraform/cloud-docs/agents/agent-pools#configure-workspaces-to-use-the-agent) for Terraform runs
+- [Remote execution mode](/terraform/cloud-docs/workspaces/settings#execution-mode) or [Agent execution mode](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/agent-pools.mdx#configure-workspaces-to-use-the-agent) for Terraform runs
 
 The latest Terraform run in the workspace must have been successful. If the most recent run ended in an errored, canceled, or discarded state, HCP Terraform pauses health assessments until there is a successfully applied run.
 
@@ -75,7 +75,7 @@ Terraform Enterprise administrators can modify their installation's [assessment 
 
 If you are an administrator for a workspace and it satisfies all [assessment requirements](/terraform/cloud-docs/workspaces/health#workspace-requirements), you can trigger a new assessment by clicking **Start health assessment** on the workspace's **Health** page.
 
-After clicking **Start health assessment**, the workspace displays a message in the bottom lefthand corner of the page to indicate if it successfully triggered a new assessment. The time it takes to complete an assessment can vary based on network latency and the number of resources managed by the workspace. 
+After clicking **Start health assessment**, the workspace displays a message in the bottom lefthand corner of the page to indicate if it successfully triggered a new assessment. The time it takes to complete an assessment can vary based on network latency and the number of resources managed by the workspace.
 
 You cannot trigger another assessment while one is in progress. An on-demand assessment resets the scheduling for automated assessments, so HCP Terraform waits to run the next assessment until the next scheduled period.
 
@@ -103,9 +103,9 @@ On the right of a workspace’s overview page, HCP Terraform displays a **Health
 
 The [Explorer page](/terraform/cloud-docs/workspaces/explorer) presents a condensed overview of the health status of the workspaces within your organization. You can see the following information:
 
-- Workspaces that are monitoring workspace health 
-- Status of any configured continuous validation checks 
-- Count of drifted resources for each workspace 
+- Workspaces that are monitoring workspace health
+- Status of any configured continuous validation checks
+- Count of drifted resources for each workspace
 
 For additional details on the data available for reporting, refer to the [Explorer](/terraform/cloud-docs/workspaces/explorer) documentation.
 

--- a/website/docs/cloud-docs/workspaces/settings/index.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/index.mdx
@@ -43,7 +43,7 @@ The display name of the workspace.
 
 ### Project
 
-The [project](/terraform/cloud-docs/projects) that this workspace belongs to. Changing the workspace's project can change the read and write permissions for the workspace and which users can access it. 
+The [project](/terraform/cloud-docs/projects) that this workspace belongs to. Changing the workspace's project can change the read and write permissions for the workspace and which users can access it.
 
 To move a workspace, you must have the "Manage all Projects" organization permission or explicit team admin privileges on both the source and destination projects. Remember that moving a workspace to another project may affect user visibility for that project's workspaces. Refer to [Project Permissions](/terraform/cloud-docs/users-teams-organizations/permissions#project-permissions) for details on workspace access.
 
@@ -61,7 +61,7 @@ Specifying the "Remote" execution mode instructs HCP Terraform to perform Terraf
 
 To disable remote execution for a workspace, change its execution mode to "Local". This mode lets you perform Terraform runs locally with the [CLI-driven run workflow](/terraform/cloud-docs/run/cli). The workspace will store state, which Terraform can access with the [CLI integration](/terraform/cli/cloud). HCP Terraform does not evaluate workspace variables or variable sets in local execution mode.
 
-If you instead need to allow HCP Terraform to communicate with isolated, private, or on-premises infrastructure, consider using [HCP Terraform agents](/terraform/cloud-docs/agents). By deploying a lightweight agent, you can establish a simple connection between your environment and HCP Terraform.
+If you instead need to allow HCP Terraform to communicate with isolated, private, or on-premises infrastructure, consider using [HCP Terraform agents](https://github.com/hashicorp/terraform-docs-agents/blob/main/website/docs/cloud-docs/agents/index.mdx). By deploying a lightweight agent, you can establish a simple connection between your environment and HCP Terraform.
 
 Changing your workspace's execution mode after a run has already been planned will cause the run to error when it is applied.
 


### PR DESCRIPTION
### What
This pull request updates all documentation links related to HCP Terraform agents to point to their new location in the [terraform-docs-agents repository](https://github.com/hashicorp/terraform-docs-agents). The changes include updates to relative paths that were previously broken and have now been replaced with absolute URLs. Files updated include, but are not limited to:
- API documentation pages (e.g., `api-docs/agents.mdx`, `api-docs/changelog.mdx`)
- Integration guides (e.g., `integrations/kubernetes/api-reference.mdx`)
- Security and overview documentation
- Workspaces and dynamic provider credentials pages

### Why
The HCP Terraform agent documentation has been migrated to a dedicated repository. As a result, existing links in our main documentation were no longer valid, causing broken navigation and potential confusion for users. By updating these links:
- Users are directed to the correct, up-to-date agent documentation.
- We ensure consistency and accuracy across our documentation.
- Overall user experience is improved by restoring full functionality of agent-related documentation.

### Screenshots
N/A

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated.
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.