### PR TITLE
Member Roles API documentation

### DIFF
--- a/website/data/cloud-docs-nav-data.json
+++ b/website/data/cloud-docs-nav-data.json
@@ -108,6 +108,7 @@
         "title": "Notification Configurations",
         "path": "api-docs/notification-configurations"
       },
+      { "title": "Member Roles", "path": "api-docs/member-roles" },
       { "title": "OAuth Clients", "path": "api-docs/oauth-clients" },
       { "title": "OAuth Tokens", "path": "api-docs/oauth-tokens" },
       { "title": "Organizations", "path": "api-docs/organizations" },

--- a/website/docs/cloud-docs/api-docs/index.mdx
+++ b/website/docs/cloud-docs/api-docs/index.mdx
@@ -127,6 +127,8 @@ The following entitlements are available:
 
 [cost estimation]: /terraform/cloud-docs/cost-estimation
 
+[member roles]: /terraform/cloud-docs/api-docs/member-roles
+
 [o-clients]: /terraform/cloud-docs/api-docs/oauth-clients
 
 [o-tokens]: /terraform/cloud-docs/api-docs/oauth-tokens

--- a/website/docs/cloud-docs/api-docs/member-roles.mdx
+++ b/website/docs/cloud-docs/api-docs/member-roles.mdx
@@ -1,7 +1,7 @@
 ---
-page_title: /teams API reference for HCP Terraform
+page_title: /member-roles API reference for HCP Terraform
 description: >-
-  Use the HCP Terraform API's `/member-roles` endpoint to read permission across all resource levels.
+  Use the HCP Terraform API's `/member-roles` endpoint to read permission groups across all resource levels.
 ---
 
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
@@ -92,21 +92,21 @@ The response shows the id and name of the groups, as well as the permissions rol
     },
     {
       "id": "bee3018293f35b435662b8882e3fc024",
-        "type": "member-roles",
-        "attributes": {
-          "roles": [
-              {
-                  "resource-type": "organizations",
-                  "role-id": "roles/terraform.legacy-organization-access-custom"
-              },
-              {
-                  "resource-type": "organizations",
-                  "role-id": "roles/admin"
-              }
-          ],
-          "member-id": "iam.group:HTwTGdftfghn9HHwKJ9w",
-          "member-name": "group_C",
-          "member-type": "groups"
+      "type": "member-roles",
+      "attributes": {
+        "roles": [
+            {
+              "resource-type": "organizations",
+              "role-id": "roles/terraform.legacy-organization-access-custom"
+            },
+            {
+              "resource-type": "organizations",
+              "role-id": "roles/admin"
+            }
+        ],
+        "member-id": "iam.group:HTwTGdftfghn9HHwKJ9w",
+        "member-name": "group_C",
+        "member-type": "groups"
       }
     },
     {
@@ -121,22 +121,22 @@ The response shows the id and name of the groups, as well as the permissions rol
     }
   ],
   "links": {
-        "self": "https://app.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
-        "first": "https://app.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
-        "prev": null,
-        "next": null,
-        "last": "https://app.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20"
-    },
-    "meta": {
-        "pagination": {
-            "current-page": 1,
-            "page-size": 20,
-            "prev-page": null,
-            "next-page": null,
-            "total-pages": 1,
-            "total-count": 19
-        }
+    "self": "https://app.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+    "first": "https://app.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+    "prev": null,
+    "next": null,
+    "last": "https://app.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20"
+  },
+  "meta": {
+    "pagination": {
+      "current-page": 1,
+      "page-size": 20,
+      "prev-page": null,
+      "next-page": null,
+      "total-pages": 1,
+      "total-count": 19
     }
+  }
 }
 ```
 
@@ -179,43 +179,43 @@ The response shows the hcp and terraform roles for a single member (e.g. group) 
 
 ```json
 {
-    "data": [
-        {
-            "id": "865a1f57998956c67ae86e745ea61654",
-            "type": "member-roles",
-            "attributes": {
-                "roles": [
-                    {
-                        "resource-type": "organizations",
-                        "role-id": "roles/admin"
-                    },
-                    {
-                        "resource-type": "projects",
-                        "role-id": "roles/terraform.legacy-project-access-custom"
-                    }
-                ],
-                "member-id": "iam.group:NzJbGbYyLgBctKmDmTkz",
-                "member-name": "group_A",
-                "member-type": "groups"
-            }
-        }
-    ],
-    "links": {
-        "self": "https://app.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
-        "first": "https://app.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
-        "prev": null,
-        "next": null,
-        "last": "https://app.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20"
-    },
-    "meta": {
-        "pagination": {
-            "current-page": 1,
-            "page-size": 20,
-            "prev-page": null,
-            "next-page": null,
-            "total-pages": 1,
-            "total-count": 1
-        }
+  "data": [
+    {
+      "id": "865a1f57998956c67ae86e745ea61654",
+      "type": "member-roles",
+      "attributes": {
+        "roles": [
+          {
+            "resource-type": "organizations",
+            "role-id": "roles/admin"
+          },
+          {
+            "resource-type": "projects",
+            "role-id": "roles/terraform.legacy-project-access-custom"
+          }
+        ],
+        "member-id": "iam.group:NzJbGbYyLgBctKmDmTkz",
+        "member-name": "group_A",
+        "member-type": "groups"
+      }
     }
+  ],
+  "links": {
+    "self": "https://app.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
+    "first": "https://app.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
+    "prev": null,
+    "next": null,
+    "last": "https://app.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20"
+  },
+  "meta": {
+    "pagination": {
+      "current-page": 1,
+      "page-size": 20,
+      "prev-page": null,
+      "next-page": null,
+      "total-pages": 1,
+      "total-count": 1
+    }
+  }
 }
 ```

--- a/website/docs/cloud-docs/api-docs/member-roles.mdx
+++ b/website/docs/cloud-docs/api-docs/member-roles.mdx
@@ -43,9 +43,9 @@ description: >-
 
 # Member Roles API reference
 
-Member role APIs return the permissions of groups known as Role Assignments from both HCP and HCP Terraform for a given resource such as an organization, project, or a workspace.
+Member role APIs return the HCP and HCP Terraform permission groups, also known as Role Assignments, for a given resource, such as an organization, project, or a workspace.
 
--> **Note:** This API is only available for HCP Europe organization and US-based private beta organization. If you have a standalone organization please refer to [Teams API](/terraform/cloud-docs/api-docs/teams)
+-> **Note:** This API is currently only available for HCP Europe organization and US-based private beta organizations. For standalone organizations, please refer to [Teams](/terraform/cloud-docs/api-docs/teams) related APIs.
 
 ## List all role assignments
 
@@ -53,8 +53,8 @@ Member role APIs return the permissions of groups known as Role Assignments from
 
 | Parameter            | Description                                      |
 | -------------------- | ------------------------------------------------ |
-| `:resource_type` | The resource level, this can be organizations, projects, workspaces. | 
-| `:resource_id` | The id of the resource that is of the type resource_type     |
+| `:resource_type` | The type of the resource. This can be organizations, projects, workspaces. | 
+| `:resource_id` | The id of the respective resource.     |
 
 
 ### Query Parameters
@@ -80,7 +80,7 @@ $ curl \
 
 ### Sample Response
 
-The response shows the id and name of the group, as well as the roles that it has access. The resource-type attribute lets you determine at which resource level the role is coming from.
+The response shows the id and name of the groups, as well as the permissions roles that it has access to. The resource-type attribute determines at which resource level the role is coming from.
 
 ```json
 {
@@ -143,12 +143,13 @@ The response shows the id and name of the group, as well as the roles that it ha
         }
     }
 }
-
 ```
 
-## Show group roles
+## Show roles for a member
 
 `GET /member-roles/:resource_type/:resource_id?filter[member_type]=:member_type&filter[member_id]=:group_id`
+
+This endpoint fetches the HCP roles and relevant permissions for a single member, such as a group, on the specified resource.
 
 | Parameter            | Description                                                      |
 | -------------------- | ------------------------------------------------                 |
@@ -223,4 +224,3 @@ The response shows the hcp and terraform roles for a single member (e.g. group) 
     }
 }
 ```
-

--- a/website/docs/cloud-docs/api-docs/member-roles.mdx
+++ b/website/docs/cloud-docs/api-docs/member-roles.mdx
@@ -1,0 +1,226 @@
+---
+page_title: /teams API reference for HCP Terraform
+description: >-
+  Use the HCP Terraform API's `/member-roles` endpoint to read permission across all resource levels.
+---
+
+⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+
+[200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
+
+[201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
+
+[202]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/202
+
+[204]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204
+
+[400]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400
+
+[401]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
+
+[403]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
+
+[404]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404
+
+[409]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409
+
+[412]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/412
+
+[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
+
+[429]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429
+
+[500]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+
+[504]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504
+
+[JSON API document]: /terraform/cloud-docs/api-docs#json-api-documents
+
+[JSON API error object]: https://jsonapi.org/format/#error-objects
+
+# Member Roles API reference
+
+Member role APIs return the permissions of groups known as Role Assignments from both HCP and HCP Terraform for a given resource such as an organization, project, or a workspace.
+
+-> **Note:** This API is only available for HCP Europe organization and US-based private beta organization. If you have a standalone organization please refer to [Teams API](/terraform/cloud-docs/api-docs/teams)
+
+## List all role assignments
+
+`GET /member-roles/:resource_type/:resource_id`
+
+| Parameter            | Description                                      |
+| -------------------- | ------------------------------------------------ |
+| `:resource_type` | The resource level, this can be organizations, projects, workspaces. | 
+| `:resource_id` | The id of the resource that is of the type resource_type     |
+
+
+### Query Parameters
+
+This endpoint supports pagination [with standard URL query parameters](/terraform/cloud-docs/api-docs#query-parameters). Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
+| Parameter       | Description                                                                                                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `q`             | **Optional.** Allows querying a list of role assignments by group name. This search is case-insensitive.                                                                     |
+| `page[number]`  | **Optional.** If omitted, the endpoint will return the first page.                                                                                                           |
+| `page[size]`    | **Optional.** If omitted, the endpoint will return 20 role assignments per page.                                                                                                        |
+| `sort`          | **Optional.** Allows sorting by group names. The only valid value is `"name"`. Prepending a hyphen to the sort parameter will reverse the order (e.g. `"-name"`).           |
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  https://app.terraform.io/api/v2/member-roles/organizations/5574ca0a-4d0b-4456-b1a6-54e8ae4c1b2a?page[number]=1&page[size]=10&sort=
+```
+
+### Sample Response
+
+The response shows the id and name of the group, as well as the roles that it has access. The resource-type attribute lets you determine at which resource level the role is coming from.
+
+```json
+{
+  "data": [
+    {
+      "id": "726a300c45-groups-bbe82f8dcb41025f18c951",
+      "type": "member-roles",
+      "attributes": {
+        "roles": [],
+        "member-id": "iam.group:hFkn8zpNB6cRp8jnqPkH",
+        "member-name": "group_D",
+        "member-type": "groups"
+      }
+    },
+    {
+      "id": "bee3018293f35b435662b8882e3fc024",
+        "type": "member-roles",
+        "attributes": {
+          "roles": [
+              {
+                  "resource-type": "organizations",
+                  "role-id": "roles/terraform.legacy-organization-access-custom"
+              },
+              {
+                  "resource-type": "organizations",
+                  "role-id": "roles/admin"
+              }
+          ],
+          "member-id": "iam.group:HTwTGdftfghn9HHwKJ9w",
+          "member-name": "group_C",
+          "member-type": "groups"
+      }
+    },
+    {
+      "id": "36ed391b9b65ad434576787d46c01af8b8",
+      "type": "member-roles",
+      "attributes": {
+        "roles": [],
+        "member-id": "iam.group:cTJfbKCJTThcq8pPQJTj",
+        "member-name": "group_B",
+        "member-type": "groups"
+      }
+    }
+  ],
+  "links": {
+        "self": "https://app.staging.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+        "first": "https://app.staging.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+        "prev": null,
+        "next": null,
+        "last": "https://app.staging.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20"
+    },
+    "meta": {
+        "pagination": {
+            "current-page": 1,
+            "page-size": 20,
+            "prev-page": null,
+            "next-page": null,
+            "total-pages": 1,
+            "total-count": 19
+        }
+    }
+}
+
+```
+
+## Show group roles
+
+`GET /member-roles/:resource_type/:resource_id?filter[member_type]=:member_type&filter[member_id]=:group_id`
+
+| Parameter            | Description                                                      |
+| -------------------- | ------------------------------------------------                 |
+| `:resource_type` | The resource level to view the roles for. This can be organizations, projects, workspaces. | 
+| `:resource_id` | The id of the resource that is of the type resource_type.              |
+| `:member_type` | Specifies the type of the member. As of now, the only acceptable value is groups.  |
+| `:group_id` | The id of the group that you want to see the permissions for.             |
+
+
+### Query Parameters
+
+This endpoint supports pagination [with standard URL query parameters](/terraform/cloud-docs/api-docs#query-parameters). Remember to percent-encode `[` as `%5B` and `]` as `%5D` if your tooling doesn't automatically encode URLs.
+
+| Parameter       | Description                                                                                                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `page[number]`  | **Optional.** If omitted, the endpoint will return the first page.                                                                                                           |
+| `page[size]`    | **Optional.** If omitted, the endpoint will return 10 teams per page.                                                                                                        |
+
+### Sample Request
+
+```shell
+$ curl \
+  --header "Authorization: Bearer $TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  --request GET \
+  https://app.terraform.io/api/v2/member-roles/organizations/5574ca0a-4d0b-4456-b1a6-54e8ae4c1b2a?filter[member_type]=groups&filter[member_id]=iam.group%6ANzJbGbHIigBctKmRrTkz
+```
+
+### Sample Response
+
+The response shows the hcp and terraform roles for a single member (e.g. group) on the specified resource.
+
+```json
+{
+    "data": [
+        {
+            "id": "865a1f57998956c67ae86e745ea61654",
+            "type": "member-roles",
+            "attributes": {
+                "roles": [
+                    {
+                        "resource-type": "organizations",
+                        "role-id": "roles/admin"
+                    },
+                    {
+                        "resource-type": "projects",
+                        "role-id": "roles/terraform.legacy-project-access-custom"
+                    }
+                ],
+                "member-id": "iam.group:NzJbGbYyLgBctKmDmTkz",
+                "member-name": "group_A",
+                "member-type": "groups"
+            }
+        }
+    ],
+    "links": {
+        "self": "https://app.staging.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
+        "first": "https://app.staging.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
+        "prev": null,
+        "next": null,
+        "last": "https://app.staging.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20"
+    },
+    "meta": {
+        "pagination": {
+            "current-page": 1,
+            "page-size": 20,
+            "prev-page": null,
+            "next-page": null,
+            "total-pages": 1,
+            "total-count": 1
+        }
+    }
+}
+```
+

--- a/website/docs/cloud-docs/api-docs/member-roles.mdx
+++ b/website/docs/cloud-docs/api-docs/member-roles.mdx
@@ -4,11 +4,6 @@ description: >-
   Use the HCP Terraform API's `/member-roles` endpoint to read permission across all resource levels.
 ---
 
-⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
-> [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
-⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
-
 [200]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
 
 [201]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
@@ -45,7 +40,7 @@ description: >-
 
 Member role APIs return the HCP and HCP Terraform permission groups, also known as Role Assignments, for a given resource, such as an organization, project, or a workspace.
 
--> **Note:** This API is currently only available for HCP Europe organization and US-based private beta organizations. For standalone organizations, please refer to [Teams](/terraform/cloud-docs/api-docs/teams) related APIs.
+-> **Note:** This API is currently only available for HCP Europe and US-based private beta accounts. For standalone HCP Terraform accounts, please refer to [Teams](/terraform/cloud-docs/api-docs/teams) related APIs.
 
 ## List all role assignments
 
@@ -126,11 +121,11 @@ The response shows the id and name of the groups, as well as the permissions rol
     }
   ],
   "links": {
-        "self": "https://app.staging.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
-        "first": "https://app.staging.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+        "self": "https://app.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
+        "first": "https://app.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20",
         "prev": null,
         "next": null,
-        "last": "https://app.staging.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20"
+        "last": "https://app.terraform.io/api/v2/member-roles/organizations/4741ca0a-4d0b-4177-b1a6-54e8ae4c1b2a?page%5Bnumber%5D=1&page%5Bsize%5D=20"
     },
     "meta": {
         "pagination": {
@@ -147,7 +142,7 @@ The response shows the id and name of the groups, as well as the permissions rol
 
 ## Show roles for a member
 
-`GET /member-roles/:resource_type/:resource_id?filter[member_type]=:member_type&filter[member_id]=:group_id`
+`GET /member-roles/:resource_type/:resource_id`
 
 This endpoint fetches the HCP roles and relevant permissions for a single member, such as a group, on the specified resource.
 
@@ -155,8 +150,8 @@ This endpoint fetches the HCP roles and relevant permissions for a single member
 | -------------------- | ------------------------------------------------                 |
 | `:resource_type` | The resource level to view the roles for. This can be organizations, projects, workspaces. | 
 | `:resource_id` | The id of the resource that is of the type resource_type.              |
-| `:member_type` | Specifies the type of the member. As of now, the only acceptable value is groups.  |
-| `:group_id` | The id of the group that you want to see the permissions for.             |
+| `filter[member_type]` | **Required.** Specifies the type of the member. As of now, the only acceptable value is groups.  |
+| `filter[group_id]` |  **Required.** The id of the group that you want to see the permissions for.             |
 
 
 ### Query Parameters
@@ -206,11 +201,11 @@ The response shows the hcp and terraform roles for a single member (e.g. group) 
         }
     ],
     "links": {
-        "self": "https://app.staging.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
-        "first": "https://app.staging.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
+        "self": "https://app.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
+        "first": "https://app.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20",
         "prev": null,
         "next": null,
-        "last": "https://app.staging.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20"
+        "last": "https://app.terraform.io/api/v2/member-roles/projects/e78425e5-af7a-40ec-b62c-9a97331b1cd0?filter%5Bmember_id%5D=iam.group%3ANzJbGbHbLgBctKmDmTkz\u0026filter%5Bmember_type%5D=groups\u0026page%5Bnumber%5D=1\u0026page%5Bsize%5D=20"
     },
     "meta": {
         "pagination": {

--- a/website/docs/cloud-docs/api-docs/project-team-access.mdx
+++ b/website/docs/cloud-docs/api-docs/project-team-access.mdx
@@ -49,6 +49,8 @@ description: >-
 
 The team access APIs are used to associate a team to permissions on a project. A single `team-project` resource contains the relationship between the Team and Project, including the privileges the team has on the project.
 
+In HCP Europe organizations, Teams are replaced by Groups. All of the `team-project` API endpoints function, but they now apply to groups instead of teams. The API responses will return information about groups and their permissions on projects.
+
 ## Resource permissions
 
 A `team-project` resource represents a team's local permissions on a specific project. Teams can also have organization-level permissions that grant access to projects. HCP Terraform uses the more restrictive access level. For example, a team with the **Manage projects** permission enabled has admin access on all projects, even if their `team-project` on a particular project only grants read access. For more information, refer to [Managing Project Access](/terraform/cloud-docs/users-teams-organizations/teams/manage#managing-project-access).
@@ -409,8 +411,8 @@ $ curl \
     "attributes": {
       "access": "custom",
       "project-access": {
-        "settings": "delete"
-        "teams": "manage",
+        "settings": "delete",
+        "teams": "manage"
       },
       "workspace-access" : {
         "runs": "apply",

--- a/website/docs/cloud-docs/api-docs/team-access.mdx
+++ b/website/docs/cloud-docs/api-docs/team-access.mdx
@@ -49,6 +49,8 @@ description: >-
 
 The team access APIs are used to associate a team to permissions on a workspace. A single `team-workspace` resource contains the relationship between the Team and Workspace, including the privileges the team has on the workspace.
 
+In HCP Europe organizations, Teams are replaced by Groups. All of the `team-workspace` API endpoints function, but they now apply to groups instead of teams. The API responses will return information about groups and their permissions on workspaces.
+
 ## Resource permissions
 
 A `team-workspace` resource represents a team's local permissions on a specific workspace. Teams can also have organization-level permissions that grant access to workspaces. HCP Terraform uses the more restrictive access level. For example, a team with the **Manage workspaces** permission enabled has admin access on all workspaces, even if their `team-workspace` on a particular workspace only grants read access. For more information, refer to [Managing Workspace Access](/terraform/cloud-docs/users-teams-organizations/teams/manage#managing-workspace-access).

--- a/website/docs/cloud-docs/api-docs/team-members.mdx
+++ b/website/docs/cloud-docs/api-docs/team-members.mdx
@@ -51,6 +51,8 @@ description: >-
 
 The Team Membership API is used to add or remove users from teams. The [Team API](/terraform/cloud-docs/api-docs/teams) is used to create or destroy teams.
 
+To manage user memberships in a group for a HCP Europe organizations, you must use the HashiCorp Cloud Platform [(HCP)](https://portal.cloud.hashicorp.com). The Team membership APIs are not available for use with HCP Europe organizations.
+
 ## Organization Membership
 
 -> **Note:** To add users to a team, they must first receive and accept the invitation to join the organization by email. This process ensures that you do not accidentally add the wrong person by mistyping a username. Refer to [the Organization Memberships API documentation](/terraform/cloud-docs/api-docs/organization-memberships) for more information.

--- a/website/docs/cloud-docs/api-docs/team-tokens.mdx
+++ b/website/docs/cloud-docs/api-docs/team-tokens.mdx
@@ -49,6 +49,8 @@ Teams relying on the [**legacy**](/terraform/cloud-docs/api-docs/team-tokens#leg
 
 You can create and delete team tokens and list an organization's team tokens.
 
+For a HCP Europe organizations, team tokes APIs can also be used for groups. The team_id parameter should be replaced with a group_id for these organizations, and API responses will return group-related information. Additionally, the manage group API tokens permission is managed on the [HCP](https://portal.cloud.hashicorp.com).
+
 ## Generate a new team token
 
 Generates a new team token.

--- a/website/docs/cloud-docs/api-docs/teams.mdx
+++ b/website/docs/cloud-docs/api-docs/teams.mdx
@@ -45,6 +45,8 @@ description: >-
 
 The Teams API is used to create, edit, and destroy teams as well as manage a team's organization-level permissions. The [Team Membership API](/terraform/cloud-docs/api-docs/team-members) is used to add or remove users from a team. Use the [Team Access API](/terraform/cloud-docs/api-docs/team-access) to associate a team with privileges on an individual workspace.
 
+For HCP Europe organizations, Teams are replaced by Groups. These organizations do not use the Create a Team or Delete a Team APIs. All other teams API endpoints function, but they now apply to groups. To manage groups and their permissions, refer to the [Member Roles API](/terraform/cloud-docs/api-docs/member-roles) documentation for a dedicated set of APIs that are specifically designed to work with groups in HCP Europe organizations.
+
 <!-- BEGIN: TFC:only name:pnp-callout -->
 @include 'tfc-package-callouts/team-management.mdx'
 <!-- END: TFC:only name:pnp-callout -->

--- a/website/docs/cloud-docs/api-docs/teams.mdx
+++ b/website/docs/cloud-docs/api-docs/teams.mdx
@@ -45,7 +45,7 @@ description: >-
 
 The Teams API is used to create, edit, and destroy teams as well as manage a team's organization-level permissions. The [Team Membership API](/terraform/cloud-docs/api-docs/team-members) is used to add or remove users from a team. Use the [Team Access API](/terraform/cloud-docs/api-docs/team-access) to associate a team with privileges on an individual workspace.
 
-For HCP Europe organizations, Teams are replaced by Groups. These organizations do not use the Create a Team or Delete a Team APIs. All other teams API endpoints function, but they now apply to groups. To manage groups and their permissions, refer to the [Member Roles API](/terraform/cloud-docs/api-docs/member-roles) documentation for a dedicated set of APIs that are specifically designed to work with groups in HCP Europe organizations.
+For HCP Europe organizations, teams are replaced by groups. These organizations do not use the [Create a Team](/terraform/cloud-docs/api-docs/teams#create-a-team) or [Delete a Team](/terraform/cloud-docs/api-docs/teams#delete-a-team) APIs. All other teams API endpoints function, but they now apply to groups. To manage groups and their permissions, refer to the [Member Roles API](/terraform/cloud-docs/api-docs/member-roles) documentation for a dedicated set of APIs that are specifically designed to work with groups in HCP Europe organizations.
 
 <!-- BEGIN: TFC:only name:pnp-callout -->
 @include 'tfc-package-callouts/team-management.mdx'


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
I have added a new page called Member Roles that gives information about two new APIs.

Please refer to the [RFC](https://docs.google.com/document/d/1kIsEsQPZtaWLwqLL-JYD3eGtU9IdEKwWfxASyRmg8sQ/edit?tab=t.0) for more details.

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
The API documentation would help users to find hcp and terraform permissions roles for a specific group .

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform ).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added to `website/redirects.js` for moved, renamed, or deleted pages.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
