### PR TITLE
Add note about VCS Events only being supported for Gitlab

### DIFF
--- a/website/docs/cloud-docs/vcs/index.mdx
+++ b/website/docs/cloud-docs/vcs/index.mdx
@@ -119,6 +119,8 @@ You can use self-hosted HCP Terraform Agents to connect HCP Terraform to your pr
 
 ## Viewing events
 
+-> **Note**: The VCS Events page is still in beta as support is being added for additional VCS providers. Currently only GitLab.com connections established after December 2020 are supported.
+
 VCS events describe changes within your organization for VCS-related actions. The VCS events page only displays events from previously processed commits in the past 30 days. The VCS page indicates previously processed commits with the message, `"Processing skipped for duplicate commit SHA"`.
 
 Viewing VCS events requires permission to manage VCS settings for the organization. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))


### PR DESCRIPTION
### What
Copied a note from the VCS Events API page into the VCS Events UI page, noting that his functionality only applies to Gitlab.com connections. This page is very confusing for customers since Gitlab is not the most common VCS provider. I had a customer ask today why there was nothing showing on this page for their Bitbucket connection, hence the note here.

Direct preview link: https://terraform-docs-common-git-nphilbrookvcsevents-hashicorp.vercel.app/terraform/cloud-docs/vcs#viewing-events

### Why
Mitigating customer and employee confusion.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [X] Description links to related pull requests or issues, if any.

#### Content
- [X] N/A Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [X] N/A API documentation and the API Changelog have been updated. 
- [X] N/A Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [X] N/A Pages with related content are updated and link to this content when appropriate.
- [X] N/A Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [X] N/A New pages have metadata (page name and description) at the top.
- [X] N/A New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [X] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [X] N/A UI elements (button names, page names, etc.) are bolded.
- [X] The Vercel website preview successfully deployed.

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
- [X] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
