### PR TITLE
Clarify that TFE_PARALLELISM has no effect in HCP Terraform

### DIFF
--- a/website/docs/cloud-docs/workspaces/variables/index.mdx
+++ b/website/docs/cloud-docs/workspaces/variables/index.mdx
@@ -30,6 +30,9 @@ You can use the `TFE_PARALLELISM` environment variable when your infrastructure 
 
 !> **Warning:** We recommend reading and understanding [Terraform parallelism](https://support.hashicorp.com/hc/en-us/articles/10348130482451) prior to setting `TFE_PARALLELISM`. You can also contact HashiCorp support for direct advice. 
 
+-> **Note:** As of the current HCP Terraform architecture, the `TFE_PARALLELISM` environment variable has no effect on execution, even if set. To explicitly change the parallelism level for remote operations, please use `TF_CLI_ARGS_plan` and/or `TF_CLI_ARGS_apply` to pass the `-parallelism=<value>` flag directly to the CLI. See: [TFE_PARALLELISM is not the same as -parallelism](https://support.hashicorp.com/hc/en-us/articles/12116956529683-TFE-PARRALLELISM-1-is-not-the-same-as-running-parallelism-1)
+
+
 #### Dynamic credentials
 
 You can configure [dynamic credentials](/terraform/cloud-docs/workspaces/dynamic-provider-credentials) for certain providers using environment variables [at the workspace level](/terraform/cloud-docs/workspaces/variables/managing-variables#workspace-specific-variables) or using [variable sets](/terraform/cloud-docs/workspaces/variables/managing-variables#variable-sets).


### PR DESCRIPTION
### What
This PR adds a clarification note to the "Parallelism" section explaining that the `TFE_PARALLELISM` environment variable no longer has any effect in HCP Terraform. 

### Why
As per current architecture and support documentation, parallelism should be configured using `TF_CLI_ARGS_plan` or `TF_CLI_ARGS_apply` instead.

Reference:
- https://support.hashicorp.com/hc/en-us/articles/12116956529683-TFE-PARRALLELISM-1-is-not-the-same-as-running-parallelism-1

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
