### PR TITLE
Remove mention of CLI runs using the Auto-Apply setting

### DIFF
--- a/website/docs/cloud-docs/run/modes-and-options.mdx
+++ b/website/docs/cloud-docs/run/modes-and-options.mdx
@@ -10,7 +10,7 @@ HCP Terraform runs support many of the same modes and options available in the T
 
 ## Plan and Apply (Standard)
 
-The default run mode of HCP Terraform is to perform a plan and then apply it. If you have enabled auto-apply, a successful plan applies immediately. Otherwise, the run waits for user confirmation before applying.
+The default run mode of HCP Terraform is to perform a plan and then apply it. If you have enabled auto-apply and are using a VCS or API workflow, a successful plan applies immediately. Otherwise, the run waits for user confirmation before applying.
 
 - **CLI:** Use `terraform apply` (without providing a saved plan file).
 - **API:** Create a run without specifying any options that select a different mode.

--- a/website/docs/cloud-docs/workspaces/settings/index.mdx
+++ b/website/docs/cloud-docs/workspaces/settings/index.mdx
@@ -81,10 +81,12 @@ To minimize the number of runs that error when changing your workspace's executi
 
 Whether or not HCP Terraform should automatically apply a successful Terraform plan. If you choose manual apply, an operator must confirm a successful plan and choose to apply it.
 
-The main auto-apply setting affects runs created by the HCP Terraform user interface, API, CLI, and version control webhooks. HCP Terraform also has a separate setting for runs created by [run triggers](/terraform/cloud-docs/workspaces/settings/run-triggers) from another workspace.
+The main auto-apply setting affects runs created by the HCP Terraform user interface, API, and version control webhooks. HCP Terraform also has a separate setting for runs created by [run triggers](/terraform/cloud-docs/workspaces/settings/run-triggers) from another workspace.
 
-Auto-apply has the following exception:
 
+Auto-apply has the following exceptions:
+
+- Runs created by the terraform CLI must use the `-auto-approve` argument flag to control auto-apply of a particular run.
 - Plans queued by users without permission to apply runs for the workspace must be approved by a user who does have permission. ([More about permissions.](/terraform/cloud-docs/users-teams-organizations/permissions))
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
@@ -207,4 +209,3 @@ See [VCS Connections](/terraform/cloud-docs/workspaces/settings/vcs) for detaile
 The **Destruction and Deletion** page allows [admin users](/terraform/cloud-docs/users-teams-organizations/permissions) to delete a workspace's managed infrastructure or delete the workspace itself.
 
 For details, refer to [Destruction and Deletion](/terraform/cloud-docs/workspaces/settings/deletion) for detailed information about this page.
-


### PR DESCRIPTION
### What

The CLI does not respect this setting at all and has it's own prompt that is controlled and automated by the -auto-approve flag.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
