### PR TITLE
Clarify webhook / configuration version / manual run interactions

### DIFF
--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -38,6 +38,8 @@ A workspace will not process a webhook if the workspace previously processed a w
 
 You can manually trigger a run using the UI. Manual runs let you apply configuration changes when you update variable values but the configuration in version control is unchanged. You must manually trigger an initial run in any new VCS-driven workspace.
 
+-> **Note:** Triggering a manual run will _not_ fetch the latest commit from your VCS; it will use the current [configuration version](/terraform/cloud-docs/workspaces/configurations) associated with the workspace. [VCS Webhooks](/terraform/cloud-docs/vcs#webhooks) are used to update the configuration version with the latest code from your VCS.
+
 To start a run:
 
 1. Sign in to [HCP Terraform](https://app.terraform.io/) or Terraform Enterprise and navigate to the workspace you want to start a run in.

--- a/website/docs/cloud-docs/run/ui.mdx
+++ b/website/docs/cloud-docs/run/ui.mdx
@@ -38,7 +38,7 @@ A workspace will not process a webhook if the workspace previously processed a w
 
 You can manually trigger a run using the UI. Manual runs let you apply configuration changes when you update variable values but the configuration in version control is unchanged. You must manually trigger an initial run in any new VCS-driven workspace.
 
--> **Note:** Triggering a manual run will _not_ fetch the latest commit from your VCS; it will use the current [configuration version](/terraform/cloud-docs/workspaces/configurations) associated with the workspace. [VCS Webhooks](/terraform/cloud-docs/vcs#webhooks) are used to update the configuration version with the latest code from your VCS.
+-> **Note:** When you trigger a manual run, HCP Terraform does not fetch the latest commit from your VCS repository, and instead uses the current [configuration version](/terraform/cloud-docs/workspaces/configurations) associated with the workspace. HCP Terraform uses [VCS Webhooks](/terraform/cloud-docs/vcs#webhooks) to monitor changes in your VCS repository and update your configuration version.
 
 To start a run:
 


### PR DESCRIPTION
### What
Clarified that triggering a new run does NOT fetch the latest code from VCS. 

### Why
This is a frequent confusion point from customers.


Vercel preview:

https://terraform-docs-common-git-nphilbrookvcsclarifications-hashicorp.vercel.app/terraform/cloud-docs/run/ui#manually-starting-runs

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [X] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [N/A] Description links to related pull requests or issues, if any.

#### Content
- [N/A] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [N/A] API documentation and the API Changelog have been updated. 
- [N/A] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [N/A] Pages with related content are updated and link to this content when appropriate.
- [N/A] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [N/A] New pages have metadata (page name and description) at the top.
- [N/A] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [N/A] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [N/A] UI elements (button names, page names, etc.) are bolded.
- [X] The Vercel website preview successfully deployed.

#### Reviews
- [X] I or someone else reviewed the content for technical accuracy.
- [X] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
