### PR TITLE
Add note regarding cost estimation and policy checks

### DIFF
--- a/website/docs/cloud-docs/policy-enforcement/import-reference/tfrun.mdx
+++ b/website/docs/cloud-docs/policy-enforcement/import-reference/tfrun.mdx
@@ -303,6 +303,8 @@ The **cost_estimation namespace** contains data associated with the current run'
 
 This namespace is only present if a cost estimate is available.
 
+-> Cost estimate data is only available for legacy [Policy Checks](/terraform/cloud-docs/policy-enforcement/manage-policy-sets#policy-checks).
+
 -> Cost estimation is disabled for runs using [resource targeting](/terraform/cli/commands/plan#resource-targeting), which may cause unexpected failures.
 
 -> **Note:** Cost estimates are not available for Terraform 0.11.


### PR DESCRIPTION
### What
Adding a note to the `tfrun` page regarding cost estimate data only being available for legacy policy checks.

### Why
Users would not be aware of this limitation without this note if viewing this page.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
