### PR TITLE
TF-24414 Add instructions on updating a stack's project

### DIFF
--- a/website/docs/cloud-docs/stacks/configure.mdx
+++ b/website/docs/cloud-docs/stacks/configure.mdx
@@ -6,7 +6,7 @@ tfc_only: true
 
 # Configure a Stack
 
-This guide explains configuring a Stack’s name, description, and VCS settings in HCP Terraform.
+This guide explains configuring a Stack’s name, description, project and VCS settings in HCP Terraform.
 
 ## Requirements
 
@@ -27,12 +27,19 @@ You can configure a Stack by performing the following steps:
 1. Select the Stack you want to configure.  
 1. Click **Stack settings** in the navigation menu.  
 1. Update any of the following settings:  
-   * Name   
-   * Description  
+   * Name
+   * Description
+   * Project, learn about [moving a stack to another project](/terraform/cloud-docs/stacks/configure#move-a-stack-to-another-project).
    * Version control settings, including:
         * Stacks automatically trigger new plans when you push them to your repositories’ default branch. To deactivate this behavior,  uncheck **VCS Trigger Enabled**.  
         * You can also configure Stacks to work from either a branch or tag-based workflow. 
 1. Click **Save settings** to apply your changes.
+
+## Move a Stack to another project
+
+To move a stack, you must have the **Manage all Projects** organization permission or explicit team admin privileges on both the source and destination projects. Moving a Stack may alter or remove access for some teams based on their [project-level permissions](/terraform/cloud-docs/users-teams-organizations/permissions#project-permissions).
+
+Upstream Stacks must be in the same project as their downstream Stacks. If you move a Stack to another project, the inputs that depend on it will break. Move upstream and downstream Stacks together to avoid disruptions. Learn more about [passing data from one Stack to another](/terraform/language/stacks/deploy/pass-data).
 
 ## Next steps
 

--- a/website/docs/cloud-docs/stacks/configure.mdx
+++ b/website/docs/cloud-docs/stacks/configure.mdx
@@ -39,7 +39,7 @@ You can configure a Stack by performing the following steps:
 
 To move a Stack, you must have the **Manage all Projects** organization permission or explicit team admin privileges on both the source and destination projects. Moving a Stack may alter or remove access for some teams based on their [project-level permissions](/terraform/cloud-docs/users-teams-organizations/permissions#project-permissions).
 
-Upstream Stacks must be in the same project as their downstream Stacks. If you move a Stack to another project, the inputs that depend on it will break. Move upstream and downstream Stacks together to avoid disruptions. Learn more about [passing data from one Stack to another](/terraform/language/stacks/deploy/pass-data).
+Upstream Stacks must be in the same project as their downstream Stacks. Moving an upstream Stack to another project breaks any downstream Stack inputs affecting future plans. Move upstream and downstream Stacks together to avoid disruptions. Learn more about [passing data from one Stack to another](/terraform/language/stacks/deploy/pass-data).
 
 ## Next steps
 

--- a/website/docs/cloud-docs/stacks/configure.mdx
+++ b/website/docs/cloud-docs/stacks/configure.mdx
@@ -39,7 +39,7 @@ You can configure a Stack by performing the following steps:
 
 To move a Stack, you must have the **Manage all Projects** organization permission or explicit team admin privileges on both the source and destination projects. Moving a Stack may alter or remove access for some teams based on their [project-level permissions](/terraform/cloud-docs/users-teams-organizations/permissions#project-permissions).
 
-Upstream Stacks must be in the same project as their downstream Stacks. Moving an upstream Stack to another project breaks any downstream Stack inputs affecting future plans. Move upstream and downstream Stacks together to avoid disruptions. Learn more about [passing data from one Stack to another](/terraform/language/stacks/deploy/pass-data).
+Upstream Stacks must be in the same project as their downstream Stacks. Moving an upstream Stack to another project breaks any downstream Stack inputs, affecting future plans. Move upstream and downstream Stacks together to avoid disruptions. Learn more about [passing data from one Stack to another](/terraform/language/stacks/deploy/pass-data).
 
 ## Next steps
 

--- a/website/docs/cloud-docs/stacks/configure.mdx
+++ b/website/docs/cloud-docs/stacks/configure.mdx
@@ -15,7 +15,7 @@ To view a Stack and its configurations, you must also be a member of a team in y
 * [Organization-level **Manage all projects**](/terraform/cloud-docs/users-teams-organizations/permissions#manage-all-projects) or higher  
 * [Project-level **Maintain**](/terraform/cloud-docs/users-teams-organizations/permissions#maintain) or higher
 
-## Configure a stack
+## Configure a Stack
 
 You can configure a Stack by performing the following steps:
 
@@ -29,7 +29,7 @@ You can configure a Stack by performing the following steps:
 1. Update any of the following settings:  
    * Name
    * Description
-   * Project, learn about [moving a stack to another project](/terraform/cloud-docs/stacks/configure#move-a-stack-to-another-project).
+   * Project, learn about [moving a Stack to another project](/terraform/cloud-docs/stacks/configure#move-a-stack-to-another-project).
    * Version control settings, including:
         * Stacks automatically trigger new plans when you push them to your repositories’ default branch. To deactivate this behavior,  uncheck **VCS Trigger Enabled**.  
         * You can also configure Stacks to work from either a branch or tag-based workflow. 
@@ -37,10 +37,10 @@ You can configure a Stack by performing the following steps:
 
 ## Move a Stack to another project
 
-To move a stack, you must have the **Manage all Projects** organization permission or explicit team admin privileges on both the source and destination projects. Moving a Stack may alter or remove access for some teams based on their [project-level permissions](/terraform/cloud-docs/users-teams-organizations/permissions#project-permissions).
+To move a Stack, you must have the **Manage all Projects** organization permission or explicit team admin privileges on both the source and destination projects. Moving a Stack may alter or remove access for some teams based on their [project-level permissions](/terraform/cloud-docs/users-teams-organizations/permissions#project-permissions).
 
 Upstream Stacks must be in the same project as their downstream Stacks. If you move a Stack to another project, the inputs that depend on it will break. Move upstream and downstream Stacks together to avoid disruptions. Learn more about [passing data from one Stack to another](/terraform/language/stacks/deploy/pass-data).
 
 ## Next steps
 
-After configuring your stack, you can learn more about how to [review your stack’s deployment plans](/terraform/cloud-docs/stacks/deploy/plans) or [destroy your stack](/terraform/cloud-docs/stacks/destroy).
+After configuring your Stack, you can learn more about how to [review your Stack’s deployment plans](/terraform/cloud-docs/stacks/deploy/plans) or [destroy your stack](/terraform/cloud-docs/stacks/destroy).

--- a/website/docs/cloud-docs/stacks/configure.mdx
+++ b/website/docs/cloud-docs/stacks/configure.mdx
@@ -6,7 +6,7 @@ tfc_only: true
 
 # Configure a Stack
 
-This guide explains configuring a Stack’s name, description, project and VCS settings in HCP Terraform.
+This guide explains configuring a Stack’s name, description, project, and VCS settings in HCP Terraform.
 
 ## Requirements
 

--- a/website/docs/cloud-docs/stacks/deploy/plans.mdx
+++ b/website/docs/cloud-docs/stacks/deploy/plans.mdx
@@ -35,7 +35,7 @@ A stack’s **Overview** page displays the following information:
 * The inputs and outputs for your stack   
 * A chart listing each deployment’s recent configuration versions
 
-Clicking on a Stack’s **Inputs** reveals a list of the inputs this Stack has access to from `upstream_input` blocks, along with the upstream Stacks that supply those inputs. Clicking on a Stack’s **Outputs** reveals a list of the outputs of this Stack and any downstream Stacks that intake those outputs. To learn more about passing data from one Stack to another, refer to [Pass data from one Stack to another](/terraform/language/stacks/deploy/link-stacks).
+Clicking on a Stack’s **Inputs** reveals a list of the inputs this Stack has access to from `upstream_input` blocks, along with the upstream Stacks that supply those inputs. Clicking on a Stack’s **Outputs** reveals a list of the outputs of this Stack and any downstream Stacks that intake those outputs. To learn more about passing data from one Stack to another, refer to [Pass data from one Stack to another](/terraform/language/stacks/deploy/pass-data).
 
 To view all of the plans for a deployment, click the name of the deployment you want to review.
 


### PR DESCRIPTION
**Note:** Do not merge this PR until the `move-stacks` feature flag has been removed.

### What
This PR:

- Updates the `/cloud-docs/stacks/configure.mdx` page to include instructions on changing a stack's project. See [Jira ticket](https://hashicorp.atlassian.net/browse/TF-24414).
- Fixes an existing link to the "Pass data from one Stack to another" page

### Why
If a user wants to move a stack to a different project, they have to recreate the stack in that project. Now, a user can move the stack from a stack's settings page.

### Screenshots

<img width="1508" alt="Screenshot 2025-03-21 at 2 12 44 PM" src="https://github.com/user-attachments/assets/5e33140d-f41e-482c-870d-fa849e12451c" />

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages. (N/A)
- [x] API documentation and the API Changelog have been updated. (N/A)
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate. (N/A)
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages. (N/A)
- [x] New pages have metadata (page name and description) at the top. (N/A)
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility. (N/A)
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars. (N/A)
- [x] UI elements (button names, page names, etc.) are bolded. (N/A)
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
