### PR TITLE
Add ephemeral resource sections to provider best practices

### DIFF
--- a/website/docs/plugin/best-practices/hashicorp-provider-design-principles.mdx
+++ b/website/docs/plugin/best-practices/hashicorp-provider-design-principles.mdx
@@ -79,3 +79,14 @@ The benefits of this practice include:
 - Ensuring Terraform can statically validate the entire configuration anywhere
 - Preventing practitioner issues should the environment change between Terraform commands
 - Preventing practitioner issues should networking or a service become unavailable
+
+## Ephemeral Resources should represent a single sensitive API object
+
+A Terraform ephemeral resource should be a declarative representation of a single sensitive API object, such as an API token or secret, which will be
+created and/or retrieved from the API during the Open operation.
+
+The benefits of this practice include:
+
+- Maximizing predictability and minimizing the blast radius of open/close operations
+- Enabling composition of related or dependent components in new and innovative ways
+- Preventing maintainer burden of managing multiple underlying components

--- a/website/docs/plugin/best-practices/hashicorp-provider-design-principles.mdx
+++ b/website/docs/plugin/best-practices/hashicorp-provider-design-principles.mdx
@@ -83,7 +83,6 @@ The benefits of this practice include:
 ## Ephemeral Resources should represent a single sensitive API object
 
 A Terraform ephemeral resource should be a declarative representation of a single API object that doesn't require Terraform to store it's data between runs, such as sensitive data like an API token or secret. This ephemeral data is created and/or retrieved from the API during the Open operation.
-created and/or retrieved from the API during the Open operation.
 
 The benefits of this practice include:
 

--- a/website/docs/plugin/best-practices/hashicorp-provider-design-principles.mdx
+++ b/website/docs/plugin/best-practices/hashicorp-provider-design-principles.mdx
@@ -82,7 +82,7 @@ The benefits of this practice include:
 
 ## Ephemeral Resources should represent a single sensitive API object
 
-A Terraform ephemeral resource should be a declarative representation of a single sensitive API object, such as an API token or secret, which will be
+A Terraform ephemeral resource should be a declarative representation of a single API object that doesn't require Terraform to store it's data between runs, such as sensitive data like an API token or secret. This ephemeral data is created and/or retrieved from the API during the Open operation.
 created and/or retrieved from the API during the Open operation.
 
 The benefits of this practice include:

--- a/website/docs/plugin/best-practices/sensitive-state.mdx
+++ b/website/docs/plugin/best-practices/sensitive-state.mdx
@@ -12,6 +12,18 @@ it's inevitable that [sensitive information will find its way into
 Terraform](/terraform/language/state/sensitive-data) in these circumstances. There are a
 couple of recommended approaches for managing sensitive state in Terraform.
 
+## Using Ephemeral Resources
+
+<Highlight>
+
+    Ephemeral resource support is only available in the [Terraform Plugin Framework](/terraform/plugin/framework)
+
+</Highlight>
+
+[Ephemeral resources](/terraform/language/v1.10.x/resources/ephemeral) allow Terraform to reference external data, while
+guaranteeing that this data will not be persisted in plan or state. When working with a sensitive API object such as an API token or secret,
+model that object using an ephemeral resource whenever possible.
+
 ## Using `Sensitive` Flag functionality
 
 When working with a field that contains information likely to be considered

--- a/website/docs/plugin/framework-benefits.mdx
+++ b/website/docs/plugin/framework-benefits.mdx
@@ -256,5 +256,6 @@ Additional new and improved features in the framework include:
 - **Validation Capabilities**: The framework exposes many more configuration validation integration points than the SDK. It is also extensible with provider-defined types that implement validation in the type itself.
 - **Functions**: The framework supports provider-defined functions which are exposed for practitioner configurations.
 - **Enhanced Import and Planning Capabilities**: The framework enables additional import and plan handling capabilities not available in SDKv2.
+- **Ephemeral Resources**: The framework supports ephemeral resources which do not store data in the Terraform plan or state artifacts.
 
 Refer to [Framework Feature Comparison](/terraform/plugin/framework/migrating/benefits) for a continued list of features, details, and examples.


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Add ephemeral resource sections to:
- Provider Design Principles - website/docs/plugin/best-practices/hashicorp-provider-design-principles.mdx
- Sensitive State best practices - website/docs/plugin/best-practices/sensitive-state.mdx
- Framework Benefits - website/docs/plugin/framework-benefits.mdx

### Why
<!-- Explain why this change is necessary and how it benefits users. -->

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
