### PR TITLE
Correct typos in HCP workload identity commands

### DIFF
--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-configuration.mdx
@@ -29,7 +29,7 @@ hcp iam service-principals create hcp-terraform --project=HCP_PROJECT_ID
 Grant your service principal the necessary permissions to manage your infrastructure during runs.
 
 ```shell
-hcp projects add-binding \
+hcp projects iam add-binding \
   --project=HCP_PROJECT_ID \
   --member=HCP_PRINCIPAL_ID \
   --role=roles/contributor

--- a/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-configuration.mdx
+++ b/website/docs/cloud-docs/workspaces/dynamic-provider-credentials/hcp-configuration.mdx
@@ -43,7 +43,7 @@ Next, create a workload identity provider that HCP uses to authenticate the HCP 
 hcp iam workload-identity-providers create-oidc hcp-terraform-dynamic-credentials \
   --service-principal=iam/project/HCP_PROJECT_ID/service-principal/hcp-terraform \
   --issuer=https://app.terraform.io \
-  --allowed-audience=hcp.workload.identity
+  --allowed-audience=hcp.workload.identity \
   --conditional-access='jwt_claims.sub matches `^organization:ORG_NAME:project:PROJECT_NAME:workspace:WORKSPACE_NAME:run_phase:.*`' \
   --description="Allow HCP Terraform agents to act as the hcp-terraform service principal"
 ```


### PR DESCRIPTION
### What
Just one page:
* missing a trailing backslash on the example HCP command to create a Workload Identity Provider. 
* missing the `iam` portion of the `hcp projects iam add-binding` command

https://developer.hashicorp.com/terraform/cloud-docs/workspaces/dynamic-provider-credentials/hcp-configuration

### Why
The commands as written are broken

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [X] N/A Description links to related pull requests or issues, if any.

#### Content
All not applicable N/A
- [X] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [X] API documentation and the API Changelog have been updated. 
- [X] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [X] Pages with related content are updated and link to this content when appropriate.
- [X] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [X] New pages have metadata (page name and description) at the top.
- [X] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [X] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [X] UI elements (button names, page names, etc.) are bolded.
- [X] The Vercel website preview successfully deployed.

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
- [X] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
