### PR TITLE
Fix link to GitLab PAT documentation in tf-migrate overview

### DIFF
--- a/website/docs/cloud-docs/migrate/tf-migrate/index.mdx
+++ b/website/docs/cloud-docs/migrate/tf-migrate/index.mdx
@@ -29,7 +29,7 @@ If your Terraform files are stored in GitHub, you must configure an API token th
 
 If your Terraform files are stored in GitLab Cloud, you must configure an API token that meets the following requirements:
 
-- The token must be a personal access token. Refer to the [GitHub documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for additional information.
+- The token must be a personal access token. Refer to the [GitLab documentation](https://docs.gitlab.com/user/profile/personal_access_tokens) for additional information.
 - The token must be have `read_repository` and `write_repository` scopes.
 
 ## Install


### PR DESCRIPTION
Fix incorrect copy and link to GitLab PAT documentation in the tf-migrate overview page

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
