### PR TITLE
Adding documentation to clarify how policy-set-outcome filters work

### DIFF
--- a/website/docs/cloud-docs/api-docs/policy-evaluations.mdx
+++ b/website/docs/cloud-docs/api-docs/policy-evaluations.mdx
@@ -125,7 +125,7 @@ This endpoint supports pagination [with standard URL query parameters](/terrafor
 | `filter[n][status]`                | **Optional.** If omitted, the endpoint returns all policies regardless of status. Must be either "passed", "failed", or "errored". |
 | `filter[n][enforcementLevel]`      | **Optional.** Only used if paired with a non-errored status filter. Must be either "advisory" or "mandatory." |
 
--> **Note**: You can use `filter[n]` to combine combinations of statuses and enforcement levels. Policy outcomes with an errored status do not have an enforcement level.
+-> **Note**: You can use `filter[n]` to combine combinations of statuses and enforcement levels. Policy outcomes with an errored status do not have an enforcement level. The filter returns all policy-set-outcomes that include at least one outcome matching the filter criteria.
 
 ### Sample Request
 
@@ -145,7 +145,9 @@ curl \
 
 #### Failed and Errored Policy Outcomes
 
-The following example call filters the response so that it only contains failed outcomes and errors.
+The following example call filters the response so that it only contains failed policy-set-outcomes and errors.
+The API applies filters when retrieving policy-set-outcomes, but it does not filter within the individual outcomes themselves. In other words, the filter returns all policy-set-outcomes that include at least one outcome matching the filter criteria.
+If the policy-set-outcomes has even a single failed outcome, then all the outcomes for that policy set are returned, not just the failed policy outcome in that set.
 
 ```shell
 curl \


### PR DESCRIPTION
### What
There have been questions and bugs raised on the policy-set-outcome filtering behaviour. 

### Why
The policy-set-outcomes filtering behaviour works as expected, the documentation around it is improved to clarify the intended behaviour

JIRA: https://hashicorp.atlassian.net/browse/IPL-8071?linkSource=email

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
