### PR TITLE
[DO NOT MERGE] website/docs/cloud-docs/integrations/kubernetes: Add Deletion Policy page

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -649,6 +649,10 @@
             "path": "integrations/kubernetes/annotations-and-labels"
           },
           {
+            "title": "Deletion Policy",
+            "path": "integrations/kubernetes/deletion-policy"
+          },
+          {
             "title": "Migration Guide",
             "path": "integrations/kubernetes/ops-v2-migration"
           }

--- a/website/docs/cloud-docs/integrations/kubernetes/deletion-policy.mdx
+++ b/website/docs/cloud-docs/integrations/kubernetes/deletion-policy.mdx
@@ -1,0 +1,21 @@
+---
+page_title:
+description: >-
+    Deletion policies used by the HCP Terraform Cloud Operator for Kubernetes.
+---
+
+# Deletion Policies used by HCP Terraform Cloud Operator
+
+| Deletion Policy | Possible values | Description |
+| --- | --- | --- | --- |
+| `Workspace` | `retain`, `soft`, `destroy`, `force` | * `retain`: When the custom resource is deleted, the associated workspace is retained. Default value.
+* `soft`: Attempts to delete the associated workspace only if it does not contain any managed resources. 
+* `destroy`: Executes a destroy operation to remove all resources managed by the associated workspace. Once the destruction of these resources is successful, the workspace itself is deleted, followed by the removal of the custom resource.
+* `force`: Forcefully and immediately deletes the workspace and the custom resource. |
+| `Agent Pool` | `retain`, `destroy` | * `retain`: When the custom resource is deleted, the associated agent pool is retained. Default value. 
+* `destroy`: Attempting to remove the agent pool is only possible when there are no associated workspaces. These workspaces need to be disconnected separately. In this case, the controller will remove all tokens and scale down the agents to zero. |
+| `Project` | `retain`, `soft` | * `retain`: When the custom resource is deleted, the operator will not delete the associated project. Default value. * `soft`: 
+Attempts to remove the project. The project must be empty. |
+| `Module` | `retain`, `destroy` | * `retain`: When the custom resource is deleted, the associated module is retained. Default value. * `soft`: 
+Executes a destroy operation. Removes all resources and the module. |
+


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Add a new page for the deletion policies

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
https://hashicorp.atlassian.net/jira/software/c/projects/TFECO/boards/1081?assignee=6284f7770dae78006807f182&selectedIssue=TFECO-9014 

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
